### PR TITLE
fix(dockerfile): install uv into PATH to fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Download and install uv
 ADD https://astral.sh/uv/install.sh /uv-installer.sh
+ENV UV_INSTALL_DIR=/usr/local/bin
 RUN sh /uv-installer.sh && rm /uv-installer.sh
 
 # Ensure uv is on PATH


### PR DESCRIPTION
This PR fixes the Docker build failure where `uv` was not found during dependency installation.

Changes:
- Set `UV_INSTALL_DIR=/usr/local/bin` before running the official uv installer to ensure `uv` is on PATH inside the container.

Verification:
- Built the image locally; the step `RUN uv sync --frozen --no-dev && uv add watchdog reloader` now succeeds.

No functional code changes; build environment only.