### PR TITLE
fix(resources): preserve file-backed resource instances and loader metadata fallback

### DIFF
--- a/src/core/registry.py
+++ b/src/core/registry.py
@@ -132,6 +132,26 @@ class ResourceRegistry:
 
         logger.info(f"Registered resource: {uri} (category: {metadata.category})")
 
+    def register_instance(self, resource_instance: BaseResource, metadata: ResourceMetadata) -> None:
+        """
+        Register a specific resource instance with metadata.
+
+        This preserves constructor-specific state (e.g., file paths) that cannot be
+        reconstructed from generic metadata alone.
+
+        Args:
+            resource_instance: Concrete resource instance to register
+            metadata: Resource metadata
+        """
+        uri = metadata.uri
+
+        # Store both the class and the concrete instance
+        self._resources[uri] = type(resource_instance)
+        self._metadata[uri] = metadata
+        self._instances[uri] = resource_instance
+
+        logger.info(f"Registered resource instance: {uri} (category: {metadata.category})")
+
     def get_resource(self, uri: str) -> BaseResource | None:
         """
         Get a resource instance by URI.


### PR DESCRIPTION
This fixes resource registration and tool loader assumptions.

Changes:
- Resource registry: add `register_instance(...)` to preserve constructor state (e.g., `file_path`).
- Embedded resources: register file-backed instances in discovery so FastMCP serves the exact instance.
- Tool loader: use registry metadata (or docstrings) instead of assuming class `METADATA`.

Result:
- Embedded file resources (e.g., `embedded://docs/README.md`) now resolve properly.
- No more `File not found: text/markdown` errors due to wrong constructor params.
- Tools without `METADATA` still register with proper description.

Validation:
- Ran unit tests; embedded resources suite and comprehensive tests pass locally.
