### PR TITLE
ci(release-please): switch to googleapis action and grant issues: write

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,13 +9,14 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
       - name: Release Please
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
         with:
           release-type: python
           config-file: release-please-config.json


### PR DESCRIPTION
- Use googleapis/release-please-action@v4 (replaces deprecated google-github-actions)
- Grant `issues: write` to allow label creation

This should fix the deprecation warning and the label permission error on the release-please workflow.