### PR TITLE
ci: auto-merge release-please PRs labeled 'autorelease: pending'

### DIFF
--- a/.github/workflows/auto-merge-release-please.yml
+++ b/.github/workflows/auto-merge-release-please.yml
@@ -1,0 +1,27 @@
+name: auto-merge release-please PRs
+
+on:
+  pull_request:
+    types: [labeled, edited, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-merge when release-please label present
+        uses: peter-evans/auto-merge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: squash
+          required-labels: |
+            autorelease: pending
+          blocking-labels: |
+            do not merge
+          delete-branch: true
+


### PR DESCRIPTION
Automatically merge release-please PRs once they have the label `autorelease: pending` and are not in draft.

- Adds `.github/workflows/auto-merge-release-please.yml`
- Uses `peter-evans/auto-merge@v3` with squash merges
- Deletes the branch after merge

This makes releases fully automated once the release-please PR is created.