### PR TITLE
ci: use peter-evans/auto-merge@v4 for auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-release-please.yml
+++ b/.github/workflows/auto-merge-release-please.yml
@@ -1,0 +1,27 @@
+name: auto-merge release-please PRs
+
+on:
+  pull_request:
+    types: [labeled, edited, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-merge when release-please label present
+        uses: peter-evans/auto-merge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: squash
+          required-labels: |
+            autorelease: pending
+          blocking-labels: |
+            do not merge
+          delete-branch: true
+

--- a/.github/workflows/auto-merge-release-please.yml
+++ b/.github/workflows/auto-merge-release-please.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto-merge when release-please label present
-        uses: peter-evans/auto-merge@v3
+        uses: peter-evans/auto-merge@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           merge-method: squash


### PR DESCRIPTION
Fix auto-merge workflow to use a valid action version (v4).

- Update `.github/workflows/auto-merge-release-please.yml` to `peter-evans/auto-merge@v4`

This resolves the action resolution error and enables automatic merging of release-please PRs labeled `autorelease: pending`.