### PR TITLE
ci: avoid self-approval by using AUTO_APPROVE_TOKEN

### DIFF
--- a/.github/workflows/auto-approve-release-please.yml
+++ b/.github/workflows/auto-approve-release-please.yml
@@ -26,15 +26,18 @@ jobs:
             exit 0
           fi
           author=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json author -q .author.login)
-          echo "author=$author"
-          if [ "$author" != "github-actions[bot]" ]; then
-            echo "Not a release-please PR author; skipping"
-            exit 0
-          fi
+          head_ref=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefName -q .headRefName)
+          title=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json title -q .title)
+          echo "author=$author head_ref=$head_ref title=$title"
           if ! gh pr view "$PR_NUMBER" --repo "$REPO" --json labels -q '.labels[].name' | grep -Fx "autorelease: pending" >/dev/null; then
             echo "Label 'autorelease: pending' not present; skipping"
             exit 0
           fi
-          echo "Approving PR #$PR_NUMBER"
-          gh pr review "$PR_NUMBER" --repo "$REPO" --approve || true
+          # Approve if it's a release-please PR by bot OR the release-please branch pattern OR standard release title
+          if [ "$author" = "github-actions[bot]" ] || echo "$head_ref" | grep -q '^release-please--branches--' || echo "$title" | grep -q '^chore\(main\): release '; then
+            echo "Approving PR #$PR_NUMBER"
+            gh pr review "$PR_NUMBER" --repo "$REPO" --approve || true
+          else
+            echo "PR does not match release-please criteria; skipping approval"
+          fi
 

--- a/.github/workflows/auto-approve-release-please.yml
+++ b/.github/workflows/auto-approve-release-please.yml
@@ -14,11 +14,15 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - name: Approve release-please PRs from github-actions when labeled
+      - name: Approve release-please PRs when labeled
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTO_APPROVE_TOKEN }}
         run: |
           set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "AUTO_APPROVE_TOKEN is not configured; skipping auto-approve to avoid self-approval errors"
+            exit 0
+          fi
           PR_NUMBER='${{ github.event.pull_request.number }}'
           REPO='${{ github.repository }}'
           if [ -z "$PR_NUMBER" ]; then
@@ -33,9 +37,8 @@ jobs:
             echo "Label 'autorelease: pending' not present; skipping"
             exit 0
           fi
-          # Approve if it's a release-please PR by bot OR the release-please branch pattern OR standard release title
-          if [ "$author" = "github-actions[bot]" ] || echo "$head_ref" | grep -q '^release-please--branches--' || echo "$title" | grep -q '^chore\(main\): release '; then
-            echo "Approving PR #$PR_NUMBER"
+          if [ "$author" = "github-actions[bot]" ] || [ "$author" = "app/github-actions" ] || echo "$head_ref" | grep -q '^release-please--branches--' || echo "$title" | grep -q '^chore\(main\): release '; then
+            echo "Approving PR #$PR_NUMBER with AUTO_APPROVE_TOKEN actor"
             gh pr review "$PR_NUMBER" --repo "$REPO" --approve || true
           else
             echo "PR does not match release-please criteria; skipping approval"


### PR DESCRIPTION
Use a separate token for auto-approval to avoid GraphQL self-approval errors when the PR author is the same actor.

- Update `.github/workflows/auto-approve-release-please.yml` to use `secrets.AUTO_APPROVE_TOKEN`
- Guard: skip approval if `AUTO_APPROVE_TOKEN` is not configured
- Matches PRs by label, release-please branch pattern, or release PR title

Setup required: add `AUTO_APPROVE_TOKEN` repository secret (a PAT from a bot or service account with `public_repo` or `repo` scope).