### PR TITLE
docs(marketing): add social-ready content (Twitter, Reddit, LinkedIn)

### DIFF
--- a/marketing/linkedin/leadership-ic.md
+++ b/marketing/linkedin/leadership-ic.md
@@ -1,0 +1,23 @@
+## How MCP for Splunk Turns Runbooks into Reusable AI Value (Leadership & IC)
+
+Leaders want consistent outcomes; ICs want less toil and faster answers. MCP for Splunk by Deslicer connects LLMs to Splunk with the features enterprises expect — without asking teams to rewrite how they work.
+
+- One server, many tenants: Client‑scoped headers let a single MCP endpoint serve multiple Splunk instances (dev/test/prod, teams, regions) — no restarts to switch targets.
+- Agentic AI workflows: Convert manual runbooks into chained tasks where each step can call built‑in tools (search, admin, config, etc.) with its own instructions and inputs.
+- Example: `missing_data_troubleshooting.json` implements Splunk’s official inputs troubleshooting as a repeatable workflow.
+  Reference: https://help.splunk.com/en/splunk-enterprise/administer/troubleshoot/10.0/splunk-enterprise-log-files/troubleshoot-inputs-with-metrics.log
+- Embedded Splunk resources: LLMs respond with better context and fewer hallucinations.
+- Community‑first FOSS: Free and open source, built by the community for the community — and will remain that way.
+
+Why this matters:
+- Productivity: Guided incident triage and repeatable outcomes across teams
+- Knowledge transfer: Bottle “hero mode” into shareable automation
+- Enterprise readiness: Broad tool surface (search, metadata, health, admin) and multi‑client isolation
+
+Get started and bring your team:
+- Website: deslicer.com
+- Repo: https://github.com/deslicer/mcp-for-splunk
+- Join our .conf25 Boston workshop (DEV1666): https://conf.splunk.com/sessions/catalog.html?search=dev1666#/
+
+We’re grateful to the Splunk community — excited to give back and build together.
+

--- a/marketing/linkedin/practitioners.md
+++ b/marketing/linkedin/practitioners.md
@@ -1,0 +1,33 @@
+## From Manual Troubleshooting to Agentic AI Workflows in Splunk (Practitioners)
+
+MCP for Splunk by Deslicer helps you bottle your best Splunk runbooks into reusable agentic workflows.
+
+### What changes day‑to‑day
+- One server, many Splunk instances: Per‑client headers isolate sessions so a single MCP endpoint serves multiple tenants (dev/test/prod or different orgs) with no restarts.
+- Agentic workflows: Chain tasks; each task calls one or many built‑in tools (search/admin/config/etc.) with its own instructions and inputs. Parallelize and standardize.
+- Embedded Splunk context: Built‑in docs/resources give LLMs more accurate guidance.
+
+### Concrete example
+`workflows/core/missing_data_troubleshooting.json` turns Splunk’s official inputs troubleshooting guide into a step‑by‑step workflow your agents can run consistently.
+Ref: https://help.splunk.com/en/splunk-enterprise/administer/troubleshoot/10.0/splunk-enterprise-log-files/troubleshoot-inputs-with-metrics.log
+
+### Simple view
+```text
+[LLM or agent]
+      │  MCP (tools + workflows)
+      ▼
+   Splunk A   Splunk B   Splunk C
+  (headers)   (headers)  (headers)
+```
+
+### Why this vs alternatives
+Other servers (e.g., Splunk’s reference) are useful starters. This one leans into enterprise realities: multi‑client isolation, workflow chaining, and embedded Splunk resources — less glue code, more repeatability.
+Comparator: https://github.com/splunk/splunk-mcp-server2
+
+### Call to action
+- Website: deslicer.com
+- Repo: https://github.com/deslicer/mcp-for-splunk (free and open source — built by the community, for the community)
+- Join our .conf25 Boston workshop (DEV1666): https://conf.splunk.com/sessions/catalog.html?search=dev1666#/
+
+We worked hard to bring this to the community — contributions and feedback very welcome.
+

--- a/marketing/reddit/post.md
+++ b/marketing/reddit/post.md
@@ -1,0 +1,18 @@
+Title: MCP for Splunk — agentic workflows, one server for many tenants, community‑first FOSS
+
+If you’re exploring MCP servers to connect LLMs to Splunk, Deslicer’s MCP for Splunk focuses on enterprise realities:
+
+- One server, many Splunk instances: client‑scoped headers = multi‑tenant without restarts
+- Agentic AI workflows: chain tasks that call built‑in tools (search/admin/config/etc.) with per‑task instructions/inputs
+- Example: `missing_data_troubleshooting.json` codifies Splunk’s official inputs troubleshooting into a repeatable workflow
+  Ref: https://help.splunk.com/en/splunk-enterprise/administer/troubleshoot/10.0/splunk-enterprise-log-files/troubleshoot-inputs-with-metrics.log
+- Embedded Splunk resources so LLMs answer with better context, fewer hallucinations
+- FOSS: free forever, built by the community, for the community
+
+Compare with Splunk’s reference server: both useful, but we emphasize multi‑client isolation + agentic workflows + embedded docs.
+Repo: https://github.com/deslicer/mcp-for-splunk
+Workshop @ .conf25 Boston (DEV1666): https://conf.splunk.com/sessions/catalog.html?search=dev1666#/
+Site: deslicer.com
+
+We’ve worked hard to make this public — feedback and contributions welcome.
+

--- a/marketing/twitter/thread.md
+++ b/marketing/twitter/thread.md
@@ -1,0 +1,24 @@
+1/ Introducing MCP for Splunk by Deslicer — a Model Context Protocol server that connects LLMs to Splunk for secure, repeatable, AI‑assisted ops. Turn manual, tribal troubleshooting into sharable automations.
+Repo: https://github.com/deslicer/mcp-for-splunk
+
+2/ One server, many Splunk instances. Client‑scoped headers let a single MCP endpoint serve multiple tenants/environments without restarts. Platform teams: ship one service; users pick targets via headers.
+
+3/ Agentic AI workflows, not one‑off prompts. Define step‑by‑step runbooks as chains of tasks; each task can call one or many built‑in tools (search, admin, config, etc.), with its own instructions and inputs. Reuse. Share. Standardize.
+
+4/ Example: missing data triage. Our `missing_data_troubleshooting.json` codifies Splunk’s official inputs troubleshooting guide into a multi‑step agent workflow — consistent every time.
+Docs reference: https://help.splunk.com/en/splunk-enterprise/administer/troubleshoot/10.0/splunk-enterprise-log-files/troubleshoot-inputs-with-metrics.log
+
+5/ Embedded Splunk resources. The server ships splunk‑aware docs/resources so LLMs answer with better context and fewer hallucinations.
+
+6/ Rich tool surface: search (oneshot/jobs/saved searches), metadata discovery, health, admin (apps/users/config), workflows — designed for enterprise day‑2 use.
+
+7/ Free and open source. Built by the community, for the community — and it will always remain FOSS. Contributions welcome.
+
+8/ Why this vs alternatives? We lean into enterprise realities: multi‑client isolation, agentic workflows, and embedded Splunk context.
+Comparator: https://github.com/splunk/splunk-mcp-server2
+
+9/ Try it, contribute, or bring your team to our .conf25 Boston workshop (DEV1666).
+deslicer.com • https://github.com/deslicer/mcp-for-splunk • https://conf.splunk.com/sessions/catalog.html?search=dev1666#/
+
+10/ Thanks to the Splunk community — we’re excited to give back and keep building together.
+


### PR DESCRIPTION
Adds a new `marketing/` directory with social-ready content:

- Twitter thread: marketing/twitter/thread.md
- Reddit post: marketing/reddit/post.md
- LinkedIn (leadership/IC): marketing/linkedin/leadership-ic.md
- LinkedIn (practitioners): marketing/linkedin/practitioners.md

Highlights:
- Agentic AI workflows that chain tasks across built-in tools (search/admin/config/etc.)
- Example workflow based on Splunk’s official inputs troubleshooting guide
  Ref: https://help.splunk.com/en/splunk-enterprise/administer/troubleshoot/10.0/splunk-enterprise-log-files/troubleshoot-inputs-with-metrics.log
- Multi-tenant client-side configuration (one server, many Splunk instances)
- Embedded Splunk resources for better LLM context
- Emphasis that the project is free and open source, built by and for the community

CTAs included for deslicer.com, repo, and .conf25 workshop (DEV1666).