### PR TITLE
Docs: update clone URL to HTTPS and fix cd path

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,15 +91,15 @@ cp env.example .env
 
 **Windows:**
 ```powershell
-git clone https://github.com/deslicer/mcp-server-for-splunk.git
-cd mcp-server-for-splunk
+git clone https://github.com/deslicer/mcp-for-splunk.git
+cd mcp-for-splunk
 .\scripts\build_and_run.ps1
 ```
 
 **macOS/Linux:**
 ```bash
-git clone https://github.com/deslicer/mcp-server-for-splunk.git
-cd mcp-server-for-splunk
+git clone https://github.com/deslicer/mcp-for-splunk.git
+cd mcp-for-splunk
 ./scripts/build_and_run.sh
 
 # Optional: install Docker on Linux if needed

--- a/docs/WINDOWS_GUIDE.md
+++ b/docs/WINDOWS_GUIDE.md
@@ -90,8 +90,8 @@ Use the built-in verification script to validate your environment:
 
 ```powershell
 # Clone the repository
-git clone https://github.com/deslicer/mcp-server-for-splunk.git
-cd mcp-server-for-splunk
+git clone https://github.com/deslicer/mcp-for-splunk.git
+cd mcp-for-splunk
 
 # Run the setup script
 .\scripts\build_and_run.ps1
@@ -101,8 +101,8 @@ cd mcp-server-for-splunk
 
 ```cmd
 # Clone the repository
-git clone https://github.com/deslicer/mcp-server-for-splunk.git
-cd mcp-server-for-splunk
+git clone https://github.com/deslicer/mcp-for-splunk.git
+cd mcp-for-splunk
 
 # Run the setup script (calls PowerShell internally)
 .\scripts\build_and_run.bat

--- a/docs/contrib/contributing.md
+++ b/docs/contrib/contributing.md
@@ -15,8 +15,8 @@ Welcome to the community! We're excited to have you contribute to making AI and 
 
 ```bash
 # Fork and clone the repository
-git clone https://github.com/deslicer/mcp-server-for-splunk.git
-cd mcp-server-for-splunk
+git clone https://github.com/deslicer/mcp-for-splunk.git
+cd mcp-for-splunk
 
 # Set up development environment
 ./scripts/build_and_run.sh --dev

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -372,8 +372,8 @@ Once all prerequisites are installed:
 
 1. **Clone the repository:**
    ```bash
-   git clone https://github.com/deslicer/mcp-server-for-splunk.git
-   cd mcp-server-for-splunk
+   git clone https://github.com/deslicer/mcp-for-splunk.git
+   cd mcp-for-splunk
    ```
 
 2. **Run the verification script:**

--- a/docs/guides/deployment/README.md
+++ b/docs/guides/deployment/README.md
@@ -20,8 +20,8 @@ Perfect for development and AI client integration:
 
 ```bash
 # Clone and setup
-git clone https://github.com/your-org/mcp-server-for-splunk.git
-cd mcp-server-for-splunk
+git clone https://github.com/your-org/mcp-for-splunk.git
+cd mcp-for-splunk
 
 # One-command setup
 ./scripts/build_and_run.sh    # macOS/Linux

--- a/docs/labs/hands-on-lab.md
+++ b/docs/labs/hands-on-lab.md
@@ -27,8 +27,8 @@ Prepare your environment and to run the mcp server.
 ### Clone Github Repository
 
 ```bash
-git clone https://github.com/deslicer/mcp-server-for-splunk.git
-cd mcp-server-for-splunk
+git clone https://github.com/deslicer/mcp-for-splunk.git
+cd mcp-for-splunk
 # Checkout dev1666 branch in git, this branch has a prepared .env file for you.
 git checkout dev1666
 ```


### PR DESCRIPTION
This PR updates documentation to use the new repository name and HTTPS clone endpoint, and corrects the `cd` directory name.

Changes:
- Switch clone URLs to `https://github.com/deslicer/mcp-for-splunk.git`
- Update `cd mcp-server-for-splunk` to `cd mcp-for-splunk`
- Files updated: `README.md`, `docs/labs/hands-on-lab.md`, `docs/getting-started/installation.md`, `docs/contrib/contributing.md`, `docs/WINDOWS_GUIDE.md`, `docs/guides/deployment/README.md`, `docs/getting-started/README.md`

No functional code changes.
