### PR TITLE
feat(dashboards): add theme parameter to create_dashboard (Studio)

### DIFF
--- a/docs/guides/create_dashboard_tool.md
+++ b/docs/guides/create_dashboard_tool.md
@@ -39,6 +39,7 @@ The `create_dashboard` tool enables AI agents and automation to create dashboard
     "label": "My Dashboard",             # Optional: Human-readable label
     "description": "Dashboard desc",     # Optional: Description text
     "dashboard_type": "auto",            # Optional: 'classic', 'studio', 'auto'
+    "theme": "light",                    # Optional: 'light' or 'dark' (Studio only, when tool wraps JSON)
     "overwrite": false                   # Optional: Update if exists
 }
 ```
@@ -127,8 +128,11 @@ result = await create_dashboard.execute(
     name="performance_dashboard",
     definition=studio_definition,
     dashboard_type="studio",
+    theme="dark",  # Optional: 'light' (default) or 'dark' — sets `<dashboard theme="...">` when wrapping JSON
     app="myapp"
 )
+```
+
 ### Studio XML Wrapper Behavior
 
 When `dashboard_type="studio"` or auto-detected as Studio, you can provide either:
@@ -137,10 +141,10 @@ When `dashboard_type="studio"` or auto-detected as Studio, you can provide eithe
 - A JSON string. The tool wraps it the same way.
 - A pre-wrapped XML string that already contains `<definition>` or `<dashboard version="2">`. The tool detects this and will not double‑wrap.
 
-Wrapper template used (theme default is light):
+Wrapper template (the `theme` argument becomes the `theme` attribute on the root `<dashboard>`; default is `light`):
 
 ```xml
-<dashboard version="2" theme="light">
+<dashboard version="2" theme="${THEME}">
   <label>${LABEL}</label>
   <description>${DESCRIPTION}</description>
   <definition><![CDATA[
@@ -153,8 +157,7 @@ Notes:
 
 - The tool protects against embedded `]]>` in JSON by splitting the CDATA safely.
 - Label/description are also posted via a follow‑up metadata call for compatibility; wrapper includes them when provided.
-
-```
+- If you pass a pre-wrapped Studio XML string, the tool does not modify it; set `theme` inside your XML in that case.
 
 ### Overwrite Existing Dashboard
 

--- a/src/tools/dashboards/create_dashboard.py
+++ b/src/tools/dashboards/create_dashboard.py
@@ -3,7 +3,7 @@ Create a dashboard (Simple XML or Dashboard Studio) via Splunk REST API.
 """
 
 import json
-from typing import Any
+from typing import Any, Literal
 from xml.sax.saxutils import escape as xml_escape  # nosec B406  # nosemgrep: use-defused-xml
 
 from fastmcp import Context
@@ -34,6 +34,9 @@ class CreateDashboard(BaseTool):
             "    label (str, optional): Human label shown in UI\n"
             "    description (str, optional): Dashboard description\n"
             "    dashboard_type (str, optional): 'studio'|'classic'|'auto' (default: 'auto')\n"
+            "    theme (str, optional): Dashboard Studio UI theme when the tool wraps JSON into "
+            "XML: 'light' or 'dark' (default: 'light'). Ignored for Classic Simple XML and when "
+            "you pass a pre-wrapped Studio XML string (already containing <dashboard>).\n"
             "    sharing (str, optional): 'user'|'app'|'global'\n"
             "    read_perms (list[str], optional): Roles/users granted read\n"
             "    write_perms (list[str], optional): Roles/users granted write\n"
@@ -49,6 +52,7 @@ class CreateDashboard(BaseTool):
         definition: Any,
         label: str | None,
         description: str | None,
+        theme: Literal["light", "dark"] = "light",
     ) -> str:
         """
         Ensure the provided Studio definition is wrapped in the required XML
@@ -82,9 +86,9 @@ class CreateDashboard(BaseTool):
         # Protect CDATA from accidental termination inside JSON
         cdata_safe_json = studio_json_str.replace("]]>", "]]]]><![CDATA[>")
 
-        # Build XML wrapper
+        # Build XML wrapper (Splunk Dashboard Studio v2: theme on root <dashboard>)
         xml_parts: list[str] = []
-        xml_parts.append('<dashboard version="2" theme="light">')
+        xml_parts.append(f'<dashboard version="2" theme="{theme}">')
         if label:
             xml_parts.append(f"  <label>{xml_escape(label)}</label>")
         if description:
@@ -110,6 +114,7 @@ class CreateDashboard(BaseTool):
         read_perms: list[str] | None = None,
         write_perms: list[str] | None = None,
         overwrite: bool = False,
+        theme: Literal["light", "dark"] = "light",
     ) -> dict[str, Any]:
         """
         Create (or overwrite) a dashboard in Splunk.
@@ -121,6 +126,7 @@ class CreateDashboard(BaseTool):
             app=app,
             label=label,
             dashboard_type=dashboard_type,
+            theme=theme,
             overwrite=overwrite,
             sharing=sharing,
         )
@@ -139,10 +145,17 @@ class CreateDashboard(BaseTool):
             if resolved_type not in ("studio", "classic", "auto"):
                 resolved_type = "auto"
 
+            if theme not in ("light", "dark"):
+                return self.format_error_response(
+                    "Invalid 'theme'. Use 'light' or 'dark' (Dashboard Studio wrapper only)."
+                )
+
             if resolved_type == "auto":
                 if isinstance(definition, dict):
                     resolved_type = "studio"
-                    eai_data = self._ensure_studio_xml_wrapper(definition, label, description)
+                    eai_data = self._ensure_studio_xml_wrapper(
+                        definition, label, description, theme
+                    )
                 elif isinstance(definition, str):
                     # Heuristics: Studio hybrid (<definition>) or pure JSON
                     if "<definition>" in definition:
@@ -153,7 +166,7 @@ class CreateDashboard(BaseTool):
                             json.loads(definition)
                             resolved_type = "studio"
                             eai_data = self._ensure_studio_xml_wrapper(
-                                definition, label, description
+                                definition, label, description, theme
                             )
                         except (json.JSONDecodeError, TypeError):
                             resolved_type = "classic"
@@ -165,7 +178,9 @@ class CreateDashboard(BaseTool):
             elif resolved_type == "studio":
                 if isinstance(definition, dict) or isinstance(definition, str):
                     try:
-                        eai_data = self._ensure_studio_xml_wrapper(definition, label, description)
+                        eai_data = self._ensure_studio_xml_wrapper(
+                            definition, label, description, theme
+                        )
                     except Exception as wrap_err:  # pylint: disable=broad-except
                         return self.format_error_response(
                             f"Invalid Studio definition: {str(wrap_err)}"
@@ -182,7 +197,9 @@ class CreateDashboard(BaseTool):
                 eai_data = definition
 
             await ctx.info(
-                f"Creating dashboard '{name}' (type={resolved_type}, owner={owner}, app={app})"
+                f"Creating dashboard '{name}' (type={resolved_type}, owner={owner}, app={app}"
+                + (f", theme={theme}" if resolved_type == "studio" else "")
+                + ")"
             )
 
             # Web URL for response (use Splunk Web port 8000, not management port)
@@ -299,8 +316,7 @@ class CreateDashboard(BaseTool):
                 f"Dashboard '{name}' {'created' if created else 'updated'} (type={detected_type})"
             )
 
-            return self.format_success_response(
-                {
+            response_payload: dict[str, Any] = {
                     "name": name,
                     "label": content.get("label", label or name),
                     "type": detected_type,
@@ -315,8 +331,10 @@ class CreateDashboard(BaseTool):
                     },
                     "web_url": web_url,
                     "id": (entry or {}).get("id", ""),
-                }
-            )
+            }
+            if detected_type == "studio":
+                response_payload["theme"] = theme
+            return self.format_success_response(response_payload)
 
         except Exception as e:  # pylint: disable=broad-except
             self.logger.error("Failed to create dashboard: %s", str(e), exc_info=True)

--- a/tests/test_dashboard_tools.py
+++ b/tests/test_dashboard_tools.py
@@ -320,6 +320,39 @@ class TestCreateDashboard:
         assert result.get("type") == "studio"
 
     @pytest.mark.asyncio
+    async def test_studio_wrapper_theme_dark(self, mock_context):
+        tool = CreateDashboard("create_dashboard", "Create a Splunk dashboard")
+        result = await tool.execute(
+            mock_context,
+            name="studio_theme_dark",
+            definition={
+                "title": "Dark Theme Studio",
+                "dataSources": {},
+                "visualizations": {},
+            },
+            dashboard_type="studio",
+            theme="dark",
+        )
+        assert result.get("status") == "success"
+        assert result.get("theme") == "dark"
+        service = mock_context.request_context.lifespan_context.service
+        stored = service._dashboards["studio_theme_dark"]["content"]["eai:data"]
+        assert '<dashboard version="2" theme="dark">' in stored
+
+    @pytest.mark.asyncio
+    async def test_studio_wrapper_invalid_theme(self, mock_context):
+        tool = CreateDashboard("create_dashboard", "Create a Splunk dashboard")
+        result = await tool.execute(
+            mock_context,
+            name="studio_bad_theme",
+            definition={"title": "Bad", "dataSources": {}, "visualizations": {}},
+            dashboard_type="studio",
+            theme="sepia",
+        )
+        assert result.get("status") == "error"
+        assert "theme" in (result.get("error") or "").lower()
+
+    @pytest.mark.asyncio
     async def test_studio_wrapper_from_json_string_auto(self, mock_context):
         tool = CreateDashboard("create_dashboard", "Create a Splunk dashboard")
         studio_json = json.dumps(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `create_dashboard` tool always wrapped Dashboard Studio JSON in XML with `theme="light"` on the root `<dashboard version="2">` element. This change adds an optional **`theme`** parameter (`light` or `dark`, default `light`) so callers can create dark-mode Studio dashboards when the tool generates the wrapper. Classic Simple XML and pre-wrapped Studio XML are unchanged (the parameter is ignored for classic; for pre-wrapped Studio XML, set `theme` in your own XML).

## Type of change

- [x] New feature
- [x] Documentation

## Checklist

- [x] Tests added/updated (`tests/test_dashboard_tools.py`: dark theme + invalid theme)
- [x] Docs updated (`docs/guides/create_dashboard_tool.md`)
- [x] Lint passes (`ruff check` on touched files)

## Implementation notes

- `src/tools/dashboards/create_dashboard.py`: `theme` flows into `_ensure_studio_xml_wrapper`; invalid values return a clear error. Success responses for Studio dashboards include `"theme"` for visibility.
- `METADATA.description` documents the new argument for MCP tool discovery.

## Related issues

N/A (user-requested enhancement).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27f22664-83ea-4d12-ad45-e9be271f59d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27f22664-83ea-4d12-ad45-e9be271f59d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

