### PR TITLE
fix: resolve PR 117 lifespan merge

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -429,8 +429,8 @@ async def ensure_components_loaded(server: FastMCP) -> None:
         server._splunk_context = SplunkContext(service=None, is_connected=False, client_config=None)
 
 
-# Initialize FastMCP server without lifespan (components loaded at startup instead)
-# Note: lifespan causes issues in HTTP mode as it runs for each SSE connection
+# Initialize FastMCP with lifespan so tools can access the shared SplunkContext.
+# Components are still preloaded below for fastmcp CLI and health endpoint compatibility.
 # Optionally load auth verifier dynamically (module:attr) or via Supabase API fallback
 auth_verifier = None
 # Disable entirely
@@ -546,7 +546,7 @@ else:
 STATELESS_HTTP = os.getenv("MCP_STATELESS_HTTP", "false").strip().lower() == "true"
 JSON_RESPONSE = os.getenv("MCP_JSON_RESPONSE", "false").strip().lower() == "true"
 
-mcp = FastMCP(name="MCP Server for Splunk", auth=auth_verifier)
+mcp = FastMCP(name="MCP Server for Splunk", auth=auth_verifier, lifespan=splunk_lifespan)
 
 # Import and setup health routes
 setup_health_routes(mcp)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolve the merge issue from contributor PR #117 by keeping the stronger token-auth implementation already on `main` and applying the remaining lifespan fix that lets tools access the shared Splunk context.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor/Chore

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (README or docs/) - not applicable
- [ ] Lint and type checks pass (`uv run ruff check`, `uv run mypy`) - not run; `uv` unavailable in this environment

## Related issues

Follow-up/resolution for #117 and #116.

## Verification

- `python3 -m pytest tests/test_splunk_client.py tests/test_token_auth.py tests/test_transport.py tests/security/test_credentials_handling.py` - 68 passed
- `python3 -m pytest` - 357 passed, 2 skipped
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-526dce33-0284-494b-9a31-aa0926a11720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-526dce33-0284-494b-9a31-aa0926a11720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

