### PR TITLE
fix(release): unblock auto-publish chain and itsi PyPI metadata

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,11 +16,14 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      # Per-package outputs from googleapis/release-please-action@v4.
-      # See https://github.com/googleapis/release-please-action#outputs
-      parent_released: ${{ steps.release.outputs['.--release_created'] }}
+      # Per-package outputs from googleapis/release-please-action@v5.
+      # In manifest mode the action emits ``${path}--${key}`` for non-root
+      # paths, but for the root path (``.``) it emits the bare key — see
+      # `dist/index.js` `if (path === '.') { core.setOutput(key, value); }`.
+      # https://github.com/googleapis/release-please-action#outputs
+      parent_released: ${{ steps.release.outputs.release_created }}
       itsi_released: ${{ steps.release.outputs['packaging/mcp-itsi-server--release_created'] }}
-      parent_tag: ${{ steps.release.outputs['.--tag_name'] }}
+      parent_tag: ${{ steps.release.outputs.tag_name }}
       itsi_tag: ${{ steps.release.outputs['packaging/mcp-itsi-server--tag_name'] }}
     steps:
       - name: Release Please

--- a/packaging/mcp-itsi-server/pyproject.toml
+++ b/packaging/mcp-itsi-server/pyproject.toml
@@ -42,11 +42,11 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/[REDACTED]/mcp-for-splunk"
-Documentation = "https://github.com/[REDACTED]/mcp-for-splunk/blob/main/mcp_itsi/README.md"
-Repository = "https://github.com/[REDACTED]/mcp-for-splunk"
-Issues = "https://github.com/[REDACTED]/mcp-for-splunk/issues"
-Changelog = "https://github.com/[REDACTED]/mcp-for-splunk/blob/main/packaging/mcp-itsi-server/CHANGELOG.md"
+Homepage = "https://github.com/deslicer/mcp-for-splunk"
+Documentation = "https://github.com/deslicer/mcp-for-splunk/blob/main/mcp_itsi/README.md"
+Repository = "https://github.com/deslicer/mcp-for-splunk"
+Issues = "https://github.com/deslicer/mcp-for-splunk/issues"
+Changelog = "https://github.com/deslicer/mcp-for-splunk/blob/main/packaging/mcp-itsi-server/CHANGELOG.md"
 
 [project.scripts]
 mcp-itsi-server = "mcp_itsi.cli:main"


### PR DESCRIPTION
## Summary

Two tightly-related fixes so that future merges of release-please PRs actually reach PyPI without anyone having to manually `workflow_dispatch` the `Release` workflow.

### 1. `release-please.yml` — read the correct output keys

`googleapis/release-please-action@v5` running in **manifest mode** (which we use) emits outputs like this (from `dist/index.js`):

```js
if (path === '.') {
    core.setOutput(key, value);                    // → "release_created", "tag_name"
} else {
    core.setOutput(`${path}--${key}`, value);      // → "packaging/mcp-itsi-server--release_created"
}
```

The current workflow looks for `${{ steps.release.outputs['.--release_created'] }}` for the root package. That key is **never set**, so `parent_released` always resolves to an empty string, the `if: needs.release-please.outputs.parent_released == 'true'` gate evaluates false, and `build-publish-parent` is skipped on every release-please merge — including v0.6.1 (run [25559174661](https://github.com/deslicer/mcp-for-splunk/actions/runs/25559174661) — both publish jobs were `skipped` while the release-please job successfully created the v0.6.1 tag/release).

This PR switches the root-path lookups to the bare keys (`release_created`, `tag_name`). The non-root ITSI keys (`packaging/mcp-itsi-server--*`) were already correct and stay unchanged.

### 2. `packaging/mcp-itsi-server/pyproject.toml` — fix `[project.urls]` placeholders

The ITSI distribution's URLs contained literal `[REDACTED]` placeholders:

```toml
Homepage = "https://github.com/[REDACTED]/mcp-for-splunk"
Repository = "https://github.com/[REDACTED]/mcp-for-splunk"
…
```

PyPI rejected the upload with:

> `HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/`
> `400 '`https://github.com/[REDACTED]/mcp-for-splunk`' is not a valid information.`

(see job [25559981243 / build-publish-itsi](https://github.com/deslicer/mcp-for-splunk/actions/runs/25559981243/job/75028755543)). Replaced with the actual `deslicer` org name. Verified locally:

```bash
uv build --no-sources --package mcp-itsi-server --out-dir /tmp/itsi-dist
uv run --with twine twine check /tmp/itsi-dist/*
# → mcp_itsi_server-0.1.0-py3-none-any.whl: PASSED
# → mcp_itsi_server-0.1.0.tar.gz:           PASSED
```

## Test plan

- [ ] Merge this PR.
- [ ] After release-please opens its next release PR (parent or ITSI), watch that the `release-please` workflow's downstream `build-publish-parent` / `build-publish-itsi` jobs run instead of being skipped.
- [ ] Manually `workflow_dispatch` `Release` with `package: itsi` once on `main` to back-fill `mcp-itsi-server@0.1.0` to PyPI (the URLs are now valid metadata, so the upload should succeed).
- [ ] Future patch/minor bumps of either package land on PyPI automatically with no manual dispatch.