### PR TITLE
fix(release-please): derive __version__ from package metadata to drop extra-files traversal

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -18,13 +18,7 @@
       "include-component-in-tag": true,
       "include-v-in-tag": true,
       "component": "mcp-itsi-server",
-      "changelog-path": "CHANGELOG.md",
-      "extra-files": [
-        {
-          "type": "generic",
-          "path": "../../mcp_itsi/_version.py"
-        }
-      ]
+      "changelog-path": "CHANGELOG.md"
     }
   }
 }

--- a/mcp_itsi/_version.py
+++ b/mcp_itsi/_version.py
@@ -1,7 +1,28 @@
 """Single source of truth for the package version.
 
-The version is kept in sync with `packaging/mcp-itsi-server/pyproject.toml`
-by release-please via the marker comment below.
+The version lives in ``packaging/mcp-itsi-server/pyproject.toml`` and is
+read here at import time via :func:`importlib.metadata.version` so that
+release-please only has to update one file. We previously kept a literal
+``__version__`` string here too and asked release-please to update it via
+``extra-files``, but the package lives at ``packaging/mcp-itsi-server``
+while the source tree lives at the repo root, and release-please rejects
+``..`` traversal in extra-file paths (``illegal pathing characters``).
+
+When running directly from a source checkout where the distribution
+metadata isn't installed yet (e.g. ``python -m mcp_itsi`` before
+``uv sync --extra itsi``), we fall back to a clearly-fake version rather
+than raising on import.
 """
 
-__version__ = "0.1.0"  # x-release-please-version
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _distribution_version
+
+_DISTRIBUTION_NAME = "mcp-itsi-server"
+_FALLBACK_VERSION = "0.0.0+local"
+
+try:
+    __version__ = _distribution_version(_DISTRIBUTION_NAME)
+except PackageNotFoundError:
+    __version__ = _FALLBACK_VERSION


### PR DESCRIPTION
## Summary

Follow-up to #132 — that PR unblocked the auto-publish chain (output keys + ITSI URL placeholders), but left a third bug that surfaced on the post-merge release-please run:

> `release-please failed: illegal pathing characters in path: packaging/mcp-itsi-server/../../mcp_itsi/_version.py`

(see [run 25560445242 / release-please](https://github.com/deslicer/mcp-for-splunk/actions/runs/25560445242/job/75030332279))

`googleapis/release-please-action` rejects any `..` segment in `extra-files` paths — `dist/index.js` validates with `/((^|\/)\.{1,2}|^~|^\/*)+\//` and throws "illegal pathing characters in path" for anything containing `..`. A symlink workaround (`packaging/mcp-itsi-server/mcp_itsi -> ../../mcp_itsi`) doesn't help either, since the action reads files via GitHub's Contents API which returns symlinks as symlinks, not as the linked target's content.

The package source (`mcp_itsi/`) lives at the repo root while the distribution build root (`packaging/mcp-itsi-server/`) lives two directories down, so there is no `..`-free relative path from the package config to `_version.py`. Restructuring the source layout to satisfy release-please would be invasive; instead this PR makes `_version.py` derive the version from the installed distribution metadata, eliminating the duplicate source-of-truth entirely.

## Changes

1. **`mcp_itsi/_version.py`** — replace the literal `__version__ = "0.1.0"` line with `importlib.metadata.version("mcp-itsi-server")`, with a `"0.0.0+local"` fallback for un-installed source checkouts.
2. **`.github/release-please/release-please-config.json`** — drop the now-unnecessary `extra-files` entry on the `packaging/mcp-itsi-server` package.

`pyproject.toml` remains the single source of truth — release-please already updates it because `release-type: python`, and `__version__` now follows automatically.

## Verification (local)

```bash
$ uv build --no-sources --package mcp-itsi-server --out-dir /tmp/itsi-dist
Successfully built /tmp/itsi-dist/mcp_itsi_server-0.1.0.tar.gz
Successfully built /tmp/itsi-dist/mcp_itsi_server-0.1.0-py3-none-any.whl

$ uv run --with twine twine check /tmp/itsi-dist/*
Checking /tmp/itsi-dist/mcp_itsi_server-0.1.0-py3-none-any.whl: PASSED
Checking /tmp/itsi-dist/mcp_itsi_server-0.1.0.tar.gz:           PASSED

$ uv run python -c "import mcp_itsi; print(mcp_itsi.__version__)"
0.1.0
```

## Test plan

- [ ] Merge this PR.
- [ ] Verify the next `release-please` job on `main` no longer errors out with "illegal pathing characters" and either opens release-please PRs or exits cleanly with "no releases to create".
- [ ] After the next ITSI release tag (e.g. `mcp-itsi-server-v0.2.0`), confirm `python -c "import mcp_itsi; print(mcp_itsi.__version__)"` reports the new version on a fresh `uv sync --extra itsi`.

## Notes

- The `0.0.0+local` fallback is a [PEP 440 local version identifier](https://peps.python.org/pep-0440/#local-version-identifiers), chosen so it sorts as clearly-not-released and never collides with any tagged version.
- The previous run failure for the parent ITSI publish job ([run 25559981243 attempt 2 / build-publish-itsi](https://github.com/deslicer/mcp-for-splunk/actions/runs/25559981243/job/75030707275)) is **not** addressed here — it was a re-run of an old workflow against the pre-#132 commit `bef9022`, so it replayed the old `[REDACTED]` URL bug. A fresh `workflow_dispatch` of `Release` against current `main` (post-#132 + this PR) will not have either issue.
