### PR TITLE
Fix Splunk docs resource URLs

### DIFF
--- a/src/core/loader.py
+++ b/src/core/loader.py
@@ -465,6 +465,46 @@ Common config files:
 Try using the discovery resource: `splunk-docs://discovery`
 """
 
+            @self.mcp_server.resource(
+                "splunk-spec://{version}/{config}", name="get_versioned_spec_reference_docs"
+            )
+            async def get_versioned_spec_reference_docs(version: str, config: str) -> str:
+                """Get Splunk configuration specification documentation for a specific version"""
+                try:
+                    from ..resources.splunk_docs import create_spec_reference_resource
+
+                    ctx = get_context()
+
+                    resource = create_spec_reference_resource(config, version=version)
+                    content = await resource.get_content(ctx)
+                    return content
+                except Exception as e:
+                    self.logger.error(
+                        f"Error getting spec docs for {config} (version {version}): {e}"
+                    )
+                    return f"""# Error: Configuration Specification Documentation
+
+Failed to retrieve configuration specification for `{config}` (version {version}).
+
+**Error**: {str(e)}
+
+Please check:
+- Config file name spelling (e.g., alert_actions.conf)
+- Splunk version availability
+- Network connectivity
+
+Common config files:
+- alert_actions.conf
+- limits.conf
+- indexes.conf
+- inputs.conf
+- outputs.conf
+- props.conf
+- transforms.conf
+
+Try using the discovery resource: `splunk-docs://discovery`
+"""
+
             self.logger.info("✅ Configuration spec handler registered successfully")
 
             # Register CIM data model documentation handler
@@ -584,6 +624,7 @@ Available topics:
                         "splunk-docs://{version}/spl-reference/{command}",
                         "splunk-docs://{version}/admin/{topic}",
                         "splunk-spec://{config}",
+                        "splunk-spec://{version}/{config}",
                         "splunk-cim://{version}/{model}",
                         "dashboard-studio://{topic}",
                     ]

--- a/src/resources/splunk_docs.py
+++ b/src/resources/splunk_docs.py
@@ -503,6 +503,13 @@ For more SPL commands, see the complete [SPL Reference](splunk-docs://{self.vers
 class AdminGuideResource(SplunkDocsResource):
     """Splunk administration documentation."""
 
+    TOPIC_PATHS = {
+        "indexes": (
+            "en/data-management/manage-splunk-enterprise-indexers/{version}/"
+            "manage-indexes/about-managing-indexes"
+        ),
+    }
+
     METADATA = ResourceMetadata(
         uri="splunk-docs://{version}/admin/{topic}",
         name="admin_guide",
@@ -527,11 +534,10 @@ class AdminGuideResource(SplunkDocsResource):
         """Get administration documentation for specific topic."""
 
         async def fetch_admin_docs():
-            # help.splunk.com uses hyphenated topic names and different URL structure
-            topic_url = self.topic.replace("_", "-").lower()
-            url = f"{self.SPLUNK_HELP_BASE}/en/splunk-enterprise/administer/{topic_url}"
+            help_version = self.format_version_for_help_url(self.version)
+            topic_url = self._build_topic_url(help_version)
 
-            content = await self.fetch_doc_content(url)
+            content = await self.fetch_doc_content(topic_url)
 
             return f"""# Splunk Administration: {self.topic}
 
@@ -549,9 +555,21 @@ For related administration topics, see the complete [Admin Guide](splunk-docs://
 
         return await _doc_cache.get_or_fetch(self.version, "admin", self.topic, fetch_admin_docs)
 
+    def _build_topic_url(self, help_version: str) -> str:
+        """Build the current Splunk Help URL for an admin topic."""
+        topic_key = self.topic.replace("_", "-").lower()
+        topic_path = self.TOPIC_PATHS.get(topic_key)
+
+        if topic_path:
+            return f"{self.SPLUNK_HELP_BASE}/{topic_path.format(version=help_version)}"
+
+        return f"{self.SPLUNK_HELP_BASE}/en/splunk-enterprise/administer/{topic_key}"
+
 
 class SplunkSpecReferenceResource(SplunkDocsResource):
     """Splunk configuration specification file reference documentation."""
+
+    VERSION_PREFIXES = {"latest", "auto"}
 
     METADATA = ResourceMetadata(
         uri="splunk-spec://{config}",
@@ -562,19 +580,41 @@ class SplunkSpecReferenceResource(SplunkDocsResource):
         tags=["spec", "configuration", "reference", "admin"],
     )
 
-    def __init__(self, config: str):
-        self.config = config
+    def __init__(self, config: str, version: str | None = None):
+        parsed_version, parsed_config = self._split_versioned_config_reference(config)
+        self.config = parsed_config
+        self.version = version or parsed_version
         # Version will be detected dynamically in get_content()
         self._cached_version = None
 
-        uri = f"splunk-spec://{config}"
+        uri_path = f"{self.version}/{self.config}" if self.version else self.config
+        uri = f"splunk-spec://{uri_path}"
         # Normalize config name for display
-        display_config = self._normalize_config_name(config)
+        display_config = self._normalize_config_name(self.config)
         super().__init__(
             uri=uri,
-            name=f"spec_{config.replace('.', '_')}",
+            name=f"spec_{uri_path.replace('/', '_').replace('.', '_')}",
             description=f"Splunk configuration spec for {display_config} (auto-detected version)",
         )
+
+    def _split_versioned_config_reference(self, config: str) -> tuple[str | None, str]:
+        """Split optional version prefixes from config references."""
+        if "/" not in config:
+            return None, config
+
+        version, config_name = config.split("/", 1)
+        if self._is_version_reference(version) and config_name:
+            return version, config_name
+
+        return None, config
+
+    def _is_version_reference(self, value: str) -> bool:
+        """Return whether a URI path segment is a Splunk version selector."""
+        if value in self.VERSION_PREFIXES:
+            return True
+
+        parts = value.split(".")
+        return len(parts) in {2, 3} and all(part.isdigit() for part in parts)
 
     def _parse_version_components(self, version: str) -> tuple[str, str]:
         """Parse version into minor (X.Y) and full (X.Y.Z) components.
@@ -616,6 +656,8 @@ class SplunkSpecReferenceResource(SplunkDocsResource):
         Returns:
             Config name with .conf extension
         """
+        _, config = self._split_versioned_config_reference(config)
+
         # Always use .conf (not .conf.spec)
         if config.endswith(".conf.spec"):
             # Strip .spec suffix if present
@@ -628,8 +670,8 @@ class SplunkSpecReferenceResource(SplunkDocsResource):
     async def get_content(self, ctx: Context) -> str:
         """Get configuration specification documentation for specific file."""
 
-        # Detect version once before caching
-        version = await self.get_splunk_version(ctx)
+        # Detect version once before caching unless the URI supplied one explicitly.
+        version = self.version or await self.get_splunk_version(ctx)
         logger.info(f"Auto-detected Splunk version: {version}")
 
         async def fetch_spec_docs():
@@ -1012,16 +1054,19 @@ def create_troubleshooting_resource(version: str, topic: str) -> Troubleshooting
     return TroubleshootingResource(version, topic)
 
 
-def create_spec_reference_resource(config: str) -> SplunkSpecReferenceResource:
+def create_spec_reference_resource(
+    config: str, version: str | None = None
+) -> SplunkSpecReferenceResource:
     """Factory function to create configuration spec reference resources.
 
     Args:
         config: Configuration file name (e.g., "alert_actions.conf", "limits.conf")
+        version: Optional Splunk version selector from versioned resource URIs
 
     Returns:
         SplunkSpecReferenceResource instance (version auto-detected from Splunk instance)
     """
-    return SplunkSpecReferenceResource(config)
+    return SplunkSpecReferenceResource(config, version=version)
 
 
 # Auto-register resources when module is imported

--- a/tests/test_admin_guide_resource.py
+++ b/tests/test_admin_guide_resource.py
@@ -1,0 +1,34 @@
+"""
+Tests for Splunk administration guide documentation resources.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.resources.splunk_docs import AdminGuideResource
+
+
+class TestAdminGuideResource:
+    """Test suite for AdminGuideResource."""
+
+    @pytest.mark.asyncio
+    async def test_indexes_topic_uses_current_indexes_documentation_url(self):
+        """Test indexes admin docs use the current Splunk Help data-management path."""
+        resource = AdminGuideResource("10.0", "indexes")
+        mock_content = "# About managing indexes\n\nIndexes store Splunk Enterprise data."
+
+        with patch.object(resource, "fetch_doc_content", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = mock_content
+
+            content = await resource.get_content(AsyncMock())
+
+            assert "# Splunk Administration: indexes" in content
+            assert "About managing indexes" in content
+
+            called_url = mock_fetch.call_args[0][0]
+            assert called_url == (
+                "https://help.splunk.com/en/data-management/"
+                "manage-splunk-enterprise-indexers/10.0/"
+                "manage-indexes/about-managing-indexes"
+            )

--- a/tests/test_spec_loader_integration.py
+++ b/tests/test_spec_loader_integration.py
@@ -50,6 +50,9 @@ def test_spec_reference_handler_registration():
     assert any("splunk-spec://{config}" in uri for uri in spec_uris), (
         f"Expected 'splunk-spec://{{config}}' pattern, got: {spec_uris}"
     )
+    assert any("splunk-spec://{version}/{config}" in uri for uri in spec_uris), (
+        f"Expected 'splunk-spec://{{version}}/{{config}}' pattern, got: {spec_uris}"
+    )
 
     # Check for correct name
     spec_names = [r["name"] for r in spec_resources]

--- a/tests/test_spec_reference.py
+++ b/tests/test_spec_reference.py
@@ -44,6 +44,10 @@ class TestSplunkSpecReferenceResource:
         # Test stripping .spec suffix
         assert resource._normalize_config_name("alert_actions.conf.spec") == "alert_actions.conf"
 
+        # Test stripping an optional version prefix from advertised spec URIs
+        assert resource._normalize_config_name("latest/props.conf") == "props.conf"
+        assert resource._normalize_config_name("10.0/props") == "props.conf"
+
     def test_parse_version_components(self):
         """Test version parsing into minor and full components."""
         resource = SplunkSpecReferenceResource("alert_actions.conf")
@@ -121,6 +125,29 @@ This is the documentation for alert_actions.conf.
                 assert "/en/splunk-enterprise/administer/admin-manual/10.0/" in called_url
                 assert "10.0.0-configuration-file-reference" in called_url
                 assert "alert_actions.conf" in called_url
+
+    @pytest.mark.asyncio
+    async def test_get_content_uses_version_prefix_from_config_reference(self):
+        """Test version-prefixed config references use the prefix as the docs version."""
+        resource = SplunkSpecReferenceResource("10.0/props.conf")
+        mock_content = "# Props Configuration"
+
+        with patch.object(resource, "get_splunk_version", new_callable=AsyncMock) as mock_version:
+            mock_version.return_value = "9.4"
+
+            with patch.object(resource, "fetch_doc_content", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = mock_content
+
+                content = await resource.get_content(AsyncMock())
+
+                assert "# Splunk Configuration Spec: props.conf" in content
+                assert "Version**: Splunk 10.0" in content
+
+                called_url = mock_fetch.call_args[0][0]
+                assert "/admin-manual/10.0/" in called_url
+                assert "10.0.0-configuration-file-reference" in called_url
+                assert called_url.endswith("/props.conf")
+                mock_version.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_get_content_fallback(self):


### PR DESCRIPTION
## Summary
- Register versioned Splunk spec resource URIs so `splunk-spec://latest/props.conf` and similar advertised paths resolve through FastMCP.
- Normalize version-prefixed config spec inputs before building Splunk Help URLs.
- Route the admin `indexes` topic to the current Splunk Help page used by `splunk-docs://latest/admin/indexes` and related tools.

## Test plan
- `uv run pytest tests/test_spec_reference.py tests/test_spec_loader_integration.py tests/test_admin_guide_resource.py`
- `uv run ruff check src/core/loader.py src/resources/splunk_docs.py tests/test_spec_reference.py tests/test_spec_loader_integration.py tests/test_admin_guide_resource.py`
- FastMCP client checks for `get_config_spec`, `get_admin_guide`, and `get_splunk_documentation` were run during validation.