### PR TITLE
fix: replace ResultsReader with JSONResultsReader for splunk-sdk 2.x compatibility (closes #147)

### DIFF
--- a/src/tools/metadata/get_metadata.py
+++ b/src/tools/metadata/get_metadata.py
@@ -92,9 +92,9 @@ class GetMetadata(BaseTool):
                 # metadata supports hosts directly
                 query = f"| metadata type=hosts index={index} | table host | head {int(limit)}"
                 job = service.jobs.oneshot(query)
-                from splunklib.results import ResultsReader  # lazy import
+                from splunklib.results import JSONResultsReader  # lazy import
 
-                for result in ResultsReader(job):
+                for result in JSONResultsReader(job):
                     if isinstance(result, dict) and "host" in result:
                         values.append(str(result["host"]))
 
@@ -102,9 +102,9 @@ class GetMetadata(BaseTool):
                 # metadata supports sources directly
                 query = f"| metadata type=sources index={index} | table source | head {int(limit)}"
                 job = service.jobs.oneshot(query)
-                from splunklib.results import ResultsReader  # lazy import
+                from splunklib.results import JSONResultsReader  # lazy import
 
-                for result in ResultsReader(job):
+                for result in JSONResultsReader(job):
                     if isinstance(result, dict) and "source" in result:
                         values.append(str(result["source"]))
 
@@ -115,9 +115,9 @@ class GetMetadata(BaseTool):
                     f"| fields sourcetype | head {int(limit)}"
                 )
                 job = service.jobs.oneshot(query)
-                from splunklib.results import ResultsReader  # lazy import
+                from splunklib.results import JSONResultsReader  # lazy import
 
-                for result in ResultsReader(job):
+                for result in JSONResultsReader(job):
                     if isinstance(result, dict) and "sourcetype" in result:
                         values.append(str(result["sourcetype"]))
 

--- a/src/tools/metadata/get_metadata.py
+++ b/src/tools/metadata/get_metadata.py
@@ -91,7 +91,7 @@ class GetMetadata(BaseTool):
             if field == "host":
                 # metadata supports hosts directly
                 query = f"| metadata type=hosts index={index} | table host | head {int(limit)}"
-                job = service.jobs.oneshot(query)
+                job = service.jobs.oneshot(query, output_mode="json")
                 from splunklib.results import JSONResultsReader  # lazy import
 
                 for result in JSONResultsReader(job):
@@ -101,7 +101,7 @@ class GetMetadata(BaseTool):
             elif field == "source":
                 # metadata supports sources directly
                 query = f"| metadata type=sources index={index} | table source | head {int(limit)}"
-                job = service.jobs.oneshot(query)
+                job = service.jobs.oneshot(query, output_mode="json")
                 from splunklib.results import JSONResultsReader  # lazy import
 
                 for result in JSONResultsReader(job):
@@ -114,7 +114,7 @@ class GetMetadata(BaseTool):
                     f"| tstats count where index={index} earliest={earliest_time} latest={latest_time} by sourcetype "
                     f"| fields sourcetype | head {int(limit)}"
                 )
-                job = service.jobs.oneshot(query)
+                job = service.jobs.oneshot(query, output_mode="json")
                 from splunklib.results import JSONResultsReader  # lazy import
 
                 for result in JSONResultsReader(job):

--- a/src/tools/metadata/sources.py
+++ b/src/tools/metadata/sources.py
@@ -59,7 +59,10 @@ class ListSources(BaseTool):
 
         try:
             # Use metadata command to retrieve sources
-            job = service.jobs.oneshot("| metadata type=sources index=_* index=* | table source")
+            job = service.jobs.oneshot(
+                "| metadata type=sources index=_* index=* | table source",
+                output_mode="json",
+            )
 
             sources = []
             for result in JSONResultsReader(job):

--- a/src/tools/metadata/sources.py
+++ b/src/tools/metadata/sources.py
@@ -62,7 +62,7 @@ class ListSources(BaseTool):
             job = service.jobs.oneshot("| metadata type=sources index=_* index=* | table source")
 
             sources = []
-            for result in ResultsReader(job):
+            for result in JSONResultsReader(job):
                 if isinstance(result, dict) and "source" in result:
                     sources.append(result["source"])
 

--- a/src/tools/metadata/sources.py
+++ b/src/tools/metadata/sources.py
@@ -5,7 +5,7 @@ Tool for listing Splunk data sources.
 from typing import Any
 
 from fastmcp import Context
-from splunklib.results import ResultsReader
+from splunklib.results import JSONResultsReader
 
 from src.core.base import BaseTool, ToolMetadata
 from src.core.utils import log_tool_execution

--- a/src/tools/metadata/sourcetypes.py
+++ b/src/tools/metadata/sourcetypes.py
@@ -61,7 +61,8 @@ class ListSourcetypes(BaseTool):
         try:
             # Use metadata command to retrieve sourcetypes
             job = service.jobs.oneshot(
-                "| metadata type=sourcetypes index=_* index=* | table sourcetype"
+                "| metadata type=sourcetypes index=_* index=* | table sourcetype",
+                output_mode="json",
             )
 
             sourcetypes = []

--- a/src/tools/metadata/sourcetypes.py
+++ b/src/tools/metadata/sourcetypes.py
@@ -5,7 +5,7 @@ Tool for listing Splunk sourcetypes.
 from typing import Any
 
 from fastmcp import Context
-from splunklib.results import ResultsReader
+from splunklib.results import JSONResultsReader
 
 from src.core.base import BaseTool, ToolMetadata
 from src.core.utils import log_tool_execution
@@ -65,7 +65,7 @@ class ListSourcetypes(BaseTool):
             )
 
             sourcetypes = []
-            for result in ResultsReader(job):
+            for result in JSONResultsReader(job):
                 if isinstance(result, dict) and "sourcetype" in result:
                     sourcetypes.append(result["sourcetype"])
 


### PR DESCRIPTION
## What
`splunk-sdk` 2.x renamed `ResultsReader` to `JSONResultsReader`. The import of `ResultsReader` in `src/tools/metadata/sources.py` causes an `ImportError`, which cascades and prevents all Splunk tools from registering.

## Fix
Change the import from `ResultsReader` to `JSONResultsReader`.

Closes #147