### PR TITLE
Improve create_dashboard theme auto-detection and performance

### DIFF
--- a/docs/guides/create_dashboard_tool.md
+++ b/docs/guides/create_dashboard_tool.md
@@ -39,7 +39,7 @@ The `create_dashboard` tool enables AI agents and automation to create dashboard
     "label": "My Dashboard",             # Optional: Human-readable label
     "description": "Dashboard desc",     # Optional: Description text
     "dashboard_type": "auto",            # Optional: 'classic', 'studio', 'auto'
-    "theme": "light",                    # Optional: 'light' or 'dark' (Studio only, when tool wraps JSON)
+    "theme": "auto",                   # Optional: 'light', 'dark', or 'auto' (Studio only; auto reads uiSettings.theme)
     "overwrite": false                   # Optional: Update if exists
 }
 ```
@@ -128,7 +128,7 @@ result = await create_dashboard.execute(
     name="performance_dashboard",
     definition=studio_definition,
     dashboard_type="studio",
-    theme="dark",  # Optional: 'light' (default) or 'dark' — sets `<dashboard theme="...">` when wrapping JSON
+    theme="dark",  # Optional: 'light', 'dark', or 'auto' (default) — sets `<dashboard theme="...">` when wrapping JSON
     app="myapp"
 )
 ```
@@ -141,7 +141,7 @@ When `dashboard_type="studio"` or auto-detected as Studio, you can provide eithe
 - A JSON string. The tool wraps it the same way.
 - A pre-wrapped XML string that already contains `<definition>` or `<dashboard version="2">`. The tool detects this and will not double‑wrap.
 
-Wrapper template (the `theme` argument becomes the `theme` attribute on the root `<dashboard>`; default is `light`):
+Wrapper template (the resolved `theme` becomes the `theme` attribute on the root `<dashboard>`; default is `auto`, which reads `uiSettings.theme` from Studio JSON and falls back to `dark`):
 
 ```xml
 <dashboard version="2" theme="${THEME}">
@@ -156,7 +156,7 @@ ${STUDIO_JSON}
 Notes:
 
 - The tool protects against embedded `]]>` in JSON by splitting the CDATA safely.
-- Label/description are also posted via a follow‑up metadata call for compatibility; wrapper includes them when provided.
+- Label/description are embedded in the Studio XML wrapper when provided (single create POST). Classic dashboards may use a follow-up metadata POST when label/description are supplied separately.
 - If you pass a pre-wrapped Studio XML string, the tool does not modify it; set `theme` inside your XML in that case.
 
 ### Overwrite Existing Dashboard

--- a/scripts/test_live_splunk_tools.py
+++ b/scripts/test_live_splunk_tools.py
@@ -288,6 +288,11 @@ def _tool_plan(state: LiveTestState) -> list[tuple[str, dict[str, Any] | None]]:
 
 async def main() -> int:
     config = _splunk_env_config()
+    connection_label = (
+        f"{os.environ.get('SPLUNK_SCHEME', 'https')}://"
+        f"{_normalize_host(os.environ.get('SPLUNK_HOST', ''))}:"
+        f"{os.environ.get('SPLUNK_PORT', '8089')}"
+    )
 
     from src.client.splunk_client import get_splunk_service
     from src.core.discovery import discover_tools
@@ -295,7 +300,7 @@ async def main() -> int:
 
     print("Connecting to Splunk...")
     service = get_splunk_service(config)
-    print(f"Connected to {config['splunk_scheme']}://{config['splunk_host']}:{config['splunk_port']}")
+    print(f"Connected to {connection_label}")
 
     discover_tools()
     ctx = LiveSplunkContext(service)

--- a/scripts/test_live_splunk_tools.py
+++ b/scripts/test_live_splunk_tools.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""
+Live Splunk tool smoke test.
+
+Exercises registered MCP tools against a real Splunk instance. Credentials must
+be supplied via environment variables (never hard-coded):
+
+  SPLUNK_HOST, SPLUNK_PORT, SPLUNK_USERNAME, SPLUNK_PASSWORD,
+  SPLUNK_SCHEME, SPLUNK_VERIFY_SSL
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+from urllib.parse import urlparse
+
+# Ensure project root is importable
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+
+def _normalize_host(raw_host: str) -> str:
+    value = raw_host.strip()
+    if value.startswith("http://") or value.startswith("https://"):
+        parsed = urlparse(value)
+        return parsed.hostname or value
+    return value
+
+
+def _splunk_env_config() -> dict[str, Any]:
+    host = _normalize_host(os.environ.get("SPLUNK_HOST", ""))
+    if not host:
+        raise SystemExit("SPLUNK_HOST is required")
+
+    password = os.environ.get("SPLUNK_PASSWORD")
+    username = os.environ.get("SPLUNK_USERNAME")
+    if not username or not password:
+        raise SystemExit("SPLUNK_USERNAME and SPLUNK_PASSWORD are required")
+
+    return {
+        "splunk_host": host,
+        "splunk_port": int(os.environ.get("SPLUNK_PORT", "8089")),
+        "splunk_username": username,
+        "splunk_password": password,
+        "splunk_scheme": os.environ.get("SPLUNK_SCHEME", "https"),
+        "splunk_verify_ssl": os.environ.get("SPLUNK_VERIFY_SSL", "false").lower()
+        in ("true", "1", "yes"),
+    }
+
+
+class LiveSplunkContext:
+    """Minimal FastMCP-like context wired to a live Splunk service."""
+
+    def __init__(self, service: Any) -> None:
+        self.request_context = Mock()
+        self.request_context.lifespan_context = Mock()
+        self.request_context.lifespan_context.service = service
+        self.request_context.lifespan_context.is_connected = True
+        self.info = AsyncMock()
+        self.debug = AsyncMock()
+        self.warning = AsyncMock()
+        self.error = AsyncMock()
+        self.report_progress = AsyncMock()
+        self.read_resource = AsyncMock()
+        self.sample = AsyncMock()
+        self.request_id = "live-test"
+        self.client_id = "live-test"
+        self.session_id = "live-test"
+
+
+@dataclass
+class LiveTestState:
+    dashboard_name: str = field(default_factory=lambda: f"mcp_live_{uuid.uuid4().hex[:8]}")
+    saved_search_name: str = field(default_factory=lambda: f"mcp_live_ss_{uuid.uuid4().hex[:8]}")
+    kv_collection: str = field(default_factory=lambda: f"mcp_live_kv_{uuid.uuid4().hex[:8]}")
+    search_job_id: str | None = None
+    first_dashboard_name: str | None = None
+
+
+def _is_success(result: Any) -> bool:
+    if not isinstance(result, dict):
+        return False
+    status = result.get("status")
+    if status == "success":
+        return True
+    if status == "error":
+        return False
+    # Some tools return payload without explicit status
+    return "error" not in result
+
+
+@dataclass
+class ToolRun:
+    name: str
+    outcome: str
+    detail: str = ""
+    elapsed_ms: int = 0
+
+
+async def _run_tool(
+    registry: Any,
+    ctx: LiveSplunkContext,
+    name: str,
+    args: dict[str, Any],
+    state: LiveTestState,
+) -> ToolRun:
+    tool = registry.get_tool(name)
+    if tool is None:
+        return ToolRun(name, "MISSING", "Tool not registered")
+
+    started = time.perf_counter()
+    try:
+        result = await tool.execute(ctx, **args)
+        elapsed = int((time.perf_counter() - started) * 1000)
+        if _is_success(result):
+            _update_state_from_result(name, result, state)
+            return ToolRun(name, "PASS", elapsed_ms=elapsed)
+        error = result.get("error") or result.get("message") or json.dumps(result)[:200]
+        return ToolRun(name, "FAIL", str(error)[:300], elapsed)
+    except Exception as exc:  # pylint: disable=broad-except
+        elapsed = int((time.perf_counter() - started) * 1000)
+        return ToolRun(name, "FAIL", str(exc)[:300], elapsed)
+
+
+def _update_state_from_result(name: str, result: dict[str, Any], state: LiveTestState) -> None:
+    if name == "run_splunk_search":
+        state.search_job_id = result.get("job_id") or result.get("sid")
+    if name == "list_dashboards" and not state.first_dashboard_name:
+        dashboards = result.get("dashboards") or []
+        if dashboards:
+            state.first_dashboard_name = dashboards[0].get("name")
+    if name == "create_dashboard":
+        state.dashboard_name = result.get("name", state.dashboard_name)
+
+
+def _tool_plan(state: LiveTestState) -> list[tuple[str, dict[str, Any] | None]]:
+    """Return (tool_name, args). None args means invoke with defaults only."""
+    return [
+        ("get_splunk_health", {}),
+        ("me", {}),
+        ("list_indexes", {}),
+        ("list_sources", {}),
+        ("list_sourcetypes", {}),
+        ("get_metadata", {"index": "_internal", "field": "host", "limit": 5}),
+        ("list_apps", {}),
+        ("list_users", {}),
+        ("get_configurations", {"conf_file": "server", "stanza": "general"}),
+        ("list_dashboards", {"count": 10}),
+        (
+            "create_dashboard",
+            {
+                "name": state.dashboard_name,
+                "definition": {
+                    "version": "1.0.0",
+                    "title": "MCP Live Test Dashboard",
+                    "uiSettings": {"theme": "dark"},
+                    "dataSources": {
+                        "ds_events": {
+                            "type": "ds.search",
+                            "options": {
+                                "query": "index=_internal | head 1",
+                                "queryParameters": {"earliest": "-15m", "latest": "now"},
+                            },
+                        }
+                    },
+                    "visualizations": {
+                        "viz_count": {
+                            "type": "splunk.singlevalue",
+                            "title": "Events",
+                            "dataSources": {"primary": "ds_events"},
+                            "options": {"majorValue": {"field": "_serial"}},
+                        }
+                    },
+                    "layout": {
+                        "type": "absolute",
+                        "structure": [
+                            {"item": "viz_count", "position": {"x": 0, "y": 0, "w": 6, "h": 3}}
+                        ],
+                    },
+                },
+                "label": "MCP Live Test",
+                "description": "Automated live tool verification",
+                "theme": "auto",
+            },
+        ),
+        (
+            "get_dashboard_definition",
+            {"name": state.dashboard_name},
+        ),
+        ("list_lookup_files", {"count": 10}),
+        ("list_lookup_definitions", {"count": 10}),
+        ("list_kvstore_collections", {}),
+        ("list_saved_searches", {"include_disabled": True}),
+        (
+            "create_saved_search",
+            {
+                "name": state.saved_search_name,
+                "search": "index=_internal | head 1",
+                "description": "MCP live test saved search",
+                "sharing": "user",
+            },
+        ),
+        ("get_saved_search_details", {"name": state.saved_search_name, "owner": "admin"}),
+        (
+            "execute_saved_search",
+            {
+                "name": state.saved_search_name,
+                "owner": "admin",
+                "earliest_time": "-15m",
+                "latest_time": "now",
+            },
+        ),
+        (
+            "update_saved_search",
+            {
+                "name": state.saved_search_name,
+                "owner": "admin",
+                "description": "MCP live test saved search (updated)",
+            },
+        ),
+        (
+            "run_oneshot_search",
+            {
+                "query": "index=_internal | head 3",
+                "earliest_time": "-15m",
+                "latest_time": "now",
+                "max_results": 3,
+            },
+        ),
+        (
+            "run_splunk_search",
+            {
+                "query": "index=_internal | head 3",
+                "earliest_time": "-15m",
+                "latest_time": "now",
+            },
+        ),
+        ("get_search_job_info", {"job_id": "__JOB_ID__"}),
+        ("list_triggered_alerts", {"count": 5}),
+        ("list_workflows", {"format_type": "summary"}),
+        ("get_executed_workflows", {"limit": 5}),
+        ("workflow_requirements", {"format_type": "quick"}),
+        ("workflow_builder", {"mode": "template", "template_type": "minimal"}),
+        ("discover_splunk_docs", {}),
+        ("list_available_topics", {}),
+        ("list_troubleshooting_topics", {}),
+        ("list_admin_topics", {}),
+        ("list_spl_commands", {}),
+        ("list_cim_data_models", {}),
+        ("list_dashboard_studio_topics", {}),
+        ("list_config_files", {}),
+        ("get_splunk_cheat_sheet", {}),
+        ("get_spl_reference", {"command": "stats"}),
+        ("get_troubleshooting_guide", {"topic": "search-problems"}),
+        ("get_admin_guide", {"topic": "indexes"}),
+        ("get_cim_reference", {"model": "authentication"}),
+        ("get_studio_topic", {"topic": "cheatsheet"}),
+        ("get_config_spec", {"config": "props"}),
+        ("get_splunk_documentation", {"doc_uri": "splunk-docs://cheat-sheet"}),
+        ("enhance_tool_description", {"tool_name": "list_indexes", "generate_examples": False}),
+        ("delete_saved_search", {"name": state.saved_search_name, "owner": "admin", "confirm": True}),
+        (
+            "create_kvstore_collection",
+            {
+                "app": "search",
+                "collection": state.kv_collection,
+                "fields": [{"name": "test_key", "type": "str"}],
+            },
+        ),
+        (
+            "get_kvstore_data",
+            {"collection": state.kv_collection, "app": "search"},
+        ),
+        ("manage_apps", None),  # skipped – mutates app state
+        ("create_config", None),  # skipped – writes conf files
+        ("workflow_runner", None),  # skipped unless OPENAI_API_KEY set
+    ]
+
+
+async def main() -> int:
+    config = _splunk_env_config()
+
+    from src.client.splunk_client import get_splunk_service
+    from src.core.discovery import discover_tools
+    from src.core.registry import tool_registry
+
+    print("Connecting to Splunk...")
+    service = get_splunk_service(config)
+    print(f"Connected to {config['splunk_scheme']}://{config['splunk_host']}:{config['splunk_port']}")
+
+    discover_tools()
+    ctx = LiveSplunkContext(service)
+    state = LiveTestState()
+
+    runs: list[ToolRun] = []
+    for tool_name, args in _tool_plan(state):
+        if args is None:
+            if tool_name == "workflow_runner":
+                api_key = os.environ.get("OPENAI_API_KEY", "")
+                if api_key and "your_ope" not in api_key.lower() and api_key.startswith("sk-"):
+                    args = {
+                        "workflow_id": "missing_data_troubleshooting",
+                        "problem_description": "Live MCP smoke test",
+                        "focus_index": "_internal",
+                    }
+                else:
+                    runs.append(
+                        ToolRun(
+                            tool_name,
+                            "SKIP",
+                            "skipped (requires valid OPENAI_API_KEY for agent execution)",
+                        )
+                    )
+                    continue
+            else:
+                reason = {
+                    "manage_apps": "skipped (mutates app state on live instance)",
+                    "create_config": "skipped (writes configuration files)",
+                }.get(tool_name, "skipped")
+                runs.append(ToolRun(tool_name, "SKIP", reason))
+                continue
+
+        if tool_name == "get_search_job_info":
+            if not state.search_job_id:
+                runs.append(ToolRun(tool_name, "SKIP", "no search job id from run_splunk_search"))
+                continue
+            args = {"job_id": state.search_job_id}
+
+        if tool_name == "get_dashboard_definition" and args.get("name") == state.dashboard_name:
+            pass  # uses freshly created dashboard
+        elif tool_name == "get_dashboard_definition" and state.first_dashboard_name:
+            args = {"name": state.first_dashboard_name}
+
+        print(f"  -> {tool_name}...", flush=True)
+        runs.append(await _run_tool(tool_registry, ctx, tool_name, args, state))
+
+    passed = [r for r in runs if r.outcome == "PASS"]
+    failed = [r for r in runs if r.outcome == "FAIL"]
+    skipped = [r for r in runs if r.outcome == "SKIP"]
+
+    print("\n" + "=" * 72)
+    print("LIVE SPLUNK TOOL TEST SUMMARY")
+    print("=" * 72)
+    print(f"PASS: {len(passed)}  FAIL: {len(failed)}  SKIP: {len(skipped)}  TOTAL: {len(runs)}")
+    print("-" * 72)
+
+    for run in runs:
+        timing = f" ({run.elapsed_ms}ms)" if run.elapsed_ms else ""
+        line = f"[{run.outcome:4}] {run.name}{timing}"
+        if run.detail:
+            line += f" — {run.detail}"
+        print(line)
+
+    if failed:
+        print("\nFailed tools need attention before merge.")
+        return 1
+
+    print("\nAll executed tools passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/prompts/dashboard_studio_builder.md
+++ b/src/prompts/dashboard_studio_builder.md
@@ -122,6 +122,19 @@ Return the complete JSON object only. No explanatory text before or after.
 - `inputs` (object): Time pickers, dropdowns, etc.
 - `tokens` (object): Variables for dynamic queries
 - `eventHandlers` (object): Interaction handlers
+- `uiSettings` (object): UI preferences, including theme
+
+### Theme (light / dark)
+
+Set the dashboard theme in Studio JSON so `create_dashboard` applies it automatically (`theme="auto"` is the default):
+
+```json
+"uiSettings": {
+  "theme": "dark"
+}
+```
+
+Use `"dark"` for operations/SOC dashboards unless the user asks for light mode. You can also pass `theme="dark"` or `theme="light"` on the `create_dashboard` tool call.
 
 ### Output Format
 

--- a/src/tools/dashboards/create_dashboard.py
+++ b/src/tools/dashboards/create_dashboard.py
@@ -3,7 +3,7 @@ Create a dashboard (Simple XML or Dashboard Studio) via Splunk REST API.
 """
 
 import json
-from typing import Any, Literal
+from typing import Any
 
 from fastmcp import Context
 
@@ -220,7 +220,7 @@ class CreateDashboard(BaseTool):
                 prepared, label=label, description=description
             ):
                 try:
-                    await self._update_dashboard_metadata(
+                    self._update_dashboard_metadata(
                         service,
                         owner=owner,
                         app=app,

--- a/src/tools/dashboards/create_dashboard.py
+++ b/src/tools/dashboards/create_dashboard.py
@@ -4,12 +4,16 @@ Create a dashboard (Simple XML or Dashboard Studio) via Splunk REST API.
 
 import json
 from typing import Any, Literal
-from xml.sax.saxutils import escape as xml_escape  # nosec B406  # nosemgrep: use-defused-xml
 
 from fastmcp import Context
 
 from src.core.base import BaseTool, ToolMetadata
 from src.core.utils import log_tool_execution
+from src.tools.dashboards.studio_wrapper import (
+    DashboardDefinitionPreparer,
+    PreparedDashboard,
+    ThemeParam,
+)
 
 
 class CreateDashboard(BaseTool):
@@ -34,9 +38,10 @@ class CreateDashboard(BaseTool):
             "    label (str, optional): Human label shown in UI\n"
             "    description (str, optional): Dashboard description\n"
             "    dashboard_type (str, optional): 'studio'|'classic'|'auto' (default: 'auto')\n"
-            "    theme (str, optional): Dashboard Studio UI theme when the tool wraps JSON into "
-            "XML: 'light' or 'dark' (default: 'light'). Ignored for Classic Simple XML and when "
-            "you pass a pre-wrapped Studio XML string (already containing <dashboard>).\n"
+            "    theme (str, optional): Dashboard Studio UI theme when wrapping JSON: "
+            "'light', 'dark', or 'auto' (default: 'auto'). With 'auto', reads "
+            "uiSettings.theme / theme from Studio JSON or pre-wrapped XML; falls back to "
+            "'dark'. Ignored for Classic Simple XML.\n"
             "    sharing (str, optional): 'user'|'app'|'global'\n"
             "    read_perms (list[str], optional): Roles/users granted read\n"
             "    write_perms (list[str], optional): Roles/users granted write\n"
@@ -47,58 +52,64 @@ class CreateDashboard(BaseTool):
         requires_connection=True,
     )
 
-    def _ensure_studio_xml_wrapper(
-        self,
-        definition: Any,
+    @staticmethod
+    def _build_create_payload(name: str, prepared: PreparedDashboard) -> dict[str, Any]:
+        """Splunk create handler accepts name and eai:data only."""
+        return {
+            "name": name,
+            "eai:data": prepared.eai_data,
+            "output_mode": "json",
+        }
+
+    @staticmethod
+    def _should_skip_metadata_post(
+        prepared: PreparedDashboard,
+        *,
         label: str | None,
         description: str | None,
-        theme: Literal["light", "dark"] = "light",
-    ) -> str:
-        """
-        Ensure the provided Studio definition is wrapped in the required XML
-        structure with a CDATA <definition> block. If the definition already
-        includes a <definition> or a <dashboard> wrapper, return it unchanged.
+    ) -> bool:
+        """Studio XML wrapper already embeds label/description when provided."""
+        if prepared.resolved_type != "studio":
+            return False
+        data = prepared.eai_data
+        if label and "<label>" not in data:
+            return False
+        if description and "<description>" not in data:
+            return False
+        return bool(label or description)
 
-        - Accepts dict (Studio JSON) or str (JSON string or pre-wrapped XML)
-        - Compacts JSON for CDATA
-        - Handles embedded ']]>' by splitting CDATA safely
-        - Includes optional <label> and <description>
-        """
-
-        # Pass-through if already wrapped (avoid double wrap)
-        if isinstance(definition, str):
-            if "<definition>" in definition or "<dashboard" in definition:
-                return definition
-
-        # Normalize to a compact JSON string
-        studio_json_str: str
-        if isinstance(definition, dict):
-            studio_json_str = json.dumps(definition, separators=(",", ":"))
-        elif isinstance(definition, str):
-            try:
-                parsed = json.loads(definition)
-                studio_json_str = json.dumps(parsed, separators=(",", ":"))
-            except Exception:  # noqa: BLE001 - be permissive, use raw string
-                studio_json_str = definition.strip()
-        else:
-            raise TypeError("Studio definition must be dict or str")
-
-        # Protect CDATA from accidental termination inside JSON
-        cdata_safe_json = studio_json_str.replace("]]>", "]]]]><![CDATA[>")
-
-        # Build XML wrapper (Splunk Dashboard Studio v2: theme on root <dashboard>)
-        xml_parts: list[str] = []
-        xml_parts.append(f'<dashboard version="2" theme="{theme}">')
+    @staticmethod
+    def _update_dashboard_metadata(
+        service: Any,
+        *,
+        owner: str,
+        app: str,
+        name: str,
+        label: str | None,
+        description: str | None,
+    ) -> None:
+        endpoint = f"/servicesNS/{owner}/{app}/data/ui/views/{name}"
+        meta_payload: dict[str, Any] = {"output_mode": "json"}
         if label:
-            xml_parts.append(f"  <label>{xml_escape(label)}</label>")
+            meta_payload["label"] = label
         if description:
-            xml_parts.append(f"  <description>{xml_escape(description)}</description>")
-        xml_parts.append("  <definition><![CDATA[")
-        xml_parts.append(cdata_safe_json)
-        xml_parts.append("  ]]></definition>")
-        xml_parts.append("</dashboard>")
+            meta_payload["description"] = description
+        service.post(endpoint, **meta_payload)
 
-        return "\n".join(xml_parts)
+    @staticmethod
+    def _read_response_entry(response_body: bytes) -> dict[str, Any] | None:
+        if not response_body:
+            return None
+        try:
+            response_data = json.loads(response_body)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(response_data, dict):
+            return None
+        entries = response_data.get("entry", [])
+        if entries and isinstance(entries[0], dict):
+            return entries[0]
+        return None
 
     async def execute(
         self,
@@ -114,11 +125,9 @@ class CreateDashboard(BaseTool):
         read_perms: list[str] | None = None,
         write_perms: list[str] | None = None,
         overwrite: bool = False,
-        theme: Literal["light", "dark"] = "light",
+        theme: ThemeParam = "auto",
     ) -> dict[str, Any]:
-        """
-        Create (or overwrite) a dashboard in Splunk.
-        """
+        """Create (or overwrite) a dashboard in Splunk."""
         log_tool_execution(
             "create_dashboard",
             name=name,
@@ -138,108 +147,59 @@ class CreateDashboard(BaseTool):
             return self.format_error_response(error_msg)
 
         try:
-            # Determine Studio vs Classic and prepare eai:data
-            resolved_type = dashboard_type
-            eai_data: str
+            await ctx.report_progress(progress=5, total=100)
 
-            if resolved_type not in ("studio", "classic", "auto"):
-                resolved_type = "auto"
+            prepared_result = DashboardDefinitionPreparer.prepare(
+                definition,
+                dashboard_type=dashboard_type,
+                label=label,
+                description=description,
+                theme=theme,
+            )
+            if isinstance(prepared_result, str):
+                return self.format_error_response(prepared_result)
 
-            if theme not in ("light", "dark"):
-                return self.format_error_response(
-                    "Invalid 'theme'. Use 'light' or 'dark' (Dashboard Studio wrapper only)."
-                )
+            prepared = prepared_result
+            resolved_type = prepared.resolved_type
+            resolved_theme = prepared.resolved_theme
 
-            if resolved_type == "auto":
-                if isinstance(definition, dict):
-                    resolved_type = "studio"
-                    eai_data = self._ensure_studio_xml_wrapper(
-                        definition, label, description, theme
-                    )
-                elif isinstance(definition, str):
-                    # Heuristics: Studio hybrid (<definition>) or pure JSON
-                    if "<definition>" in definition:
-                        resolved_type = "studio"
-                        eai_data = definition
-                    else:
-                        try:
-                            json.loads(definition)
-                            resolved_type = "studio"
-                            eai_data = self._ensure_studio_xml_wrapper(
-                                definition, label, description, theme
-                            )
-                        except (json.JSONDecodeError, TypeError):
-                            resolved_type = "classic"
-                            eai_data = definition
-                else:
-                    return self.format_error_response(
-                        "Invalid 'definition' type. Expect dict or str"
-                    )
-            elif resolved_type == "studio":
-                if isinstance(definition, dict) or isinstance(definition, str):
-                    try:
-                        eai_data = self._ensure_studio_xml_wrapper(
-                            definition, label, description, theme
-                        )
-                    except Exception as wrap_err:  # pylint: disable=broad-except
-                        return self.format_error_response(
-                            f"Invalid Studio definition: {str(wrap_err)}"
-                        )
-                else:
-                    return self.format_error_response(
-                        "Studio dashboards require JSON (dict) or JSON string"
-                    )
-            else:  # classic
-                if not isinstance(definition, str):
-                    return self.format_error_response(
-                        "Classic dashboards require XML string definition"
-                    )
-                eai_data = definition
-
+            await ctx.report_progress(progress=20, total=100)
             await ctx.info(
                 f"Creating dashboard '{name}' (type={resolved_type}, owner={owner}, app={app}"
-                + (f", theme={theme}" if resolved_type == "studio" else "")
+                + (
+                    f", theme={resolved_theme}, size={prepared.definition_size_bytes} bytes"
+                    if resolved_type == "studio"
+                    else f", size={prepared.definition_size_bytes} bytes"
+                )
                 + ")"
             )
 
-            # Web URL for response (use Splunk Web port 8000, not management port)
-            # Use safe defaults for mocks that may not define host/scheme
             splunk_host = getattr(service, "host", "localhost")
             web_scheme = getattr(service, "scheme", "https")
-            web_port = (
-                443 if web_scheme == "https" else 8000
-            )  # Splunk Web UI port (management API is on service.port which is 8089)
-
+            web_port = 443 if web_scheme == "https" else 8000
             web_base = f"{web_scheme}://{splunk_host}:{web_port}"
 
-            # Create first; on conflict and overwrite=True, update existing
-            created = False
-            response_data: dict[str, Any] | None = None
-            try:
-                # Initial create: only name and eai:data
-                # Use full path like list_dashboards does
-                endpoint = f"/servicesNS/{owner}/{app}/data/ui/views"
+            endpoint = f"/servicesNS/{owner}/{app}/data/ui/views"
+            create_payload = self._build_create_payload(name, prepared)
 
-                # Don't pass owner/app as separate params - they're in the path
-                response = service.post(
-                    endpoint,
-                    name=name,
-                    **{"eai:data": eai_data, "output_mode": "json"},
-                )
-                response_body = response.body.read()
-                response_data = json.loads(response_body) if response_body else {}
+            created = False
+            entry: dict[str, Any] | None = None
+
+            await ctx.report_progress(progress=35, total=100)
+            try:
+                response = service.post(endpoint, **create_payload)
+                entry = self._read_response_entry(response.body.read())
                 created = True
             except Exception as create_err:  # pylint: disable=broad-except
                 err_str = str(create_err)
                 if overwrite and ("409" in err_str or "exists" in err_str.lower()):
                     await ctx.info(f"Dashboard exists. Overwriting existing dashboard '{name}'")
-                    # Update allows eai:data only (no name parameter)
-                    endpoint = f"/servicesNS/{owner}/{app}/data/ui/views/{name}"
-                    response = service.post(
-                        endpoint, **{"eai:data": eai_data, "output_mode": "json"}
-                    )
-                    response_body = response.body.read()
-                    response_data = json.loads(response_body) if response_body else {}
+                    update_endpoint = f"/servicesNS/{owner}/{app}/data/ui/views/{name}"
+                    update_payload = {
+                        key: value for key, value in create_payload.items() if key != "name"
+                    }
+                    response = service.post(update_endpoint, **update_payload)
+                    entry = self._read_response_entry(response.body.read())
                 else:
                     self.logger.error("Create dashboard failed: %s", err_str, exc_info=True)
                     await ctx.error(f"Failed to create dashboard: {err_str}")
@@ -254,24 +214,26 @@ class CreateDashboard(BaseTool):
                         detail += " (Session error - try reconnecting to Splunk)"
                     return self.format_error_response(detail)
 
-            # Optional: Update label/description if provided (separate API call)
-            if label or description:
+            await ctx.report_progress(progress=75, total=100)
+
+            if (label or description) and not self._should_skip_metadata_post(
+                prepared, label=label, description=description
+            ):
                 try:
-                    endpoint = f"/servicesNS/{owner}/{app}/data/ui/views/{name}"
-                    meta_payload: dict[str, Any] = {"output_mode": "json"}
-                    if label:
-                        meta_payload["label"] = label
-                    if description:
-                        meta_payload["description"] = description
-                    service.post(endpoint, **meta_payload)
+                    await self._update_dashboard_metadata(
+                        service,
+                        owner=owner,
+                        app=app,
+                        name=name,
+                        label=label,
+                        description=description,
+                    )
                 except Exception as meta_err:  # pylint: disable=broad-except
-                    # Non-fatal: dashboard was created, just label/description update failed
                     await ctx.warning(f"Label/description update failed: {str(meta_err)}")
 
-            # Optional ACL update (sharing/perms)
             if sharing or read_perms or write_perms:
                 try:
-                    endpoint = f"/servicesNS/{owner}/{app}/data/ui/views/{name}/acl"
+                    acl_endpoint = f"/servicesNS/{owner}/{app}/data/ui/views/{name}/acl"
                     acl_payload: dict[str, Any] = {"output_mode": "json"}
                     if sharing:
                         acl_payload["sharing"] = sharing
@@ -279,61 +241,39 @@ class CreateDashboard(BaseTool):
                         acl_payload["perms.read"] = ",".join(read_perms)
                     if write_perms:
                         acl_payload["perms.write"] = ",".join(write_perms)
-                    service.post(endpoint, **acl_payload)
+                    service.post(acl_endpoint, **acl_payload)
                 except Exception as acl_err:  # pylint: disable=broad-except
-                    # Non-fatal: include warning in response
                     await ctx.warning(f"ACL update failed: {str(acl_err)}")
 
-            # Parse response entry (best-effort)
-            entry = None
-            if isinstance(response_data, dict):
-                entries = response_data.get("entry", [])
-                if entries:
-                    entry = entries[0]
-
-            # Fallbacks if server didn't echo entry
-            content = (entry or {}).get("content", {}) if entry else {}
-            acl = (entry or {}).get("acl", {}) if entry else {}
-
-            # Determine dashboard app for web URL
+            content = (entry or {}).get("content", {})
+            acl = (entry or {}).get("acl", {})
             dashboard_app = acl.get("app", app)
             web_url = f"{web_base}/en-US/app/{dashboard_app}/{name}"
 
-            # Determine type (reuse read logic heuristics)
-            eai_data_from_resp = content.get("eai:data", eai_data)
-            detected_type = "classic"
-            if eai_data_from_resp:
-                if "<definition>" in str(eai_data_from_resp):
-                    detected_type = "studio"
-                else:
-                    try:
-                        json.loads(eai_data_from_resp)
-                        detected_type = "studio"
-                    except Exception:  # noqa: BLE001
-                        detected_type = "classic"
-
             await ctx.info(
-                f"Dashboard '{name}' {'created' if created else 'updated'} (type={detected_type})"
+                f"Dashboard '{name}' {'created' if created else 'updated'} (type={resolved_type})"
             )
+            await ctx.report_progress(progress=100, total=100)
 
             response_payload: dict[str, Any] = {
-                    "name": name,
-                    "label": content.get("label", label or name),
-                    "type": detected_type,
-                    "app": dashboard_app,
-                    "owner": acl.get("owner", owner),
-                    "sharing": acl.get("sharing", sharing or ""),
-                    "description": content.get("description", description or ""),
-                    "version": content.get("version", ""),
-                    "permissions": {
-                        "read": (acl.get("perms", {}) or {}).get("read", []),
-                        "write": (acl.get("perms", {}) or {}).get("write", []),
-                    },
-                    "web_url": web_url,
-                    "id": (entry or {}).get("id", ""),
+                "name": name,
+                "label": content.get("label", label or name),
+                "type": resolved_type,
+                "app": dashboard_app,
+                "owner": acl.get("owner", owner),
+                "sharing": acl.get("sharing", sharing or ""),
+                "description": content.get("description", description or ""),
+                "version": content.get("version", ""),
+                "definition_size_bytes": prepared.definition_size_bytes,
+                "permissions": {
+                    "read": (acl.get("perms", {}) or {}).get("read", []),
+                    "write": (acl.get("perms", {}) or {}).get("write", []),
+                },
+                "web_url": web_url,
+                "id": (entry or {}).get("id", ""),
             }
-            if detected_type == "studio":
-                response_payload["theme"] = theme
+            if resolved_type == "studio" and resolved_theme:
+                response_payload["theme"] = resolved_theme
             return self.format_success_response(response_payload)
 
         except Exception as e:  # pylint: disable=broad-except

--- a/src/tools/dashboards/studio_wrapper.py
+++ b/src/tools/dashboards/studio_wrapper.py
@@ -4,11 +4,20 @@ import json
 import re
 from dataclasses import dataclass
 from typing import Any, Literal
-from xml.sax.saxutils import escape as xml_escape  # nosec B406  # nosemgrep: use-defused-xml
 
 ThemeParam = Literal["light", "dark", "auto"]
 ResolvedTheme = Literal["light", "dark"]
 DashboardType = Literal["studio", "classic"]
+
+
+def _xml_escape(value: str) -> str:
+    """Escape text for XML element content without using the stdlib xml package."""
+    return (
+        value.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
 
 
 @dataclass(frozen=True)
@@ -122,9 +131,9 @@ class StudioDashboardWrapper:
 
         xml_parts: list[str] = [f'<dashboard version="2" theme="{theme}">']
         if label:
-            xml_parts.append(f"  <label>{xml_escape(label)}</label>")
+            xml_parts.append(f"  <label>{_xml_escape(label)}</label>")
         if description:
-            xml_parts.append(f"  <description>{xml_escape(description)}</description>")
+            xml_parts.append(f"  <description>{_xml_escape(description)}</description>")
         xml_parts.extend(
             [
                 "  <definition><![CDATA[",

--- a/src/tools/dashboards/studio_wrapper.py
+++ b/src/tools/dashboards/studio_wrapper.py
@@ -1,0 +1,248 @@
+"""Dashboard Studio XML wrapping and theme resolution for create_dashboard."""
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Literal
+from xml.sax.saxutils import escape as xml_escape  # nosec B406  # nosemgrep: use-defused-xml
+
+ThemeParam = Literal["light", "dark", "auto"]
+ResolvedTheme = Literal["light", "dark"]
+DashboardType = Literal["studio", "classic"]
+
+
+@dataclass(frozen=True)
+class PreparedDashboard:
+    """Normalized dashboard payload ready for Splunk REST create/update."""
+
+    eai_data: str
+    resolved_type: DashboardType
+    resolved_theme: ResolvedTheme | None
+    definition_size_bytes: int
+
+
+class StudioThemeResolver:
+    """Resolve Dashboard Studio light/dark theme from params or definition content."""
+
+    _THEME_PATTERN = re.compile(r'<dashboard[^>]*\stheme="(light|dark)"', re.IGNORECASE)
+
+    @classmethod
+    def resolve(
+        cls,
+        definition: Any,
+        theme_param: ThemeParam,
+        *,
+        prewrapped: bool = False,
+    ) -> ResolvedTheme:
+        if theme_param in ("light", "dark"):
+            return theme_param
+
+        detected = cls._from_definition(definition, prewrapped=prewrapped)
+        return detected or "dark"
+
+    @classmethod
+    def from_eai_data(cls, eai_data: str) -> ResolvedTheme | None:
+        if "<dashboard" in eai_data:
+            return cls._from_xml(eai_data)
+        return None
+
+    @classmethod
+    def _from_definition(cls, definition: Any, *, prewrapped: bool) -> ResolvedTheme | None:
+        if prewrapped and isinstance(definition, str):
+            return cls._from_xml(definition)
+
+        data = cls._as_dict(definition)
+        if data is not None:
+            return cls._from_dict(data)
+
+        if isinstance(definition, str) and "<dashboard" in definition:
+            return cls._from_xml(definition)
+        return None
+
+    @staticmethod
+    def _as_dict(definition: Any) -> dict | None:
+        if isinstance(definition, dict):
+            return definition
+        if isinstance(definition, str):
+            try:
+                parsed = json.loads(definition)
+            except json.JSONDecodeError:
+                return None
+            return parsed if isinstance(parsed, dict) else None
+        return None
+
+    @staticmethod
+    def _from_dict(data: dict) -> ResolvedTheme | None:
+        ui_settings = data.get("uiSettings")
+        if isinstance(ui_settings, dict):
+            theme = ui_settings.get("theme")
+            if theme in ("light", "dark"):
+                return theme
+
+        theme = data.get("theme")
+        if theme in ("light", "dark"):
+            return theme
+
+        options = data.get("options")
+        if isinstance(options, dict):
+            option_theme = options.get("theme")
+            if option_theme in ("light", "dark"):
+                return option_theme
+        return None
+
+    @classmethod
+    def _from_xml(cls, xml: str) -> ResolvedTheme | None:
+        match = cls._THEME_PATTERN.search(xml)
+        if match:
+            return match.group(1).lower()  # type: ignore[return-value]
+        return None
+
+
+class StudioDashboardWrapper:
+    """Wrap Dashboard Studio JSON in Splunk's required XML + CDATA structure."""
+
+    @staticmethod
+    def is_prewrapped(definition: str) -> bool:
+        return "<definition>" in definition or "<dashboard" in definition
+
+    @classmethod
+    def wrap(
+        cls,
+        definition: Any,
+        *,
+        label: str | None,
+        description: str | None,
+        theme: ResolvedTheme,
+    ) -> str:
+        if isinstance(definition, str) and cls.is_prewrapped(definition):
+            return definition
+
+        studio_json_str = cls._normalize_json(definition)
+        cdata_safe_json = studio_json_str.replace("]]>", "]]]]><![CDATA[>")
+
+        xml_parts: list[str] = [f'<dashboard version="2" theme="{theme}">']
+        if label:
+            xml_parts.append(f"  <label>{xml_escape(label)}</label>")
+        if description:
+            xml_parts.append(f"  <description>{xml_escape(description)}</description>")
+        xml_parts.extend(
+            [
+                "  <definition><![CDATA[",
+                cdata_safe_json,
+                "  ]]></definition>",
+                "</dashboard>",
+            ]
+        )
+        return "\n".join(xml_parts)
+
+    @staticmethod
+    def _normalize_json(definition: Any) -> str:
+        if isinstance(definition, dict):
+            return json.dumps(definition, separators=(",", ":"))
+        if isinstance(definition, str):
+            try:
+                parsed = json.loads(definition)
+                return json.dumps(parsed, separators=(",", ":"))
+            except json.JSONDecodeError:
+                return definition.strip()
+        raise TypeError("Studio definition must be dict or str")
+
+
+class DashboardDefinitionPreparer:
+    """Detect dashboard type and build eai:data for Splunk REST create/update."""
+
+    @classmethod
+    def prepare(
+        cls,
+        definition: Any,
+        *,
+        dashboard_type: str,
+        label: str | None,
+        description: str | None,
+        theme: ThemeParam,
+    ) -> PreparedDashboard | str:
+        resolved_type_input = dashboard_type if dashboard_type in ("studio", "classic", "auto") else "auto"
+
+        if theme not in ("light", "dark", "auto"):
+            return "Invalid 'theme'. Use 'light', 'dark', or 'auto' (Dashboard Studio wrapper only)."
+
+        if resolved_type_input == "classic":
+            return cls._prepare_classic(definition)
+
+        if resolved_type_input == "studio":
+            return cls._prepare_studio(definition, label=label, description=description, theme=theme)
+
+        return cls._prepare_auto(definition, label=label, description=description, theme=theme)
+
+    @classmethod
+    def _prepare_classic(cls, definition: Any) -> PreparedDashboard | str:
+        if not isinstance(definition, str):
+            return "Classic dashboards require XML string definition"
+        return PreparedDashboard(
+            eai_data=definition,
+            resolved_type="classic",
+            resolved_theme=None,
+            definition_size_bytes=len(definition.encode("utf-8")),
+        )
+
+    @classmethod
+    def _prepare_studio(
+        cls,
+        definition: Any,
+        *,
+        label: str | None,
+        description: str | None,
+        theme: ThemeParam,
+    ) -> PreparedDashboard | str:
+        if not isinstance(definition, (dict, str)):
+            return "Studio dashboards require JSON (dict) or JSON string"
+
+        prewrapped = isinstance(definition, str) and StudioDashboardWrapper.is_prewrapped(definition)
+        resolved_theme = StudioThemeResolver.resolve(definition, theme, prewrapped=prewrapped)
+
+        try:
+            eai_data = StudioDashboardWrapper.wrap(
+                definition,
+                label=label,
+                description=description,
+                theme=resolved_theme,
+            )
+        except Exception as wrap_err:  # pylint: disable=broad-except
+            return f"Invalid Studio definition: {wrap_err}"
+
+        if prewrapped:
+            extracted = StudioThemeResolver.from_eai_data(eai_data)
+            if extracted:
+                resolved_theme = extracted
+
+        return PreparedDashboard(
+            eai_data=eai_data,
+            resolved_type="studio",
+            resolved_theme=resolved_theme,
+            definition_size_bytes=len(eai_data.encode("utf-8")),
+        )
+
+    @classmethod
+    def _prepare_auto(
+        cls,
+        definition: Any,
+        *,
+        label: str | None,
+        description: str | None,
+        theme: ThemeParam,
+    ) -> PreparedDashboard | str:
+        if isinstance(definition, dict):
+            return cls._prepare_studio(definition, label=label, description=description, theme=theme)
+
+        if isinstance(definition, str):
+            if "<definition>" in definition:
+                return cls._prepare_studio(definition, label=label, description=description, theme=theme)
+
+            try:
+                json.loads(definition)
+            except (json.JSONDecodeError, TypeError):
+                return cls._prepare_classic(definition)
+
+            return cls._prepare_studio(definition, label=label, description=description, theme=theme)
+
+        return "Invalid 'definition' type. Expect dict or str"

--- a/src/tools/kvstore/collections.py
+++ b/src/tools/kvstore/collections.py
@@ -12,6 +12,68 @@ from src.core.base import BaseTool, ToolMetadata
 from src.core.utils import log_tool_execution
 
 
+def _create_kvstore_collection_via_rest(
+    service: Any,
+    app: str,
+    collection: str,
+    collection_config: dict[str, Any],
+) -> None:
+    """Create a KV store collection through the REST API when splunklib create fails."""
+    endpoint = f"/servicesNS/nobody/{app}/storage/collections/config"
+    params = {"name": collection, "output_mode": "json", **collection_config}
+    response = service.post(endpoint, **params)
+    if response.status in (200, 201, 409):
+        return
+    body = response.body.read()
+    raise HTTPError(response.status, response.reason, body)
+
+
+def _resolve_kvstore_collection(
+    service: Any,
+    app: str,
+    collection: str,
+    collection_config: dict[str, Any],
+) -> Any:
+    """Create a KV store collection when needed and return the collection entity."""
+    if collection in service.kvstore:
+        return service.kvstore[collection]
+
+    created: Any | None = None
+    try:
+        created = service.kvstore.create(collection, **collection_config)
+    except (TypeError, KeyError, AttributeError):
+        try:
+            created = service.kvstore.create(name=collection, **collection_config)
+        except (TypeError, KeyError, AttributeError, HTTPError) as inner_error:
+            if isinstance(inner_error, HTTPError) and inner_error.status not in (400, 409):
+                raise
+            _create_kvstore_collection_via_rest(service, app, collection, collection_config)
+            return service.kvstore[collection]
+    except HTTPError as error:
+        if error.status == 409:
+            return service.kvstore[collection]
+        if collection_config and error.status == 400:
+            fallback_config = {
+                key: value
+                for key, value in collection_config.items()
+                if not key.startswith("field.")
+            }
+            field_entries = {
+                key.split(".", 1)[1]: value
+                for key, value in collection_config.items()
+                if key.startswith("field.")
+            }
+            if field_entries:
+                fallback_config["fields"] = field_entries
+            _create_kvstore_collection_via_rest(service, app, collection, fallback_config)
+            return service.kvstore[collection]
+        raise
+
+    if created is not None and hasattr(created, "name"):
+        return created
+    return service.kvstore[collection]
+
+
 class ListKvstoreCollections(BaseTool):
     """
     List all KV Store collections in Splunk.
@@ -178,6 +240,8 @@ class CreateKvstoreCollection(BaseTool):
                     if isinstance(f, dict):
                         field_name = f.get("name") or f.get("field")
                         field_type = (f.get("type") or "string").lower()
+                        if field_type == "str":
+                            field_type = "string"
                         if field_name:
                             normalized_fields[str(field_name)] = str(field_type)
                     elif isinstance(f, str):
@@ -199,38 +263,9 @@ class CreateKvstoreCollection(BaseTool):
                 if collection in service.kvstore:
                     new_collection = service.kvstore[collection]
                 else:
-                    try:
-                        # First try positional signature
-                        new_collection = service.kvstore.create(collection, **collection_config)
-                    except (TypeError, KeyError):
-                        # Retry using keyword name
-                        new_collection = service.kvstore.create(
-                            name=collection, **collection_config
-                        )
-                    except HTTPError as e:
-                        # Retry with 'fields' dict if REST-style params were not accepted
-                        if field_params and e.status == 400:
-                            fallback_config = {
-                                k: v
-                                for k, v in collection_config.items()
-                                if not k.startswith("field.")
-                            }
-                            fallback_config["fields"] = {
-                                k.split(".", 1)[1]: v for k, v in field_params.items()
-                            }
-                            try:
-                                new_collection = service.kvstore.create(
-                                    collection, **fallback_config
-                                )
-                            except (TypeError, KeyError):
-                                new_collection = service.kvstore.create(
-                                    name=collection, **fallback_config
-                                )
-                        elif e.status == 409:
-                            # Already exists - treat as idempotent success by returning existing collection
-                            new_collection = service.kvstore[collection]
-                        else:
-                            raise
+                    new_collection = _resolve_kvstore_collection(
+                        service, app, collection, collection_config
+                    )
 
                 # Ensure schema via update_field for each normalized field (best-effort)
                 if normalized_fields:

--- a/src/tools/kvstore/data.py
+++ b/src/tools/kvstore/data.py
@@ -5,6 +5,7 @@ Tool for retrieving data from Splunk KV Store collections.
 from typing import Any
 
 from fastmcp import Context
+from splunklib import client as spl_client
 
 from src.core.base import BaseTool, ToolMetadata
 from src.core.utils import log_tool_execution
@@ -56,22 +57,18 @@ class GetKvstoreData(BaseTool):
         self.logger.info(f"Retrieving data from KV Store collection: {collection}")
         await ctx.info(f"Retrieving data from KV Store collection: {collection}")
 
+        original_namespace = getattr(service, "namespace", None)
+        if app:
+            service.namespace = spl_client.namespace(app=app, owner="nobody", sharing="app")
+
         try:
-            # Get the collection from the appropriate app context
-            if app:
-                kvstore = service.kvstore[app]
-            else:
-                kvstore = service.kvstore
+            collection_obj = service.kvstore[collection]
 
-            collection_obj = kvstore[collection]
-
-            # Retrieve data with optional query filter
             if query:
                 documents = collection_obj.data.query(**query)
             else:
                 documents = collection_obj.data.query()
 
-            # Convert to list for response
             doc_list = list(documents)
 
             await ctx.info(f"Retrieved {len(doc_list)} documents from collection {collection}")
@@ -81,3 +78,5 @@ class GetKvstoreData(BaseTool):
             self.logger.error(f"Failed to retrieve KV Store data: {str(e)}")
             await ctx.error(f"Failed to retrieve KV Store data: {str(e)}")
             return self.format_error_response(str(e))
+        finally:
+            service.namespace = original_namespace

--- a/src/tools/search/saved_search_tools.py
+++ b/src/tools/search/saved_search_tools.py
@@ -5,6 +5,7 @@ Provides comprehensive functionality for managing and executing Splunk saved sea
 including listing, executing, creating, updating, and deleting saved searches.
 """
 
+import asyncio
 import time
 from typing import Any, Literal
 
@@ -418,7 +419,7 @@ class ExecuteSavedSearch(BaseTool):
 
         while not job.is_done():
             job.refresh()
-            time.sleep(0.1)
+            await asyncio.sleep(0.1)
 
         results = []
         result_count = 0
@@ -459,7 +460,7 @@ class ExecuteSavedSearch(BaseTool):
                 progress=int(float(job.content.get("dispatchState", {}).get("percentComplete", 0))),
                 total=100,
             )
-            time.sleep(0.5)
+            await asyncio.sleep(0.5)
             job.refresh()
 
         # Get job statistics

--- a/src/tools/search/saved_search_tools.py
+++ b/src/tools/search/saved_search_tools.py
@@ -56,6 +56,13 @@ def _find_saved_search(
 
     for try_owner in dict.fromkeys([owner, "admin", "nobody"]):
         if try_owner:
+            namespaces.append(
+                spl_client.namespace(
+                    app=app or DEFAULT_SAVED_SEARCH_APP,
+                    owner=try_owner,
+                    sharing="user",
+                )
+            )
             namespaces.append(spl_client.namespace(owner=try_owner, sharing="user"))
 
     namespaces.extend([spl_client.namespace(sharing="global"), original_namespace, None])
@@ -89,23 +96,42 @@ def _find_saved_search(
     return None
 
 
+DEFAULT_SAVED_SEARCH_APP = "search"
+
+
+def _namespace_for_saved_search_acl(acl: dict[str, Any]) -> Any:
+    """Build a splunklib namespace from saved search ACL metadata."""
+    app = acl.get("app") or DEFAULT_SAVED_SEARCH_APP
+    owner = acl.get("owner") or "nobody"
+    sharing = acl.get("sharing") or "app"
+    return spl_client.namespace(app=app, owner=owner, sharing=sharing)
+
+
+def _namespace_for_saved_search_create(
+    *,
+    app: str,
+    owner: str,
+    sharing: Literal["user", "app", "global"],
+) -> Any:
+    """Return a namespace where saved searches can be created and dispatched reliably."""
+    if sharing == "global":
+        return spl_client.namespace(app=app, owner="nobody", sharing="global")
+    if sharing == "app":
+        return spl_client.namespace(app=app, owner="nobody", sharing="app")
+    return spl_client.namespace(app=app, owner=owner, sharing="user")
+
+
 def _apply_saved_search_namespace(service: Any, saved_search: Any) -> Any:
     """Set service namespace to match a located saved search entity."""
     original_namespace = getattr(service, "namespace", None)
     acl = saved_search.content.get("eai:acl")
-    if isinstance(acl, dict):
-        app = acl.get("app")
-        owner = acl.get("owner")
-        sharing = acl.get("sharing") or "user"
-        if app:
-            service.namespace = spl_client.namespace(
-                app=app, owner=owner or "nobody", sharing=sharing
-            )
-        elif owner:
-            service.namespace = spl_client.namespace(owner=owner, sharing=sharing)
+    if isinstance(acl, dict) and any(acl.get(key) for key in ("app", "owner", "sharing")):
+        service.namespace = _namespace_for_saved_search_acl(acl)
     else:
         create_owner = getattr(service, "username", None) or "admin"
-        service.namespace = spl_client.namespace(owner=create_owner, sharing="user")
+        service.namespace = spl_client.namespace(
+            app=DEFAULT_SAVED_SEARCH_APP, owner=create_owner, sharing="user"
+        )
     return original_namespace
 
 
@@ -392,13 +418,18 @@ class ExecuteSavedSearch(BaseTool):
         self, ctx: Context, saved_search, dispatch_kwargs: dict, max_results: int, start_time: float
     ) -> dict[str, Any]:
         """Execute saved search in oneshot mode"""
-        dispatch_kwargs["output_mode"] = "json"
-
         job = saved_search.dispatch(**dispatch_kwargs)
+
+        while not job.is_done():
+            job.refresh()
+            time.sleep(0.1)
+
         results = []
         result_count = 0
 
-        reader = JSONResultsReader(job)
+        reader = JSONResultsReader(
+            job.results(output_mode="json", count=max_results)
+        )
         for result in reader:
             if isinstance(result, dict):
                 results.append(result)
@@ -611,25 +642,22 @@ class CreateSavedSearch(BaseTool):
 
             original_namespace = getattr(service, "namespace", None)
             create_owner = getattr(service, "username", None) or "admin"
+            target_app = (app or DEFAULT_SAVED_SEARCH_APP).strip()
             try:
-                if app:
-                    service.namespace = spl_client.namespace(
-                        app=app, owner="nobody", sharing=sharing or "app"
-                    )
-                    service.saved_searches.create(name, **config)
-                else:
-                    service.namespace = spl_client.namespace(
-                        owner=create_owner, sharing=sharing or "user"
-                    )
-                    service.saved_searches.create(name, **config)
+                service.namespace = _namespace_for_saved_search_create(
+                    app=target_app,
+                    owner=create_owner,
+                    sharing=sharing,
+                )
+                service.saved_searches.create(name, **config)
             finally:
                 service.namespace = original_namespace
 
             saved_search = _find_saved_search(
                 service,
                 name,
-                app=app,
-                owner=create_owner if sharing == "user" and not app else None,
+                app=target_app,
+                owner=create_owner if sharing == "user" else None,
             )
             if not saved_search:
                 return self.format_error_response(
@@ -647,7 +675,7 @@ class CreateSavedSearch(BaseTool):
                         "description": description,
                         "earliest_time": earliest_time,
                         "latest_time": latest_time,
-                        "app": app or "default",
+                        "app": target_app,
                         "sharing": sharing,
                         "is_scheduled": is_scheduled,
                         "cron_schedule": cron_schedule if is_scheduled else "",

--- a/src/tools/search/saved_search_tools.py
+++ b/src/tools/search/saved_search_tools.py
@@ -9,10 +9,104 @@ import time
 from typing import Any, Literal
 
 from fastmcp import Context
+from splunklib import client as spl_client
 from splunklib.results import JSONResultsReader
 
 from src.core.base import BaseTool, ToolMetadata
 from src.core.utils import log_tool_execution, sanitize_search_query
+
+
+def _acl_field(content: dict[str, Any], field: str) -> str | None:
+    acl = content.get("eai:acl")
+    if not isinstance(acl, dict):
+        return None
+    value = acl.get(field)
+    return str(value) if value is not None else None
+
+
+def _matches_app_owner(
+    content: dict[str, Any],
+    app: str | None,
+    owner: str | None,
+) -> bool:
+    if app:
+        acl_app = _acl_field(content, "app")
+        if acl_app is not None and acl_app != app:
+            return False
+    if owner:
+        acl_owner = _acl_field(content, "owner")
+        if acl_owner is not None and acl_owner != owner:
+            return False
+    return True
+
+
+def _find_saved_search(
+    service: Any,
+    name: str,
+    app: str | None = None,
+    owner: str | None = None,
+) -> Any | None:
+    original_namespace = getattr(service, "namespace", None)
+    namespaces: list[Any | None] = []
+
+    if app:
+        namespaces.append(
+            spl_client.namespace(app=app, owner=owner or "nobody", sharing="app")
+        )
+
+    for try_owner in dict.fromkeys([owner, "admin", "nobody"]):
+        if try_owner:
+            namespaces.append(spl_client.namespace(owner=try_owner, sharing="user"))
+
+    namespaces.extend([spl_client.namespace(sharing="global"), original_namespace, None])
+
+    seen: set[str] = set()
+    try:
+        for namespace in namespaces:
+            key = repr(namespace)
+            if key in seen:
+                continue
+            seen.add(key)
+
+            if namespace is not None:
+                service.namespace = namespace
+
+            try:
+                candidate = service.saved_searches[name]
+                if _matches_app_owner(candidate.content, app, owner):
+                    return candidate
+            except KeyError:
+                pass
+
+            for saved_search in service.saved_searches:
+                if saved_search.name == name and _matches_app_owner(
+                    saved_search.content, app, owner
+                ):
+                    return saved_search
+    finally:
+        service.namespace = original_namespace
+
+    return None
+
+
+def _apply_saved_search_namespace(service: Any, saved_search: Any) -> Any:
+    """Set service namespace to match a located saved search entity."""
+    original_namespace = getattr(service, "namespace", None)
+    acl = saved_search.content.get("eai:acl")
+    if isinstance(acl, dict):
+        app = acl.get("app")
+        owner = acl.get("owner")
+        sharing = acl.get("sharing") or "user"
+        if app:
+            service.namespace = spl_client.namespace(
+                app=app, owner=owner or "nobody", sharing=sharing
+            )
+        elif owner:
+            service.namespace = spl_client.namespace(owner=owner, sharing=sharing)
+    else:
+        create_owner = getattr(service, "username", None) or "admin"
+        service.namespace = spl_client.namespace(owner=create_owner, sharing="user")
+    return original_namespace
 
 
 class ListSavedSearches(BaseTool):
@@ -228,34 +322,7 @@ class ExecuteSavedSearch(BaseTool):
             # Find the saved search
             await ctx.info(f"Looking for saved search: {name}")
 
-            # Build search criteria
-            search_kwargs = {}
-            if app:
-                search_kwargs["app"] = app
-            if owner:
-                search_kwargs["owner"] = owner
-
-            saved_search = None
-            try:
-                if search_kwargs:
-                    # Search with specific criteria
-                    for ss in service.saved_searches(**search_kwargs):
-                        if ss.name == name:
-                            saved_search = ss
-                            break
-                else:
-                    # Direct access
-                    saved_search = service.saved_searches[name]
-            except KeyError:
-                # Try to find it by iterating through all saved searches
-                for ss in service.saved_searches:
-                    if ss.name == name:
-                        if app and ss.content.get("eai:acl", {}).get("app") != app:
-                            continue
-                        if owner and ss.content.get("eai:acl", {}).get("owner") != owner:
-                            continue
-                        saved_search = ss
-                        break
+            saved_search = _find_saved_search(service, name, app, owner)
 
             if not saved_search:
                 error_msg = f"Saved search '{name}' not found"
@@ -263,6 +330,16 @@ class ExecuteSavedSearch(BaseTool):
                     error_msg += f" (app: {app}, owner: {owner})"
                 await ctx.error(error_msg)
                 return self.format_error_response(error_msg, saved_search_name=name)
+
+            original_namespace = _apply_saved_search_namespace(service, saved_search)
+            try:
+                saved_search = service.saved_searches[saved_search.name]
+            except KeyError:
+                service.namespace = original_namespace
+                return self.format_error_response(
+                    f"Saved search '{name}' is not accessible in the expected namespace",
+                    saved_search_name=name,
+                )
 
             # Check if saved search is disabled
             if self._convert_splunk_boolean(saved_search.content.get("disabled"), False):
@@ -275,28 +352,36 @@ class ExecuteSavedSearch(BaseTool):
 
             # Use override times if provided, otherwise use saved search defaults
             if earliest_time is not None:
-                dispatch_kwargs["earliest_time"] = earliest_time
+                dispatch_kwargs["dispatch.earliest_time"] = earliest_time
             elif saved_search.content.get("dispatch.earliest_time"):
-                dispatch_kwargs["earliest_time"] = saved_search.content.get(
+                dispatch_kwargs["dispatch.earliest_time"] = saved_search.content.get(
                     "dispatch.earliest_time"
                 )
 
             if latest_time is not None:
-                dispatch_kwargs["latest_time"] = latest_time
+                dispatch_kwargs["dispatch.latest_time"] = latest_time
             elif saved_search.content.get("dispatch.latest_time"):
-                dispatch_kwargs["latest_time"] = saved_search.content.get("dispatch.latest_time")
+                dispatch_kwargs["dispatch.latest_time"] = saved_search.content.get(
+                    "dispatch.latest_time"
+                )
 
             await ctx.info(f"Executing saved search '{name}' in {mode} mode")
             start_time = time.time()
 
             if mode == "oneshot":
-                return await self._execute_oneshot(
-                    ctx, saved_search, dispatch_kwargs, max_results, start_time
-                )
+                try:
+                    return await self._execute_oneshot(
+                        ctx, saved_search, dispatch_kwargs, max_results, start_time
+                    )
+                finally:
+                    service.namespace = original_namespace
             else:
-                return await self._execute_job(
-                    ctx, saved_search, dispatch_kwargs, max_results, start_time
-                )
+                try:
+                    return await self._execute_job(
+                        ctx, saved_search, dispatch_kwargs, max_results, start_time
+                    )
+                finally:
+                    service.namespace = original_namespace
 
         except Exception as e:
             self.logger.error(f"Failed to execute saved search '{name}': {str(e)}")
@@ -307,7 +392,6 @@ class ExecuteSavedSearch(BaseTool):
         self, ctx: Context, saved_search, dispatch_kwargs: dict, max_results: int, start_time: float
     ) -> dict[str, Any]:
         """Execute saved search in oneshot mode"""
-        dispatch_kwargs["count"] = max_results
         dispatch_kwargs["output_mode"] = "json"
 
         job = saved_search.dispatch(**dispatch_kwargs)
@@ -525,11 +609,34 @@ class CreateSavedSearch(BaseTool):
 
             await ctx.info(f"Creating saved search '{name}'")
 
-            # Create the saved search
-            if app:
-                service.saved_searches.create(name, **config, app=app, sharing=sharing)
-            else:
-                service.saved_searches.create(name, **config, sharing=sharing)
+            original_namespace = getattr(service, "namespace", None)
+            create_owner = getattr(service, "username", None) or "admin"
+            try:
+                if app:
+                    service.namespace = spl_client.namespace(
+                        app=app, owner="nobody", sharing=sharing or "app"
+                    )
+                    service.saved_searches.create(name, **config)
+                else:
+                    service.namespace = spl_client.namespace(
+                        owner=create_owner, sharing=sharing or "user"
+                    )
+                    service.saved_searches.create(name, **config)
+            finally:
+                service.namespace = original_namespace
+
+            saved_search = _find_saved_search(
+                service,
+                name,
+                app=app,
+                owner=create_owner if sharing == "user" and not app else None,
+            )
+            if not saved_search:
+                return self.format_error_response(
+                    f"Saved search '{name}' was submitted but is not accessible after creation",
+                    name=name,
+                    created=False,
+                )
 
             return self.format_success_response(
                 {
@@ -644,27 +751,7 @@ class UpdateSavedSearch(BaseTool):
             # Find the saved search
             await ctx.info(f"Looking for saved search to update: {name}")
 
-            saved_search = None
-            try:
-                # Try direct access first
-                saved_search = service.saved_searches[name]
-
-                # Check app/owner constraints if specified
-                if app and saved_search.content.get("eai:acl", {}).get("app") != app:
-                    saved_search = None
-                if owner and saved_search.content.get("eai:acl", {}).get("owner") != owner:
-                    saved_search = None
-
-            except KeyError:
-                # Search by iterating if direct access fails
-                for ss in service.saved_searches:
-                    if ss.name == name:
-                        if app and ss.content.get("eai:acl", {}).get("app") != app:
-                            continue
-                        if owner and ss.content.get("eai:acl", {}).get("owner") != owner:
-                            continue
-                        saved_search = ss
-                        break
+            saved_search = _find_saved_search(service, name, app, owner)
 
             if not saved_search:
                 error_msg = f"Saved search '{name}' not found"
@@ -725,8 +812,12 @@ class UpdateSavedSearch(BaseTool):
 
             await ctx.info(f"Updating saved search '{name}' with changes: {changes_made}")
 
-            # Apply updates
-            saved_search.update(**update_config)
+            original_namespace = _apply_saved_search_namespace(service, saved_search)
+            try:
+                saved_search = service.saved_searches[saved_search.name]
+                saved_search.update(**update_config)
+            finally:
+                service.namespace = original_namespace
 
             return self.format_success_response(
                 {
@@ -805,27 +896,7 @@ class DeleteSavedSearch(BaseTool):
             # Find the saved search
             await ctx.info(f"Looking for saved search to delete: {name}")
 
-            saved_search = None
-            try:
-                # Try direct access first
-                saved_search = service.saved_searches[name]
-
-                # Check app/owner constraints if specified
-                if app and saved_search.content.get("eai:acl", {}).get("app") != app:
-                    saved_search = None
-                if owner and saved_search.content.get("eai:acl", {}).get("owner") != owner:
-                    saved_search = None
-
-            except KeyError:
-                # Search by iterating if direct access fails
-                for ss in service.saved_searches:
-                    if ss.name == name:
-                        if app and ss.content.get("eai:acl", {}).get("app") != app:
-                            continue
-                        if owner and ss.content.get("eai:acl", {}).get("owner") != owner:
-                            continue
-                        saved_search = ss
-                        break
+            saved_search = _find_saved_search(service, name, app, owner)
 
             if not saved_search:
                 error_msg = f"Saved search '{name}' not found"
@@ -845,8 +916,12 @@ class DeleteSavedSearch(BaseTool):
                 f"Deleting saved search '{name}' (app: {search_app}, owner: {search_owner})"
             )
 
-            # Delete the saved search
-            saved_search.delete()
+            original_namespace = _apply_saved_search_namespace(service, saved_search)
+            try:
+                saved_search = service.saved_searches[saved_search.name]
+                saved_search.delete()
+            finally:
+                service.namespace = original_namespace
 
             return self.format_success_response(
                 {
@@ -942,27 +1017,7 @@ class GetSavedSearchDetails(BaseTool):
             # Find the saved search
             await ctx.info(f"Retrieving details for saved search: {name}")
 
-            saved_search = None
-            try:
-                # Try direct access first
-                saved_search = service.saved_searches[name]
-
-                # Check app/owner constraints if specified
-                if app and saved_search.content.get("eai:acl", {}).get("app") != app:
-                    saved_search = None
-                if owner and saved_search.content.get("eai:acl", {}).get("owner") != owner:
-                    saved_search = None
-
-            except KeyError:
-                # Search by iterating if direct access fails
-                for ss in service.saved_searches:
-                    if ss.name == name:
-                        if app and ss.content.get("eai:acl", {}).get("app") != app:
-                            continue
-                        if owner and ss.content.get("eai:acl", {}).get("owner") != owner:
-                            continue
-                        saved_search = ss
-                        break
+            saved_search = _find_saved_search(service, name, app, owner)
 
             if not saved_search:
                 error_msg = f"Saved search '{name}' not found"

--- a/src/tools/search/saved_search_tools.py
+++ b/src/tools/search/saved_search_tools.py
@@ -83,6 +83,7 @@ def _find_saved_search(
                 if _matches_app_owner(candidate.content, app, owner):
                     return candidate
             except KeyError:
+                # Direct lookup misses names outside the current namespace; keep scanning.
                 pass
 
             for saved_search in service.saved_searches:
@@ -359,55 +360,50 @@ class ExecuteSavedSearch(BaseTool):
 
             original_namespace = _apply_saved_search_namespace(service, saved_search)
             try:
-                saved_search = service.saved_searches[saved_search.name]
-            except KeyError:
-                service.namespace = original_namespace
-                return self.format_error_response(
-                    f"Saved search '{name}' is not accessible in the expected namespace",
-                    saved_search_name=name,
-                )
-
-            # Check if saved search is disabled
-            if self._convert_splunk_boolean(saved_search.content.get("disabled"), False):
-                error_msg = f"Saved search '{name}' is disabled"
-                await ctx.error(error_msg)
-                return self.format_error_response(error_msg, saved_search_name=name)
-
-            # Prepare execution parameters
-            dispatch_kwargs = {}
-
-            # Use override times if provided, otherwise use saved search defaults
-            if earliest_time is not None:
-                dispatch_kwargs["dispatch.earliest_time"] = earliest_time
-            elif saved_search.content.get("dispatch.earliest_time"):
-                dispatch_kwargs["dispatch.earliest_time"] = saved_search.content.get(
-                    "dispatch.earliest_time"
-                )
-
-            if latest_time is not None:
-                dispatch_kwargs["dispatch.latest_time"] = latest_time
-            elif saved_search.content.get("dispatch.latest_time"):
-                dispatch_kwargs["dispatch.latest_time"] = saved_search.content.get(
-                    "dispatch.latest_time"
-                )
-
-            await ctx.info(f"Executing saved search '{name}' in {mode} mode")
-            start_time = time.time()
-
-            if mode == "oneshot":
                 try:
+                    saved_search = service.saved_searches[saved_search.name]
+                except KeyError:
+                    return self.format_error_response(
+                        f"Saved search '{name}' is not accessible in the expected namespace",
+                        saved_search_name=name,
+                    )
+
+                # Check if saved search is disabled
+                if self._convert_splunk_boolean(saved_search.content.get("disabled"), False):
+                    error_msg = f"Saved search '{name}' is disabled"
+                    await ctx.error(error_msg)
+                    return self.format_error_response(error_msg, saved_search_name=name)
+
+                # Prepare execution parameters
+                dispatch_kwargs = {}
+
+                # Use override times if provided, otherwise use saved search defaults
+                if earliest_time is not None:
+                    dispatch_kwargs["dispatch.earliest_time"] = earliest_time
+                elif saved_search.content.get("dispatch.earliest_time"):
+                    dispatch_kwargs["dispatch.earliest_time"] = saved_search.content.get(
+                        "dispatch.earliest_time"
+                    )
+
+                if latest_time is not None:
+                    dispatch_kwargs["dispatch.latest_time"] = latest_time
+                elif saved_search.content.get("dispatch.latest_time"):
+                    dispatch_kwargs["dispatch.latest_time"] = saved_search.content.get(
+                        "dispatch.latest_time"
+                    )
+
+                await ctx.info(f"Executing saved search '{name}' in {mode} mode")
+                start_time = time.time()
+
+                if mode == "oneshot":
                     return await self._execute_oneshot(
                         ctx, saved_search, dispatch_kwargs, max_results, start_time
                     )
-                finally:
-                    service.namespace = original_namespace
-            else:
-                try:
-                    return await self._execute_job(
-                        ctx, saved_search, dispatch_kwargs, max_results, start_time
-                    )
-                finally:
-                    service.namespace = original_namespace
+                return await self._execute_job(
+                    ctx, saved_search, dispatch_kwargs, max_results, start_time
+                )
+            finally:
+                service.namespace = original_namespace
 
         except Exception as e:
             self.logger.error(f"Failed to execute saved search '{name}': {str(e)}")

--- a/tests/test_dashboard_tools.py
+++ b/tests/test_dashboard_tools.py
@@ -340,6 +340,62 @@ class TestCreateDashboard:
         assert '<dashboard version="2" theme="dark">' in stored
 
     @pytest.mark.asyncio
+    async def test_studio_wrapper_theme_auto_from_ui_settings(self, mock_context):
+        tool = CreateDashboard("create_dashboard", "Create a Splunk dashboard")
+        result = await tool.execute(
+            mock_context,
+            name="studio_theme_auto",
+            definition={
+                "title": "Auto Theme",
+                "uiSettings": {"theme": "dark"},
+                "dataSources": {},
+                "visualizations": {},
+            },
+            dashboard_type="studio",
+        )
+        assert result.get("status") == "success"
+        assert result.get("theme") == "dark"
+        service = mock_context.request_context.lifespan_context.service
+        stored = service._dashboards["studio_theme_auto"]["content"]["eai:data"]
+        assert '<dashboard version="2" theme="dark">' in stored
+
+    @pytest.mark.asyncio
+    async def test_studio_wrapper_theme_auto_default_dark(self, mock_context):
+        tool = CreateDashboard("create_dashboard", "Create a Splunk dashboard")
+        result = await tool.execute(
+            mock_context,
+            name="studio_theme_auto_default",
+            definition={
+                "title": "No Theme In JSON",
+                "dataSources": {},
+                "visualizations": {},
+            },
+            dashboard_type="studio",
+        )
+        assert result.get("status") == "success"
+        assert result.get("theme") == "dark"
+        service = mock_context.request_context.lifespan_context.service
+        stored = service._dashboards["studio_theme_auto_default"]["content"]["eai:data"]
+        assert '<dashboard version="2" theme="dark">' in stored
+
+    @pytest.mark.asyncio
+    async def test_create_stores_label_and_description_from_initial_post(self, mock_context):
+        tool = CreateDashboard("create_dashboard", "Create a Splunk dashboard")
+        result = await tool.execute(
+            mock_context,
+            name="single_post_metadata",
+            definition={"title": "One POST", "dataSources": {}, "visualizations": {}},
+            label="One POST Label",
+            description="Created in one request",
+        )
+        assert result.get("status") == "success"
+        assert result.get("definition_size_bytes", 0) > 0
+        service = mock_context.request_context.lifespan_context.service
+        stored = service._dashboards["single_post_metadata"]["content"]["eai:data"]
+        assert "<label>One POST Label</label>" in stored
+        assert "<description>Created in one request</description>" in stored
+
+    @pytest.mark.asyncio
     async def test_studio_wrapper_invalid_theme(self, mock_context):
         tool = CreateDashboard("create_dashboard", "Create a Splunk dashboard")
         result = await tool.execute(

--- a/tests/test_saved_search_namespace.py
+++ b/tests/test_saved_search_namespace.py
@@ -1,0 +1,60 @@
+"""Unit tests for saved search namespace helpers."""
+
+from unittest.mock import Mock
+
+from splunklib import client as spl_client
+
+from src.tools.search.saved_search_tools import (
+    DEFAULT_SAVED_SEARCH_APP,
+    _apply_saved_search_namespace,
+    _namespace_for_saved_search_acl,
+    _namespace_for_saved_search_create,
+)
+
+
+def test_namespace_for_saved_search_create_user_uses_app_context():
+    namespace = _namespace_for_saved_search_create(
+        app="search", owner="admin", sharing="user"
+    )
+    assert namespace["app"] == "search"
+    assert namespace["owner"] == "admin"
+    assert namespace["sharing"] == "user"
+
+
+def test_namespace_for_saved_search_acl_defaults_missing_app():
+    namespace = _namespace_for_saved_search_acl(
+        {"owner": "admin", "sharing": "user"}
+    )
+    assert namespace["app"] == DEFAULT_SAVED_SEARCH_APP
+    assert namespace["owner"] == "admin"
+    assert namespace["sharing"] == "user"
+
+
+def test_apply_saved_search_namespace_uses_acl():
+    service = Mock()
+    service.namespace = None
+    saved_search = Mock()
+    saved_search.content = {
+        "eai:acl": {"app": "search", "owner": "admin", "sharing": "app"}
+    }
+
+    original = _apply_saved_search_namespace(service, saved_search)
+
+    assert service.namespace["app"] == "search"
+    assert service.namespace["sharing"] == "app"
+    assert original is None
+
+
+def test_apply_saved_search_namespace_fallback_for_empty_acl():
+    service = Mock()
+    service.namespace = spl_client.namespace(sharing="global")
+    service.username = "admin"
+    saved_search = Mock()
+    saved_search.content = {"eai:acl": {}}
+
+    original = _apply_saved_search_namespace(service, saved_search)
+
+    assert service.namespace["app"] == DEFAULT_SAVED_SEARCH_APP
+    assert service.namespace["owner"] == "admin"
+    assert service.namespace["sharing"] == "user"
+    assert original["sharing"] == "global"

--- a/tests/test_studio_wrapper.py
+++ b/tests/test_studio_wrapper.py
@@ -1,0 +1,89 @@
+"""Unit tests for Dashboard Studio wrapper helpers."""
+
+import json
+
+import pytest
+
+from src.tools.dashboards.studio_wrapper import (
+    DashboardDefinitionPreparer,
+    StudioDashboardWrapper,
+    StudioThemeResolver,
+)
+
+
+class TestStudioThemeResolver:
+    def test_resolve_explicit_dark(self):
+        assert StudioThemeResolver.resolve({}, "dark") == "dark"
+
+    def test_resolve_auto_from_ui_settings(self):
+        definition = {"uiSettings": {"theme": "light"}, "title": "T"}
+        assert StudioThemeResolver.resolve(definition, "auto") == "light"
+
+    def test_resolve_auto_from_top_level_theme(self):
+        definition = {"theme": "dark", "title": "T"}
+        assert StudioThemeResolver.resolve(definition, "auto") == "dark"
+
+    def test_resolve_auto_fallback_dark(self):
+        assert StudioThemeResolver.resolve({"title": "T"}, "auto") == "dark"
+
+    def test_resolve_auto_from_prewrapped_xml(self):
+        xml = '<dashboard version="2" theme="light"><definition><![CDATA[{}]]></definition></dashboard>'
+        assert StudioThemeResolver.resolve(xml, "auto", prewrapped=True) == "light"
+
+
+class TestStudioDashboardWrapper:
+    def test_wrap_dict_includes_theme_and_label(self):
+        wrapped = StudioDashboardWrapper.wrap(
+            {"title": "Demo", "dataSources": {}},
+            label="Demo Label",
+            description=None,
+            theme="dark",
+        )
+        assert '<dashboard version="2" theme="dark">' in wrapped
+        assert "<label>Demo Label</label>" in wrapped
+        assert "<definition><![CDATA[" in wrapped
+
+    def test_prewrapped_pass_through(self):
+        prewrapped = (
+            '<dashboard version="2" theme="light">\n'
+            '  <definition><![CDATA[{"title":"X"}]]></definition>\n'
+            "</dashboard>"
+        )
+        assert StudioDashboardWrapper.wrap(prewrapped, label=None, description=None, theme="dark") == prewrapped
+
+
+class TestDashboardDefinitionPreparer:
+    def test_prepare_auto_detects_json_string(self):
+        prepared = DashboardDefinitionPreparer.prepare(
+            json.dumps({"title": "Auto", "dataSources": {}, "visualizations": {}}),
+            dashboard_type="auto",
+            label=None,
+            description=None,
+            theme="auto",
+        )
+        assert not isinstance(prepared, str)
+        assert prepared.resolved_type == "studio"
+        assert prepared.resolved_theme == "dark"
+
+    def test_prepare_classic_xml(self):
+        prepared = DashboardDefinitionPreparer.prepare(
+            "<dashboard><label>Classic</label></dashboard>",
+            dashboard_type="auto",
+            label=None,
+            description=None,
+            theme="auto",
+        )
+        assert not isinstance(prepared, str)
+        assert prepared.resolved_type == "classic"
+        assert prepared.resolved_theme is None
+
+    def test_prepare_invalid_theme(self):
+        result = DashboardDefinitionPreparer.prepare(
+            {"title": "X"},
+            dashboard_type="studio",
+            label=None,
+            description=None,
+            theme="sepia",  # type: ignore[arg-type]
+        )
+        assert isinstance(result, str)
+        assert "theme" in result.lower()

--- a/tests/test_studio_wrapper.py
+++ b/tests/test_studio_wrapper.py
@@ -2,8 +2,6 @@
 
 import json
 
-import pytest
-
 from src.tools.dashboards.studio_wrapper import (
     DashboardDefinitionPreparer,
     StudioDashboardWrapper,


### PR DESCRIPTION
## Summary

- **Dashboard Studio theme:** `theme` now defaults to `"auto"`, reading `uiSettings.theme` from Studio JSON (fallback `dark`). Agents are guided via `dashboard_studio_builder.md` to set `"uiSettings": {"theme": "dark"}`.
- **Performance:** Studio dashboards embed label/description in the XML wrapper and use a single Splunk create POST (`name` + `eai:data` only). Classic dashboards still get an optional metadata POST when needed. Added `ctx.report_progress()` and `definition_size_bytes` in responses.
- **Structure:** Extracted `studio_wrapper.py` (`StudioThemeResolver`, `StudioDashboardWrapper`, `DashboardDefinitionPreparer`).
- **Saved search fixes (live-test driven):** Namespace-aware lookup/create, removed invalid `count` on dispatch, use `dispatch.earliest_time` / `dispatch.latest_time` for saved search execution.
- **Live smoke test:** Added `scripts/test_live_splunk_tools.py` (credentials via env vars).

## Live Splunk verification (`deslicer-i-096c1c39346b8a2c1.splunk.show`)

**43 PASS / 5 FAIL / 3 SKIP** out of 51 tools

| Result | Tools |
|--------|-------|
| PASS | All read/list/search/admin/doc tools including **`create_dashboard`** (dark theme auto), `get_dashboard_definition`, health, indexes, oneshot/job search, workflows list/builder, etc. |
| FAIL | `execute_saved_search`, `update_saved_search`, `delete_saved_search` (namespace dispatch on this instance), `create_kvstore_collection`, `get_kvstore_data` (KV store create unsupported on this Splunk Show instance) |
| SKIP | `manage_apps`, `create_config` (mutating), `workflow_runner` (requires valid `OPENAI_API_KEY`) |

Run locally:

```bash
SPLUNK_HOST=your-host SPLUNK_USERNAME=admin SPLUNK_PASSWORD='...' SPLUNK_VERIFY_SSL=false   uv run python scripts/test_live_splunk_tools.py
```

## Test plan

- [x] `uv run pytest tests/test_dashboard_tools.py tests/test_studio_wrapper.py` (25 passed)
- [x] Live Splunk smoke test on `deslicer-i-096c1c39346b8a2c1.splunk.show` (43/51 pass)
- [ ] Follow-up: finish saved search execute/update/delete namespace handling on Splunk Show
- [ ] Follow-up: KV store create on environments where KV store collections are enabled