### PR TITLE
feat(itsi): schema-aware tooling + write-path validation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,33 @@
 name: Docker
 
+# Builds + pushes the mcp-server-for-splunk image to GHCR.
+#
+# Triggers:
+#   * push tags `v*.*.*`         — manual / ad-hoc tag pushes
+#   * workflow_dispatch          — maintainer-initiated rebuilds
+#   * workflow_call              — fanned out from release-please.yml on merge
+#
+# NOTE: release-please creates the `v*.*.*` tag using the default GITHUB_TOKEN,
+# and GitHub does not start new workflow runs from GITHUB_TOKEN-created events.
+# So the `push: tags` trigger never fires for automated releases — that's why
+# release-please.yml calls this workflow directly via `workflow_call`.
+
 on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to tag the image with (e.g. 1.2.3). Leave empty to use the git ref."
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to tag the image with (e.g. 1.2.3)."
+        required: true
+        type: string
 
 jobs:
   docker:
@@ -27,6 +51,14 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
+          # `value=${{ inputs.version }}` is honoured on workflow_call /
+          # workflow_dispatch; on a `push: tags` run inputs.version is empty so
+          # metadata-action falls back to the git tag.
+          tags: |
+            type=semver,pattern={{version}},value=${{ inputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
+            type=ref,event=tag
+            type=raw,value=v${{ inputs.version }},enable=${{ inputs.version != '' }}
 
       - name: Build and push
         uses: docker/build-push-action@v7

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,7 @@ permissions:
   pull-requests: write
   issues: write
   id-token: write
+  packages: write
 
 jobs:
   release-please:
@@ -24,6 +25,7 @@ jobs:
       parent_released: ${{ steps.release.outputs.release_created }}
       itsi_released: ${{ steps.release.outputs['packaging/mcp-itsi-server--release_created'] }}
       parent_tag: ${{ steps.release.outputs.tag_name }}
+      parent_version: ${{ steps.release.outputs.version }}
       itsi_tag: ${{ steps.release.outputs['packaging/mcp-itsi-server--tag_name'] }}
     steps:
       - name: Release Please
@@ -47,4 +49,15 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       package: itsi
+    secrets: inherit
+
+  # Docker image tracks the parent package (tagged `v*.*.*`). The tag created
+  # by release-please can't trigger docker.yml's `push: tags` event, so we fan
+  # out to it directly here on merge.
+  build-docker-parent:
+    needs: release-please
+    if: needs.release-please.outputs.parent_released == 'true'
+    uses: ./.github/workflows/docker.yml
+    with:
+      version: ${{ needs.release-please.outputs.parent_version }}
     secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,9 @@ lic/*.lic
 # Local data storage
 .data/
 data/
+# ...but keep bundled ITSI schema data (shipped with the package).
+!mcp_itsi/knowledge/schema/data/
+!mcp_itsi/knowledge/schema/data/**
 
 # Local env backups
 .env_bak
@@ -143,3 +146,7 @@ opt-splunk/
 
 # Git worktrees (created via `git worktree add .worktrees/...`)
 .worktrees/
+
+# Local research scratch (e.g. firecrawl scrapes used to regenerate schemas)
+.research/
+.firecrawl/

--- a/docs/guides/itsi/2026-06-02-schema-tooling-design.md
+++ b/docs/guides/itsi/2026-06-02-schema-tooling-design.md
@@ -1,0 +1,147 @@
+# ITSI Schema-Aware Tooling — Design Spec
+
+> Status: Implemented
+> Date: 2026-06-02
+> Scope: `mcp_itsi/` ITSI MCP server
+
+## Regenerating schemas
+
+```bash
+# Re-scrape the live docs, parse, and rebuild the bundled doc:
+python -m scripts.itsi_schema.refresh
+
+# Or reuse an existing local scrape (no network):
+python -m scripts.itsi_schema.refresh --skip-scrape
+```
+
+## Problem
+
+Every ITSI create/update tool (`service.py`, `kpi_base_search.py`, and the
+other ~11 ITOA CRUD tools) accepts a free-form `payload: dict[str, Any]` with
+no schema awareness. ITOA objects are deeply nested — a `service` contains
+`kpis[]`, which contain `entity_thresholds` → `threshold_levels[]`; a single
+`service_kpi` has ~50 fields and `kpi_base_search` ~30. The only schema
+guidance shipped today is a hand-curated, **partial**, prose `content/api/schema.md`.
+
+As a result, an LLM building these payloads is effectively guessing, which
+makes CRUD on ITOA objects error-prone and unreliable.
+
+## Goals
+
+1. Give agents authoritative, machine-usable schemas for **every ITOA object type**.
+2. Catch payload mistakes **before** they hit ITSI, with actionable messages.
+3. Help agents **assemble** nested objects via example/skeleton payloads.
+4. Keep the source of truth maintainable and regenerable from Splunk's docs.
+
+## Non-goals
+
+- Hand-authored Pydantic/JSON-Schema models per object type (drift + maintenance).
+- Server-side workflow builders (e.g. `itsi_add_kpi_to_service`) — deferred.
+- Event Management object coverage — deferred (ITOA first).
+
+## Source of truth
+
+Splunk's [ITSI 4.21 REST API schema](https://help.splunk.com/en/splunk-it-service-intelligence/splunk-it-service-intelligence/leverage-rest-apis/4.21/itsi-rest-api-schema/itsi-rest-api-schema)
+page is a single, highly-structured page: every object type has a
+`Field | Type | Description` table plus explicit *subordinate object* links.
+This parses mechanically into per-object structured schemas.
+
+**Approach: hybrid.** Parse the docs into bundled structured schemas (offline,
+deterministic, version-pinned to 4.21, regenerable). Derive a lightweight
+JSON-Schema shape from the `Type` column for validation. Optionally enrich with
+a live example object pulled from the connected ITSI instance.
+
+The raw scraped markdown lives in `.research/itsi/` (gitignored) as the
+regeneration input. Only the parsed JSON and a regenerated full `schema.md`
+get committed.
+
+## Architecture
+
+### 1. Schema knowledge layer — `mcp_itsi/knowledge/schema/`
+
+| File | Responsibility |
+|------|----------------|
+| `models.py` | `AttributeSpec`, `ObjectSchema`, `SubordinateRef` dataclasses; `to_dict()`, `to_json_schema()` |
+| `data/*.json` | Generated structured schema, one file per object type (bundled, version-pinned) |
+| `registry.py` | `SchemaRegistry`: load bundled JSON once; `get()`, `list_types()`, `search()` |
+| `validator.py` | `PayloadValidator.validate(payload, schema, is_partial)` → `ValidationResult(ok, errors[], warnings[])`; recurses into subordinate objects |
+| `examples.py` | Minimal-valid + fully-populated skeleton payloads per type; curated examples for `service` and `kpi_base_search` |
+
+`ValidationResult` semantics:
+
+- **Hard errors** (block writes): unknown/misspelled field, wrong type, missing
+  clearly-required field.
+- **Warnings** (non-blocking): read-only/server-generated field supplied,
+  empty required-ish array, suspect value.
+
+`required` detection is **conservative** — derived from prose hints
+("required", "Not required") plus obvious cases (`title`; `_key` on update).
+Under-flagging is preferred over false positives that block valid writes.
+
+### 2. Schema generation (dev-time) — `scripts/itsi_schema/`
+
+| File | Responsibility |
+|------|----------------|
+| `parse_schema_md.py` | Parse saved schema markdown tables + subordinate links → `data/*.json`. A mapping table reconciles doc display names → endpoint object-type ids (e.g. "Service" → `service`, "KPI Base Search" → `kpi_base_search`, "Service KPI" → subordinate of `service`) |
+| `refresh.py` | Re-run firecrawl scrape + parser to regenerate schemas when Splunk updates the docs |
+
+Type mapping: `String→string`, `Integer→integer`, `Boolean→boolean`,
+`Object/Dict→object`, `Array→array`.
+
+### 3. New tools — `mcp_itsi/tools/schema.py`
+
+| Tool | Behavior | Connection |
+|------|----------|------------|
+| `itsi_get_object_schema(object_type, include_example=True, include_live_example=False)` | description, endpoint/interface, attribute table, inlined subordinate schemas, derived JSON-Schema, skeleton example(s); optional real sample from the instance | only if `include_live_example` |
+| `itsi_list_object_schemas()` | every type: summary, endpoint, attribute count, subordinate objects | no |
+| `itsi_validate_object_payload(object_type, payload, is_partial=False)` | dry-run validation → `ok / errors / warnings` | no |
+
+### 4. Pre-flight validation on writes (uniform, DRY)
+
+- `mcp_itsi/tools/_validation.py` — `preflight(object_type, payload, is_partial)`
+  + `PayloadValidationError`. Uses a request-scoped `ContextVar` warnings buffer.
+- `_itoa_ops.create_object` / `update_object` gain `validate=True`:
+  - On **hard errors** → raise `PayloadValidationError`.
+  - On **warnings** → push to the `ContextVar` buffer.
+- `BaseITSITool.__call__`:
+  - Reset the warnings buffer at the start of each call.
+  - Catch `PayloadValidationError` → `error_response(message, validation_errors=...)`.
+  - After a successful `execute`, drain the buffer and merge
+    `validation_warnings` into the success response.
+
+This protects **all** ITOA create/update tools and surfaces warnings inline
+with **no per-tool edits**.
+
+### 5. Existing tools & docs
+
+- Enrich `service.py` / `kpi_base_search.py` descriptions to point at
+  `itsi_get_object_schema` + `itsi_validate_object_payload` and name key
+  required fields.
+- Regenerate `content/api/schema.md` from the full parsed schema (replaces the
+  partial hand-written version); keep the catalog entry.
+- Expose each schema as a resource `itsi://schema/<object_type>` via a
+  `schema_resource` builder mirroring `docs_resource`.
+
+### 6. Tests & evaluations
+
+- Unit tests: parser sanity, registry load, validator (unknown field / type
+  mismatch / missing required / nested KPI / partial-update skips required),
+  example generation, ContextVar warnings drain.
+- mcp-builder eval set (XML): an agent fetches a schema and builds a valid
+  `service`/`kpi_base_search`; validation catches a planted mistake.
+
+## Module/SRP notes
+
+All new code stays well under the 500-line limit, each file single-purpose:
+`SchemaRegistry` (manager), `PayloadValidator` (validation), `examples`
+(construction), `schema.py` tools (interface), `_validation.py` (write-path
+coordinator). No changes to the generic registration mechanism.
+
+## Rollout
+
+1. Scrape + parser → generate `data/*.json` and full `schema.md`.
+2. Schema knowledge layer (`models`, `registry`, `validator`, `examples`).
+3. New tools + registration in `all_tools()`; schema resources in `all_resources()`.
+4. Write-path pre-flight (`_validation.py`, `_itoa_ops`, `base.py`).
+5. Enrich showcase tool descriptions.
+6. Tests + evaluations.

--- a/docs/guides/itsi/README.md
+++ b/docs/guides/itsi/README.md
@@ -5,13 +5,15 @@ A dedicated Model Context Protocol server for **Splunk IT Service Intelligence (
 - **Plugin** of [`mcp-for-splunk`](../../../README.md) — one process, one URL, one set of credentials.
 - **Standalone** FastMCP server — its own container or local Python process, separately routed.
 
-Both modes ship **70 tools**, **9 documentation resources**, and **3 workflow prompts**, target ITSI 4.21, and accept the same `X-Splunk-*` per-request auth headers as the parent server.
+Both modes ship **73 tools**, **27 MCP resources** (9 documentation guides, 17 object-type schemas, and `itsi://llms.txt`), and **3 workflow prompts**, target ITSI 4.21, and accept the same `X-Splunk-*` per-request auth headers as the parent server.
 
 ## Pick a guide
 
 | You want to… | Go to | Time |
 |---|---|---|
 | Get a working server in under 15 minutes | **[Getting Started](getting-started.md)** | 10–15 min |
+| Use the tools effectively (schema-first workflow, recipes, pitfalls) | **[User Guide](user-guide.md)** | 15 min |
+| Hand an AI agent a condensed usage map | **[`llms.txt`](../../../mcp_itsi/llms.txt)** (also `itsi://llms.txt`) | reference |
 | Decide standalone vs plugin and roll out properly | **[Deployment Guide](deployment.md)** | 20 min |
 | Browse every tool, resource, and prompt | **[Package README](../../../mcp_itsi/README.md)** | reference |
 | Configure auth headers for an MCP client | [Authentication](../../../mcp_itsi/README.md#authentication) | 5 min |

--- a/docs/guides/itsi/getting-started.md
+++ b/docs/guides/itsi/getting-started.md
@@ -82,7 +82,7 @@ Look for these lines in the logs to confirm the plugin loaded:
 
 ```text
 Loading ITSI plugin into parent MCP server
-Registered 70 ITSI tools
+Registered 73 ITSI tools
 ITSI plugin loaded
 ```
 
@@ -173,11 +173,11 @@ Expected:
 
 ```text
 ========== STANDALONE MODE ==========
-- tools: 70   resources: 9   prompts: 3
+- tools: 73   resources: 27   prompts: 3
 ... failures: 0 (smoke + deep + CRUD)
 
 ========== PLUGIN MODE (mcp-for-splunk + itsi plugin) ==========
-- tools: 123   resources: 28   prompts: 6
+- tools: 126   resources: 46   prompts: 6
 ... failures: 0 (smoke + deep + CRUD + plugin isolation)
 
 --- TOTAL FAILURES: 0 ---
@@ -193,6 +193,8 @@ Targeted scripts you can also run directly:
 | `scripts/test_itsi_plugin_isolation.py` | Confirms parent + plugin coexist (plugin mode only). |
 
 ## Step 5 — Try a real workflow
+
+> **Tip for reliable writes:** before creating or updating objects, have the agent call `itsi_get_object_schema(<type>)` and `itsi_validate_object_payload(<type>, payload)`. See the [User Guide](user-guide.md) for the full schema-first workflow.
 
 Ask your AI client something like:
 
@@ -228,6 +230,7 @@ For wider-project troubleshooting (Splunk auth, transport, sessions) see [`docs/
 
 ## Where next
 
+- **[User Guide](user-guide.md)** — the schema-first workflow, reading data efficiently, safe create/update patterns, recipes, and pitfalls. (Agents: read `itsi://llms.txt` for the condensed version.)
 - **[Deployment Guide](deployment.md)** — choose between standalone and plugin, configure Traefik, run behind a reverse proxy, scale.
 - **[Package README](../../../mcp_itsi/README.md)** — full tool catalog, resources, prompts.
 - **[Service-creation review](../itsi_service_creation_review.md)** — documented walk-through against the official ITSI guides.

--- a/docs/guides/itsi/user-guide.md
+++ b/docs/guides/itsi/user-guide.md
@@ -1,0 +1,147 @@
+# ITSI MCP Server — User Guide
+
+This guide shows how to **drive the ITSI MCP server effectively** — whether you're an operator prompting an AI client or an LLM agent calling tools directly. It assumes you already have a server running and connected; if not, start with [Getting Started](getting-started.md).
+
+The server exposes **73 `itsi_*` tools**, **27 read-only resources**, and **3 workflow prompts** against Splunk IT Service Intelligence (ITSI 4.21).
+
+> **Agents:** read the bundled [`itsi://llms.txt`](../../../mcp_itsi/llms.txt) resource first — it's the condensed version of this guide.
+
+## The mental model
+
+ITSI configuration objects (called **ITOA objects**) are **deeply nested JSON documents**:
+
+- A **service** contains `kpis[]` (KPI definitions) and `entity_rules[]` (which entities belong to it).
+- A **KPI** references a `kpi_base_search` and carries threshold settings.
+- An **entity** is matched to services by alias fields (`host`, `ip`, ...).
+- **Notable events** are produced by **correlation searches** and grouped by **aggregation policies** into episodes.
+
+Every object is addressed by a `_key` (notable events use `event_id`). The nesting is why hand-written payloads fail: a single misspelled or invented field name is rejected by ITSI. The fix is to always work **schema-first**.
+
+## The golden path
+
+Follow these five steps for **every** create or update. They turn an error-prone guess into a validated write.
+
+1. **Discover** — `itsi_list_object_schemas` lists every object type, its REST endpoint, required fields, and nested objects.
+2. **Get the schema** — `itsi_get_object_schema(object_type)` returns every documented field with type and description, inlined schemas for nested objects, a derived JSON Schema, and example payloads (minimal, full, curated). Add `include_live_example=true` to copy the exact shape of a real object from your instance.
+3. **Build** the payload from the returned examples — never invent field names.
+4. **Validate** — `itsi_validate_object_payload(object_type, payload)` dry-runs validation without writing. Fix every `error`; review every `warning`.
+5. **Write** — `itsi_create_*` / `itsi_update_*`. The server re-validates: hard errors block *before* the API call and return `validation_errors`; warnings come back inline under `validation_warnings`.
+
+```text
+itsi_list_object_schemas  →  itsi_get_object_schema  →  itsi_validate_object_payload  →  itsi_create_* / itsi_update_*
+        (discover)                 (learn the shape)            (dry-run check)                  (write, re-validated)
+```
+
+## Reading data
+
+All `itsi_list_*` tools share a common, efficient query interface.
+
+| Parameter | Purpose | Example |
+|---|---|---|
+| `filter_query` | MongoDB-style filter (object or JSON string) | `{"title": {"$regex": ".*Web.*"}}` |
+| `fields` | Comma-separated projection to shrink responses | `"title,_key,enabled"` |
+| `limit` / `offset` | Pagination | `limit=50, offset=100` |
+| `sort_key` / `sort_dir` | Ordering (`1` asc, `-1` desc) | `sort_key="title"` |
+
+**Resolve a `_key` first.** Before `itsi_get_*`, `itsi_update_*`, or `itsi_delete_*`, list or count to find the object's `_key`. Use `itsi_count_services` (and similar) when you only need a number.
+
+```jsonc
+// "List the 10 most recently modified services that are enabled, titles only"
+itsi_list_services({
+  "filter_query": { "enabled": 1 },
+  "fields": "title,_key",
+  "sort_key": "mod_time",
+  "sort_dir": -1,
+  "limit": 10
+})
+```
+
+## Creating and updating safely
+
+### Partial vs. full updates
+
+`itsi_update_*` is **partial by default** — only the fields you send change. Set `is_partial=false` for a full overwrite of the document.
+
+### The GET → merge → PUT pattern
+
+Some ITSI endpoints validate the **entire** document even on a partial update. If a partial update returns a 5xx, fall back to:
+
+1. `itsi_get_<object>(key)` to fetch the current document.
+2. Merge your changes into it locally.
+3. `itsi_update_<object>(key, merged, is_partial=false)` to write it back whole.
+
+### What the validator catches
+
+`itsi_validate_object_payload` and the write-path pre-flight recurse into nested objects (service KPIs, entity rules, threshold settings) and report two severities:
+
+- **Errors (block the write):** unknown or misspelled fields (with a "did you mean?" suggestion), wrong types, and missing required fields.
+- **Warnings (allowed, surfaced inline):** read-only/server-generated fields (`_key`, `object_type`, `create_time`, `mod_time`, `acl`, ...) and fields not in the documented 4.21 schema.
+
+Booleans accept either `true/false` or `1/0` — ITSI uses both.
+
+## Recipes
+
+### Create a service with a KPI
+
+```text
+1. itsi_get_object_schema("service", include_live_example=true)
+   → study `kpis[]` (a "service_kpi" subordinate) and `entity_rules[]`.
+2. (If using a shared base search) itsi_list_kpi_base_searches → pick a _key.
+3. Build the service payload from the curated example.
+4. itsi_validate_object_payload("service", payload)  → fix errors.
+5. itsi_create_service(payload)  → note the returned _key and any validation_warnings.
+```
+
+### Onboard an entity
+
+Entities match services via alias fields. **Every field named in `identifier.fields` must also appear at the document root**, as a list:
+
+```jsonc
+itsi_create_entity({
+  "title": "web-1",
+  "identifier": { "fields": ["host"], "values": ["web-1"] },
+  "host": ["web-1"]            // required: mirrors identifier.fields
+})
+```
+
+### Triage episodes
+
+```text
+1. itsi_list_notable_events({ "filter_query": {"severity": {"$gte": 4}}, "limit": 20 })
+2. itsi_get_notable_event(event_id)              → inspect details
+3. itsi_acknowledge_notable_event(event_id)      → status = in progress
+4. itsi_close_notable_event(event_id, comment)   → status = closed
+```
+
+Or invoke the `itsi_episode_triage` prompt for a guided runbook.
+
+## Common pitfalls
+
+| Symptom | Cause / fix |
+|---|---|
+| `Unknown field 'X'. Did you mean 'Y'?` | Typo or invented field — re-fetch `itsi_get_object_schema` and copy field names. |
+| `Missing required field 'title'` | Required field omitted — check `required_fields` from the schema. |
+| Update 5xxs on a partial change | Endpoint validates the full doc — use GET → merge → PUT with `is_partial=false`. |
+| Entity created but never matches a service | Alias field missing at the document root (must mirror `identifier.fields`). |
+| `404 ITSI API` | Wrong namespace — pass `X-ITSI-App` / `X-ITSI-User-NS` (defaults `SA-ITOA` / `nobody`). |
+| `No Splunk credentials provided` | Client sent no auth headers and no env defaults — see [Authentication](getting-started.md#authentication). |
+
+## Resources and prompts
+
+Read-only resources need no credentials and are ideal for grounding an agent:
+
+- `itsi://llms.txt` — condensed agent usage guide (this document's TL;DR).
+- `itsi://schema/<object_type>` — structured schema JSON per type (e.g. `itsi://schema/service`).
+- `itsi://docs/overview` — map of the bundled knowledge corpus.
+- `itsi://docs/api/schema`, `itsi://docs/api/reference` — full ITSI 4.21 REST schema and endpoint/filter reference.
+- `itsi://docs/service-insights`, `itsi://docs/entity-integrations`, `itsi://docs/event-analytics`, `itsi://docs/best-practices` — concept guides.
+
+The same docs are also callable as tools: `itsi_list_docs`, `itsi_read_doc`, `itsi_search_docs`.
+
+Workflow prompts: `itsi_service_onboarding`, `itsi_kpi_design`, `itsi_episode_triage`.
+
+## Where next
+
+- **[Getting Started](getting-started.md)** — install, connect a client, run the smoke tests.
+- **[Deployment Guide](deployment.md)** — standalone vs. plugin, networking, scaling.
+- **[Package README](../../../mcp_itsi/README.md)** — full tool catalog, auth headers, environment variables.

--- a/mcp_itsi/README.md
+++ b/mcp_itsi/README.md
@@ -4,7 +4,7 @@
   [![FastMCP](https://img.shields.io/badge/FastMCP-2.13%2B-blue)](https://gofastmcp.com/)
   [![Python](https://img.shields.io/badge/Python-3.10%2B-green)](https://python.org)
   [![ITSI](https://img.shields.io/badge/ITSI-4.21-purple)](https://help.splunk.com/en/splunk-it-service-intelligence/splunk-it-service-intelligence/leverage-rest-apis/4.21/itsi-rest-api-reference/itsi-rest-api-reference)
-  [![Tools](https://img.shields.io/badge/tools-70-orange)](#capabilities-at-a-glance)
+  [![Tools](https://img.shields.io/badge/tools-73-orange)](#capabilities-at-a-glance)
   [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](../LICENSE)
 
   *Model Context Protocol server purpose-built for Splunk IT Service Intelligence — runs standalone or as a plugin of [`mcp-server-for-splunk`](../README.md).*
@@ -14,8 +14,9 @@
 
 ## What you get
 
-- **70 tools** covering full CRUD on every mutable ITSI object (services, service templates, entities, entity types, KPI base searches, KPI threshold templates, glass tables, deep dives, home views, teams, notable events, aggregation policies, correlation searches) plus discovery, doc-search, and event triage shortcuts.
-- **9 documentation resources** distilled from the official ITSI 4.21 docs — accessible as MCP resources (`itsi://docs/<slug>`) and as `itsi_list_docs` / `itsi_read_doc` / `itsi_search_docs` tools.
+- **73 tools** covering full CRUD on every mutable ITSI object (services, service templates, entities, entity types, KPI base searches, KPI threshold templates, glass tables, deep dives, home views, teams, notable events, aggregation policies, correlation searches) plus schema discovery, payload validation, doc-search, and event triage shortcuts.
+- **Schema-aware writes** — bundled schemas for every ITSI object type power `itsi_list_object_schemas`, `itsi_get_object_schema`, and `itsi_validate_object_payload`, and every create/update is validated before submission (structural errors block the call; warnings surface inline on success).
+- **27 MCP resources** — 9 documentation guides (`itsi://docs/<slug>`), 17 object-type schemas (`itsi://schema/<object_type>`), and an agent usage map (`itsi://llms.txt`). The docs are also callable as `itsi_list_docs` / `itsi_read_doc` / `itsi_search_docs`.
 - **3 workflow prompts** — `itsi_service_onboarding`, `itsi_kpi_design`, `itsi_episode_triage`.
 - **Two deployment modes** with identical capabilities: a dedicated FastMCP process or a plugin of the parent `mcp-server-for-splunk` server.
 - **The same auth contract as `mcp-for-splunk`**: per-request `X-Splunk-*` headers (basic, bearer, or session token) plus optional `X-ITSI-*` namespace overrides.
@@ -25,6 +26,8 @@
 | You want to… | Go to |
 |---|---|
 | Run a server in 5 minutes against a real ITSI host | [Getting Started](../docs/guides/itsi/getting-started.md) |
+| Use the tools effectively (schema-first workflow, recipes) | [User Guide](../docs/guides/itsi/user-guide.md) |
+| Hand an AI agent a condensed usage map | [`llms.txt`](llms.txt) (also `itsi://llms.txt`) |
 | Decide between standalone and plugin mode | [Deployment Guide](../docs/guides/itsi/deployment.md) |
 | Configure auth headers for your MCP client | [Authentication](#authentication) below |
 | Browse the tool catalog and resource list | [Capabilities at a glance](#capabilities-at-a-glance) below |
@@ -186,7 +189,17 @@ All variables have safe defaults; everything below is optional.
 
 ## Capabilities at a glance
 
-### Service Insights (14 tools)
+### Schema & validation (3 tools)
+
+Start here when creating or updating any object — these make CRUD on deeply nested ITOA objects reliable.
+
+| Tool | Purpose |
+|---|---|
+| `itsi_list_object_schemas` | List every object type with a documented schema, its endpoint, required fields, and nested objects. |
+| `itsi_get_object_schema` | Full schema for one type: fields + types, inlined subordinate schemas, derived JSON Schema, and example payloads. Optionally fetch a live example. |
+| `itsi_validate_object_payload` | Dry-run validate a payload (errors + warnings) without writing — recurses into nested objects. |
+
+### Service Insights (12 tools)
 
 | Tool | Purpose |
 |---|---|
@@ -203,7 +216,7 @@ All variables have safe defaults; everything below is optional.
 | `itsi_delete_service_template` | Delete a template. |
 | `itsi_templatize_service` | Generate a template payload from a service. |
 
-### Entity integration (10 tools)
+### Entity integration (11 tools)
 
 | Tool | Purpose |
 |---|---|
@@ -226,7 +239,7 @@ All variables have safe defaults; everything below is optional.
 
 `itsi_list_glass_tables`, `itsi_get_glass_table`, `itsi_create_glass_table`, `itsi_update_glass_table`, `itsi_delete_glass_table`, `itsi_list_home_views`, `itsi_get_home_view`, `itsi_create_home_view`, `itsi_update_home_view`, `itsi_delete_home_view`, `itsi_list_deep_dives`, `itsi_get_deep_dive`, `itsi_create_deep_dive`, `itsi_update_deep_dive`, `itsi_delete_deep_dive`.
 
-### Event Analytics (15 tools)
+### Event Analytics (14 tools)
 
 | Tool | Purpose |
 |---|---|
@@ -243,9 +256,15 @@ All variables have safe defaults; everything below is optional.
 
 `itsi_list_maintenance_windows`, `itsi_get_maintenance_window`, `itsi_list_teams`, `itsi_get_team`, `itsi_get_supported_object_types`, `itsi_list_docs`, `itsi_read_doc`, `itsi_search_docs`.
 
-### Resources
+### Resources (27)
+
+Read-only and credential-free. An agent should read `itsi://llms.txt` first.
 
 ```text
+# Agent usage map (llms.txt)
+itsi://llms.txt
+
+# Documentation guides (9)
 itsi://docs/overview
 itsi://docs/api/reference
 itsi://docs/api/schema
@@ -255,6 +274,18 @@ itsi://docs/event-analytics
 itsi://docs/modules
 itsi://docs/best-practices
 itsi://docs/cookbook/header-auth
+
+# Object-type schemas (17) — structured JSON, same data as itsi_get_object_schema
+itsi://schema/service              itsi://schema/base_service_template
+itsi://schema/entity               itsi://schema/entity_type
+itsi://schema/kpi_base_search      itsi://schema/kpi_threshold_template
+itsi://schema/glass_table          itsi://schema/home_view
+itsi://schema/deep_dive            itsi://schema/team
+itsi://schema/correlation_search   itsi://schema/maintenance_calendar
+itsi://schema/event_management_state
+itsi://schema/notable_event_group  itsi://schema/notable_event_comment
+itsi://schema/notable_event_email_template
+itsi://schema/notable_event_aggregation_policy
 ```
 
 ### Prompts
@@ -307,11 +338,11 @@ Expected output:
 
 ```text
 ========== STANDALONE MODE ==========
-- tools: 70   resources: 9   prompts: 3
+- tools: 73   resources: 27   prompts: 3
 ... failures: 0 (smoke + deep + CRUD)
 
 ========== PLUGIN MODE (mcp-for-splunk + itsi plugin) ==========
-- tools: 123   resources: 28   prompts: 6
+- tools: 126   resources: 46   prompts: 6
 ... failures: 0 (smoke + deep + CRUD + plugin isolation)
 
 --- TOTAL FAILURES: 0 ---
@@ -320,6 +351,8 @@ Expected output:
 ## See also
 
 - **[Getting Started](../docs/guides/itsi/getting-started.md)** — first 15 minutes against a real ITSI cluster.
+- **[User Guide](../docs/guides/itsi/user-guide.md)** — the schema-first workflow, recipes, and common pitfalls.
+- **[`llms.txt`](llms.txt)** — condensed agent usage map (also served at `itsi://llms.txt`).
 - **[Deployment Guide](../docs/guides/itsi/deployment.md)** — standalone vs plugin, networking, scaling.
 - **[ITSI MCP overview](../docs/guides/itsi_mcp.md)** — short hub page in the project docs.
 - **[Service-creation walk-through and critical review](../docs/guides/itsi_service_creation_review.md)** — what works, what's still rough, and the workarounds we've documented.

--- a/mcp_itsi/core/base.py
+++ b/mcp_itsi/core/base.py
@@ -61,6 +61,13 @@ class BaseITSITool(ABC):
         self.logger = logging.getLogger(f"mcp_itsi.tools.{self.METADATA.name}")
 
     async def __call__(self, ctx: Context, **kwargs: Any) -> dict[str, Any]:
+        # Local import avoids a module-level cycle (tools -> core.base -> tools).
+        from mcp_itsi.tools._validation import (
+            PayloadValidationError,
+            drain_warnings,
+            reset_warnings,
+        )
+
         if self.METADATA.requires_connection:
             try:
                 call_ctx = build_call_context(ctx)
@@ -70,8 +77,18 @@ class BaseITSITool(ABC):
         else:
             call_ctx = None  # type: ignore[assignment]
 
+        reset_warnings()
         try:
-            return await self.execute(ctx, call_ctx, **kwargs)
+            result = await self.execute(ctx, call_ctx, **kwargs)
+            return self._attach_warnings(result, drain_warnings())
+        except PayloadValidationError as exc:
+            self.logger.info("Pre-flight validation blocked %s", self.METADATA.name)
+            return error_response(
+                str(exc),
+                object_type=exc.object_type,
+                validation_errors=[e.to_dict() for e in exc.result.errors],
+                validation_warnings=[w.to_dict() for w in exc.result.warnings],
+            )
         except ITSIError as exc:
             self.logger.warning(
                 "ITSI API error in %s: %s (status=%s)",
@@ -83,6 +100,15 @@ class BaseITSITool(ABC):
         except Exception as exc:  # noqa: BLE001 -- we surface to the caller
             self.logger.exception("Unhandled error in tool %s", self.METADATA.name)
             return error_response(f"{type(exc).__name__}: {exc}")
+
+    @staticmethod
+    def _attach_warnings(
+        result: dict[str, Any], warnings: list[dict[str, str]]
+    ) -> dict[str, Any]:
+        """Merge pre-flight warnings into a successful response."""
+        if warnings and isinstance(result, dict) and result.get("status") == "success":
+            result.setdefault("validation_warnings", warnings)
+        return result
 
     @abstractmethod
     async def execute(

--- a/mcp_itsi/knowledge/content/api/schema.md
+++ b/mcp_itsi/knowledge/content/api/schema.md
@@ -1,191 +1,1009 @@
-# ITSI REST API schema (4.21) — distilled
+# ITSI REST API schema (4.21)
 
 > Source: <https://help.splunk.com/en/splunk-it-service-intelligence/splunk-it-service-intelligence/leverage-rest-apis/4.21/itsi-rest-api-schema/itsi-rest-api-schema>
+>
+> Auto-generated from the ITSI 4.21 REST API schema docs by
+> `scripts/itsi_schema`. Do not edit by hand — run the refresh script instead.
+> For machine-usable schemas and validation, use the `itsi_get_object_schema`,
+> `itsi_list_object_schemas` and `itsi_validate_object_payload` tools.
 
-ITSI stores its configuration in the splunkd KV store. **Do not** write to
-the KV store directly — always go through the REST endpoints documented in
-the API reference. This file lists the JSON shapes you'll most often need.
+ITSI stores its configuration in the splunkd KV store. **Do not** write to the
+KV store directly — always go through the REST endpoints. Common system fields
+(`object_type`, `create_time`, `mod_time`, `_owner`, `_user`, `version`, ...)
+are server-generated and read-only.
 
-## Common attributes
 
-Every ITSI object has these system fields (omitted from the per-type schemas
-below to keep them readable):
+## Object types
 
-| Field           | Type   | Notes                                                  |
-|-----------------|--------|--------------------------------------------------------|
-| `object_type`   | string | E.g. `service`, `entity`.                              |
-| `create_by`     | string | Splunk user that created the object.                   |
-| `create_time`   | string | UTC timestamp.                                         |
-| `mod_source`    | string | `manual` for user actions.                             |
-| `mod_time`      | string | UTC timestamp of the last modification.                |
-| `_owner`        | string | Always `nobody`.                                       |
-| `_user`         | string | Last user that touched the object.                     |
-| `version`       | string | Same as the ITSI app version.                          |
+`base_service_template`, `correlation_search`, `deep_dive`, `entity`, `entity_type`, `event_management_state`, `glass_table`, `home_view`, `kpi_base_search`, `kpi_threshold_template`, `maintenance_calendar`, `notable_event_aggregation_policy`, `notable_event_comment`, `notable_event_email_template`, `notable_event_group`, `service`, `team`
 
-## entity
+## Subordinate structures
 
-```json
-{
-  "_key": "<uuid>",
-  "title": "mysql-04",
-  "description": "",
-  "object_type": "entity",
-  "identifier": { "fields": ["host"], "values": ["mysql-04"] },
-  "informational": { "fields": ["itsi_role"], "values": ["operating_system_host"] },
-  "services": [ { "_key": "<service-uuid>", "title": "Database Service" } ],
-  "entity_type_ids": ["<entity-type-uuid>"],
-  "sec_grp": "default_itsi_security_group"
-}
-```
+`anomaly_detection_algorithm_settings`, `deep_dive_lane_setting`, `entity_rules`, `entity_type_dashboard_drilldown`, `entity_type_data_drilldown`, `entity_type_vital_metrics`, `event_management_export`, `glass_table_icon`, `glass_table_widget_configuration`, `kpi_threshold_levels`, `kpi_threshold_settings`, `service_kpi`, `service_template_kpi`, `time_variate_thresholds_specification`
 
-`entity` may belong only to the Global team
-(`default_itsi_security_group`).
+---
 
-## service
+# Object type schemas
 
-```json
-{
-  "_key": "<uuid>",
-  "title": "Buttercup Store",
-  "description": "Customer-facing storefront.",
-  "kpis": [ /* Service KPI objects, see below */ ],
-  "entity_rules": [
-    {
-      "rule_condition": "AND",
-      "rule_items": [
-        { "field": "category", "rule_type": "matches", "value": "*Web*", "field_type": "alias" }
-      ]
-    }
-  ],
-  "services_depends_on": [
-    { "service_id": "<id>", "kpis_depending_on": ["<kpi-id>"] }
-  ],
-  "services_depending_on_me": [],
-  "enabled": 1,
-  "sec_grp": "default_itsi_security_group",
-  "base_service_template_id": "",
-  "service_tags": { "tags": ["unix", "seattle"], "template_tags": ["cloud_systems"] }
-}
-```
+## Service Template (`base_service_template`)
 
-## base_service_template
+**Endpoint:** `/itoa_interface/base_service_template`  
 
-```json
-{
-  "_key": "<uuid>",
-  "title": "Web Server (template)",
-  "description": "Reusable KPI bundle for web servers.",
-  "kpis": [ /* Service Template KPI objects */ ],
-  "entity_rules": [ /* same shape as service */ ],
-  "service_id": "<service-uuid-this-was-derived-from>",
-  "sec_grp": "default_itsi_security_group",
-  "linked_services": [ /* abbreviated service objects */ ],
-  "total_linked_services": 12,
-  "sync_status": "synced",
-  "scheduled_time": null,
-  "scheduled_job": {},
-  "template_tags": ["web", "infra"]
-}
-```
+ITSI service templates help you manage shared content for similar services. Services linked to a service template receive content from the service template, such as KPIs and entity rules. You must create a service template from an existing service. The `base_service_template` object contains KPI definitions, entity rules, and any linked services.
 
-`base_service_template` belongs only to the Global team.
+**Subordinate objects:** `entity_rules`, `service_template_kpi`
 
-## entity_rules
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `_key` | string | - | Auto-generated unique identifier for this service template. |
+| `description` | string | - | User defined description for the service template. |
+| `title` | string | yes | Title of this service template. |
+| `kpis` | array | - | Array of KPI descriptions for this service template. *(nested: `service_template_kpi`)* |
+| `entity_rules` | array | - | Array of rules describing entities referenced by this service template. *(nested: `entity_rules`)* |
+| `service_id` | string | - | _key value of the service this service template is generated from. |
+| `sec_grp` | string | - | The team the service template belongs to. Service templates can only belong to default_itsi_security_group (Global team). |
+| `linked_services` | array | - | Array of services linked to this service template. if the user does not have access to all linked services, the linked_services field only contains the services they have read access to. |
+| `total_linked_services` | integer | - | The number of services linked to this service template. |
+| `last_sync_error` | string | - | Error message if the last sync operation failed. |
+| `sync_status` | string | - | Sync status of service template: "synced", "sync_scheduled", "syncing", "sync failed". |
+| `scheduled_time` | string | - | The time to push service template changes to linked services if "sync later" is selected rather than "sync now". |
+| `scheduled_job` | object | - | Sync job detail if "sync later" is selected rather than "sync now". |
+| `template_tags` | array | - | The service tags contained within the template. |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
 
-Top level: array of OR'd rule groups. Each group AND's `rule_items`.
+## Correlation Search (`correlation_search`)
 
-```json
-[
-  {
-    "rule_condition": "AND",
-    "rule_items": [
-      { "field": "title",   "rule_type": "matches", "value": "Foo",       "field_type": "title" },
-      { "field": "category","rule_type": "matches", "value": "*Bar*",     "field_type": "alias" },
-      { "field": "subcat",  "rule_type": "not",     "value": "Foo",       "field_type": "info"  }
-    ]
-  }
-]
-```
+**Endpoint:** `/event_management_interface/correlation_search`  
 
-`rule_type` accepts `matches`, `not`, `matchesblank`, `doesnotmatchblank`.
+`correlation_search` contains the data for a correlation search. A correlation search is a recurring search that generates a notable event when search results meet specific conditions. A multi-KPI alert is a type of correlation search.
 
-## entity_type
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `is_scheduled` | integer | - | Values: 1 means scheduled; 0 means not scheduled. |
+| `disabled` | integer | - | Values: 1 means disabled; 0 means enabled. |
+| `cron_schedule` | string | - | Schedule searches to run periodically at fixed times, dates, or intervals using a cron expression. Default value is `*/5* * * *` (every 5 minutes). |
+| `dispatch.earliest_time` | string | - | Indicates the beginning of the time range for the search. The default value is `-15m`. |
+| `dispatch.latest_time` | string | - | Indicates the end of the time range for the search. The default value is `-now`. |
+| `description` | string | - | A description of the type of issue the search is intended to detect. |
+| `search` | string | - | The Splunk search to run. |
+| `name` | string | - | A name that describes the correlation search. For example, "cpu_load_percent". |
+| `action.itsi_event_generator.param.title` | string | - | The title to use for the notable event in Episode Review. For example, `mysql-01 server cpu Load %`. |
+| `action.itsi_event_generator.param.description` | string | - | A brief phrase to describe the notable event. For example, "This alert triggers when DB CPU load on the mysql-01 server reaches 80%." |
+| `action.itsi_event_generator.param.status` | string | - | The triage status of the event in Episode Review. You can provide a token in the format `%fieldname%` to substitute the value of a third-party alert field. Values must match an integer specified in `$SPLUNK_HOME/etc/apps/SA-ITOA/local/itsi_notable_event_status.conf` or `/default/itsi_notable_event_status.conf` if a local version does not exist. By default, these values are 0-5. |
+| `action.itsi_event_generator.param.owner` | array | - | The ITSI role to which the notable event is assigned in Episode Review. |
+| `action.itsi_event_generator.param.severity` | string | - | The level of importance of the event. You can provide a token in the format `%fieldname%` to substitute the value of a third-party alert field. Values must match an integer specified in `$SPLUNK_HOME/etc/apps/SA-ITOA/local/itsi_notable_event_severity.conf` or `/default/itsi_notable_event_severity.conf` if a local version does not exist. By default, these values are 1-6. |
+| `action.itsi_event_generator.param.drilldown_search_title` | string | - | The name of the drilldown search link. You can drill down to a specific Splunk search from an episode in Episode Review. |
+| `action.itsi_event_generator.param.drilldown_search_search` | string | - | The Splunk search you drill down to. |
+| `action.itsi_event_generator.param.drilldown_search_latest_offset` | string | - | Defines how far ahead from the time of the event to look for related events. |
+| `action.itsi_event_generator.param.drilldown_search_earliest_offset` | string | - | Defines how far back from the time of the event to start looking for related events. |
+| `action.itsi_event_generator.param.drilldown_title` | string | - | The name of the drilldown website link if you want to drill down to a specific website from the episode in Episode Review. |
+| `action.itsi_event_generator.param.drilldown_uri` | string | - | The website you drill down to. |
+| `action.itsi_event_generator.param.event_identifier_fields` | string | - | These identifier fields form the event hash field, which is added to every notable event to help identify unique alarm types. |
+| `action.itsi_event_generator.param.service_ids` | string | - | One or more ITSI services to which this correlation search applies. You can only specify services that belong to teams for which you have read access. |
+| `action.itsi_event_generator.param.entity_lookup_field` | string | - | The field in the data retrieved by the correlation search that is used to look up corresponding entities. For example, `host`. |
+| `action.itsi_event_generator.param.search_type` | string | - | search_type = "basic", "composite_kpi_score_type", or composite_kpi_percentage_type |
+| `action.itsi_event_generator.param.meta_data` | object | - | One of two JSON object schemas, depending on whether it is a correlation search or a multi-KPI alert. Correlation search object schema: - threshold_health_score - threshold score set by user - threshold_status - threshold status (default is undefined) - suppression criteria fields - alert_type - score or status - is_suppression - if suppression is enabled or not - is_consecutive - if count is consecutive or not - count - minimum number of times if this alert happens - suppression_period - suppression period in minute if it is non-consecutive - min_alert_period - minimum alert period of selected KPIs - run_every - frequency of search in minutes - score_based_kpis - list of KPIs which is added as part of a composite KPI. Each object in the list must have kpiid - <kpi id>, serviceid - <service id>, urgency - <urgency value> Multi-KPI alert object schema: - time_label - time label for time range - percentage_based_kpis - list of KPIs and service IDs included. Each item should contain kpiid - <kpi id>, serviceid - <service id>, label_thresholds - <threshold and operation type for trigger>. label_thresholds data format is as follows: `{ operation : 'OR', // default for now thresholds : [ { severity: <severity name>, percentage: <percentage value>, percentage_operation: '>=', // default for now } ...... ] }` |
+| `action.itsi_event_generator.param.editor` | string | - | One of two values: advance_correlation_builder_editor or multi_kpi_alert_editor. It directs to the specific UI page to make edits based on the type of search, correlation search or multi-KPI alert. |
+| `action.itsi_event_generator` | integer | - | Value: 1 |
+| `actions` | string | - | Value: itsi_event_generator |
+| `alert.suppress` | integer | - | Enable suppression to minimize the number of duplicate notable events sent to Episode Review. Values: 1 (means enabled) or 0 (means disabled). |
+| `alert.suppress.fields` | string | - | The fields to consider when determining if another event matches the current one. |
+| `alert.suppress.period` | string | - | The number of seconds to ignore other events that have the same field values. |
+| `action.rss` | integer | - | Included in RSS feed. Values: 1 (means enabled) or 0 (means disabled). |
+| `action.email` | integer | - | Send an email when the alert is triggered. Values: 1 (means enabled) or 0 (means disabled). |
+| `action.email.to` | string | - | The email addresses to send the email to. |
+| `action.email.subject` | string | - | The subject of the email. |
+| `action.email.sendcsv` | integer | - | Send an email in CSV format. Values: 1 (means enabled) or 0 (means disabled). |
+| `action.email.sendpdf` | integer | - | Send an email with a PDF attachment. Values: 1 (means enabled) or 0 (means disabled). |
+| `action.email.inline` | integer | - | Send an email with the text inline. Values: 1 (means enabled) or 0 (means disabled). |
+| `action.email.format` | string | - | Default value is pdf. Other values: html, csv. |
+| `action.email.sendresults` | string | - | Include alert information as an email attachment. Values: 1 (means enabled) or 0 (means disabled). |
+| `action.script` | integer | - | Triggers a shell script if enabled. Values: 1 (means enabled) or 0 (means disabled). |
+| `action.script.filename` | string | - | Provide the file name of the shell script to run when this alert is triggered. |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
 
-```json
-{
-  "_key": "<uuid>",
-  "title": "Linux",
-  "description": "Linux hosts.",
-  "data_drilldown": [
-    { "title": "syslog", "type": "events",
-      "static_filter": { "sourcetype": "linux_syslog" },
-      "entity_field_filter": ["host"] }
-  ],
-  "dashboard_drilldowns": [
-    { "title": "Linux dashboard", "id": "linux_overview",
-      "is_splunk_dashboard": true, "dashboard_type": "xml_dashboard",
-      "params": { "host": "$alias.host$" } }
-  ],
-  "vital_metrics": [
-    {
-      "metric_name": "Average CPU usage",
-      "search": "| mstats avg(cpu.usage) WHERE index=os ... by host span=5m",
-      "split_by_fields": ["host"],
-      "matching_entity_fields": ["host"],
-      "is_key": true,
-      "unit": "%",
-      "alert_rule": {
-        "is_enabled": true, "cron_schedule": "*/5 * * * *",
-        "critical_threshold": "90", "warning_threshold": "75"
-      }
-    }
-  ]
-}
-```
+## Deep Dive (`deep_dive`)
 
-## Service KPI (`service.kpis[]`)
+**Endpoint:** `/itoa_interface/deep_dive`  
 
-```json
-{
-  "_key": "<kpi-uuid>",
-  "title": "ServiceHealthScore",
-  "type": "service_health",
-  "kpi_base_search": "<base-search-uuid>",
-  "search_type": "shared_base",
-  "base_search": "...",
-  "threshold_field": "aggregate",
-  "entity_statop": "avg",
-  "aggregate_statop": "avg",
-  "urgency": 11,
-  "cron_schedule": "*/5 * * * *",
-  "alert_on": "both",
-  "is_entity_breakdown": true,
-  "entity_id_fields": "host",
-  "entity_alias_filtering_fields": null,
-  "entity_thresholds": { /* threshold object */ },
-  "aggregate_thresholds": { /* threshold object */ },
-  "kpi_threshold_template_id": "<template-uuid>",
-  "time_variate_thresholds": false,
-  "time_variate_thresholds_specification": { "policies": { "default_policy": { "title": "Default" } } },
-  "anomaly_detection_is_enabled": false,
-  "anomaly_detection_alerting_enabled": false,
-  "alert_lag": "30"
-}
-```
+ITSI deep dives are investigative tools that help you identify and troubleshoot issues in your IT environment. You can use deep dives to view KPI search results over time, zoom-in on KPI metrics and log events, and visually correlate root cause. You can add different types of lanes to a deep dive view, including KPI lanes, which let you view KPI metrics in detail. You can also add lanes to view ad hoc and data model searches. `deep_dive` objects contain all of the elements required to render deep dive lanes.
 
-## Notable event (Event Management)
+**Subordinate objects:** `deep_dive_lane_setting`
 
-Notable events are addressed by `event_id` (string) under
-`/event_management_interface/notable_event/<event_id>`. Important fields:
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `_key` | string | - | Auto-generated unique identifier for this deep dive. |
+| `description` | string | - | User-defined description for this deep dive. |
+| `title` | string | yes | Name of the deep dive. |
+| `object_type` | string | read-only | deep_dive |
+| `earliest_time` | string | - | Earliest time for all of the searches in this deep dive. |
+| `latest_time` | string | - | Latest time for all of the searches in this deep dive. |
+| `focus_id` | string | - | The service id of the service in focus. |
+| `topology_id` | string | - | Define the service to be put in focus in the deep dive topology view. If none exists then the focus_id is set as the topology_id. view sidebar |
+| `lane_settings_collection` | array | - | <Array of lane settings specifying each lane's configuration. See Deep Dive Lane Settings. *(nested: `deep_dive_lane_setting`)* |
+| `is_named` | boolean | - | True when the deep dive is saved, false otherwise. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
 
-- `severity` — integer, 1=info, 6=critical
-- `status` — integer, 0=unassigned, 1=new, 2=in progress, 3=pending, 4=resolved, 5=closed
-- `owner` — Splunk user assigned to the event
-- `service_ids` / `service_titles` — affected services
-- `description`, `title`, `event_identifier_hash`
-- `drilldown_search_*` and `drilldown_uri` for triage
+## Entity (`entity`)
 
-Aggregation policies (`notable_event_aggregation_policy`) carry filter
-criteria, group titles, and action rules. Correlation searches
-(`correlation_search`) are saved searches in `splunk_search` that produce
-notable events.
+**Endpoint:** `/itoa_interface/entity`  
+
+An entity is a basic unit of configuration in an IT environment that meets a specific need for an IT service. Entities are usually servers, but can be other IT infrastructure components, such as network devices, storage subsystems, applications, and so on. Entities are optional. The `entity` object contains field aliases and values that identify the entity in KPI searches.
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `_key` | string | - | Auto-generated unique identifier for this entity. Can be any unique value. |
+| `title` | string | yes | Name of the entity. Can be any unique value. |
+| `description` | string | - | User defined description of the entity. |
+| `object_type` | string | read-only | entity |
+| `identifier` | object | - | _values_: Array of alias values that identify the entity _fields_: Array of search fields that identify events for the entity. |
+| `informational` | object | - | _values_: Array of alias values that provide information/description for the entity. _fields_: Array of search fields to extract information/description of the entity. |
+| `services` | array | - | Array of sub-objects with _key and title fields of services monitoring this entity via rules configured in services. |
+| `sec_grp` | string | - | The team the object belongs to. The entity object can only belong to default_itsi_security_group (Global team). |
+| `sai_entity_key` | string | - | This field exists in ITSI entities that have been merged with SAI entities. It symbolizes the original SAI entities's _key and is used for drilldowns to SAI. |
+| `entity_type_ids` | array | - | Array of _key values for each entity type associated with the entity. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## Entity Type (`entity_type`)
+
+**Endpoint:** `/itoa_interface/entity_type`  
+
+An `entity_type` defines how to classify a type of data source. For example, you can create a Linux, Windows, Unix/Linux add-on, VMware, or Kubernetes entity type. An entity type can include zero or more data drilldowns and zero or more dashboard drilldowns. You can use a single data drilldown or dashboard drilldown for multiple entity types.
+
+**Subordinate objects:** `entity_type_dashboard_drilldown`, `entity_type_data_drilldown`, `entity_type_vital_metrics`
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `title` | string | yes | The name of the entity type. |
+| `description` | string | - | A description of the entity type. |
+| `dashboard_drilldowns` | array | - | An array of dashboard drilldown objects. Each dashboard drilldown defines an internal or external resource you specify with a URL and parameters that map to one of an entity fields. The parameters are passed to the resource when you open the URL. See [Entity Type Dashboard Drilldown](https://help.splunk.com/en/splunk-it-service-intelligence/splunk-it-service-intelligence/leverage-rest-apis/4.21/itsi-rest-api-schema/itsi-rest-api-schema#db5a9c8d_7a60_4c88_9385_44cf3fb415b5--en__ITSI_REST_API_schema). *(nested: `entity_type_dashboard_drilldown`)* |
+| `data_drilldown` | array | - | An array of data drilldown objects. Each data drilldown defines filters for raw data associated with entities that belong to the entity type. See [Entity Type Data Drilldown](https://help.splunk.com/en/splunk-it-service-intelligence/splunk-it-service-intelligence/leverage-rest-apis/4.21/itsi-rest-api-schema/itsi-rest-api-schema#ade3ea81_9cb7_4514_a0c4_dedaa2e5e9f1--en__Entity_Type_Data_Drilldown). *(nested: `entity_type_data_drilldown`)* |
+| `vital_metrics` | array | - | An array of vital metric objects. Vital metrics are statistical calculations based on SPL searches that represent the overall health of entities of that type. See [Entity Type Vital Metrics](https://help.splunk.com/en/splunk-it-service-intelligence/splunk-it-service-intelligence/leverage-rest-apis/4.21/itsi-rest-api-schema/itsi-rest-api-schema#id_76df76d8_0f87_4b90_b28d_1cda9f70b7cc--en__Entity_Type_Vital_Metrics). *(nested: `entity_type_vital_metrics`)* |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## Event Management State (`event_management_state`)
+
+**Endpoint:** `/event_management_interface/event_management_state`  
+
+The `event_management_state` object stores user settings for custom saved views of Episode Review. For instructions to save custom views through the UI, see [Save a custom view of Episode Review](https://help.splunk.com/?resourceId=ITSI_EA_CustomizeEpisode) in the _User Manual_.
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `_key` | string | - | The unique ID for Episode Review view in the KV store. |
+| `title` | string | - | A user-defined name for the custom episode review. |
+| `earliest` | string | - | The earliest time for the main search in the Episode Review custom view. |
+| `latest` | string | - | The latest time for the main search in the Episode Review custom view. |
+| `fetchLimit` | integer | - | The maximum number of notable events to fetch in a single request. |
+| `sortField` | string | - | The field in the data (column in Episode Review) to sort notable events by. |
+| `sortDirection` | string | - | Whether to sort notable events in ascending or descending order. |
+| `arbitrarySearch` | string | - | The Splunk search string used to filter raw notable events. |
+| `filterCollection` | array | - | A set of filters that represent the Episode Review page filters. |
+| `viewingOption` | string | - | Whether to display notable events as standard or prominent mode in Episode Review. |
+| `eventDeduplication` | boolean | - | If true, episode view is turned on. Otherwise individual notable events are displayed. |
+| `columnsShown` | array | - | A list of fields in the data (columns in Episode Review) to display. |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## Glass Table (`glass_table`)
+
+**Endpoint:** `/itoa_interface/glass_table`  
+
+ITSI glass tables are custom visualizations that let you monitor KPI search results. `glass_table` objects define all widgets and drawing elements that appear in the glass table.
+
+**Subordinate objects:** `glass_table_widget_configuration`, `glass_table_icon`
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `_key` | string | - | Unique identifier for this glass table. |
+| `title` | string | yes | Name of this glass table. |
+| `description` | string | - | User-defined description for this glass table. |
+| `object_type` | string | read-only | glass_table. |
+| `latest` | string | - | Latest time for all of the widget searches on the glass table. |
+| `latest_label` | string | - | Latest label displayed in the glass table instant picker. Matches latest attribute. |
+| `svg_coordinates` | string | - | x and y viewbox offsets for the glass table. |
+| `content` | array | - | Array of JSON structures containing all attributes needed to draw the glass table. See Glass Table Widget Configuration. |
+| `is_epoch` | boolean | - | True when the glass table uses a custom (non-preset) time, false otherwise. |
+| `templateSelectedServiceId` | string | - | The id of the service currently in focus if templatization is enabled. |
+| `templateSwappableServiceIds` | array | - | The array of services available to be swapped to for templatization. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## Service Analyzer (`home_view`)
+
+**Endpoint:** `/itoa_interface/home_view`  
+
+Service Analyzer is the ITSI UI home page. It displays service and KPI health scores that are trending at top severity levels. You can configure Service Analyzer to filter the display of services and KPIs relevant to the user. The Service Analyzer object is called `home_view`.
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `_key` | string | - | Unique ID for the entry in KV store. |
+| `object_type` | string | read-only | home_view |
+| `-owner` | string | - | User that creates the saved service analyzer. |
+| `title` | string | - | User given title for the service analyzer. |
+| `earliest_time` | string | - | Earliest time for the searches. |
+| `latest_time` | string | - | Latest time for the searches. |
+| `serviceWhitelist` | string | - | List of filtered services. |
+| `kpiWhitelist` | string | - | List of filtered kpis. |
+| `isServiceFilterEnabled` | boolean | - | True if services are filtered, false by default. |
+| `isKpiFilterEnabled` | string | - | True if kpis are filtered, false by default. |
+| `serviceTilesSettings` | object | - | SeverityTilesSettingModel with number of kpi tiles and filter. |
+| `view` | string | - | Determines if service analyzer view is standard or full screen. Standard is default. |
+| `isDefault` | string | - | True if it is the default (standard) service analyzer, false otherwise. |
+| `titleSize` | string | - | medium\\|large\], large by default. |
+| `searchType` | string | - | maxseverity\] \[aggregate\\|maxseverity\] aggregate shows the most recent service value and the max severity is service value unless there is an entity value with worst severity. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## KPI Base Search (`kpi_base_search`)
+
+**Endpoint:** `/itoa_interface/kpi_base_search`  
+
+Searches that can be aggregated together to reduce overall search load. KPI Base Searches include the core attributes of a KPI for search generation. `kpi_base_search` objects are contained within the KPI (`kpis`) object data structure.
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `entity_alias_filtering_fields` | string | - | The fields to filter on. See KPI definition. |
+| `_version` | string | read-only | ITSI version number of this KPI base search. |
+| `description` | string | - | General description for this KPI base search. |
+| `mod_source` | string | read-only | Source of the last modification. |
+| `mod_time` | string | read-only | The time of the last modification based on UTC time zone. |
+| `is_service_entity_filter` | boolean | - | If true a filter is used on the search based on the entities included in the service. |
+| `actions` | string | - |  |
+| `object_type` | string | read-only | kpi_base_search |
+| `is_entity_breakdown` | boolean | - | Determines if search breaks down by entities. |
+| `_owner` | string | read-only | KV store owner. |
+| `source_itsi_da` | string | - | Source of DA used for this search. See KPI Threshold Templates. |
+| `metrics` | array | - | Set of statistical operations performed on threshold field. |
+| `aggregate_statop` | string | - | Statistical operation (avg, max, median, stdev, and so on) used to combine data for the aggregate alert_value (used for all KPI). |
+| `unit` | string | - | User-defined units for the values in threshold field. |
+| `title` | string | yes | Name of this metric |
+| `_key` | string | - | Internal identifier. |
+| `threshold_field` | string | - | The field on which the statistical operation runs. |
+| `entity_statop` | string | - | Statistical operation (avg, max, mean, and so on) used to combine data for alert_values on a per entity basis (used if is_entity_breakdown is true). |
+| `search_alert_earliest` | string | - | Earliest time to look for events every time KPI search runs. This determines how far back each time window is during KPI search runs. |
+| `alert_period` | string | - | User specified interval to run the KPI search in minutes. |
+| `alert_lag` | string | - | Contains the number of seconds of lag to apply to the alert search, max is 30 minutes (1800 seconds). |
+| `base_search` | string | - | KPI search defined by user for this KPI. All generated searches for the KPI are based on this search. |
+| `entity_id_fields` | string | - | Fields from this KPI's search events that will be mapped to the alias fields defined in entities for the service containing this KPI. This field enables the KPI search to tie the aliases of entities to the fields from the KPI events in identifying entities at search time. |
+| `identifying_name` | string | read-only | Internal only |
+| `mod_timestamp` | string | read-only | Timestamp of last modification based on UTC time zone. |
+| `acl` | object | read-only | Access control blob. |
+| `_user` | string | read-only | Like owner, but different. |
+| `sec_grp` | string | - | The team the object belongs to. This object can only belong to default_itsi_security_group (Global team). |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## KPI Threshold Templates (`kpi_threshold_template`)
+
+**Endpoint:** `/itoa_interface/kpi_threshold_template`  
+
+A `kpi_threshold_template` is a set of predefined threshold values that you can apply to multiple KPIs.
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `title` | string | yes | Name of this template. |
+| `description` | string | - | Description of this particular template. |
+| `adaptive_thresholding_training_window` | string | - | Earliest time for the adaptive threshold training algorithm to run over. The latest time is always `now`. |
+| `time_variate_thresholds` | boolean | - | If true, thresholds for alerts are pulled from time_variate_thresholds_specification. |
+| `time_variate_thresholds_specification` | object | - | Data structure for time variate threshold specification. |
+| `adaptive_thresholds_is_enabled` | boolean | - | If true, adaptive thresholding is enabled for this KPI. |
+| `sec_grp` | string | - | The team the object belongs to. This object can only belong to default_itsi_security_group (Global team). |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## Maintenance Calendar (`maintenance_calendar`)
+
+**Endpoint:** `/maintenance_services_interface/maintenance_calendar`  
+
+Use `maintenance_calendar` to put services and entities in maintenance mode at required intervals.
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `_key` | string | - | Unique ID for the entry in the KV store. |
+| `title` | string | - | Title of the maintenance window. |
+| `comment` | string | - | Optional description of the maintenance window. |
+| `objects` | array | - | Array of dictionaries describing the objects put in maintenance by this maintenance window. The schema for each object definition in the array: `_key`: Unique if assigned to the object currently. `object_type`: Type of object being identified. Currently only `entity` and `service` are supported. |
+| `start_time` | string | - | Timestamp that marks the beginning of maintenance window. Based on UTC time. |
+| `end_time` | string | - | Timestamp that marks the end of maintenance window. Based on UTC time. |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## Notable Event Aggregation Policy (`notable_event_aggregation_policy`)
+
+**Endpoint:** `/event_management_interface/notable_event_aggregation_policy`  
+
+`notable_event_aggregation_policy` contains the data for a notable event aggregation policy which aggregates notable events into episodes.
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `disabled` | boolean | - | `1` if the aggregation policy is disabled and `0` if enabled. |
+| `breaking_criteria` | object | - | A JSON blob of all the criteria used to break an episode. |
+| `filter_criteria` | object | - | A JSON blob of all the criteria used to filter events into an episode. |
+| `is_default` | boolean | - | Indicates if this is the default aggregation policy. `1` if it's the default policy and `0` if not. |
+| `description` | string | - | The description of the notable event aggregation policy. |
+| `group_severity` | string | - | The default severity of each episode created by the notable event aggregation policy. |
+| `group_status` | string | - | The default status of each episode created by the notable event aggregation policy. |
+| `group_asignee` | string | - | The default owner of each episode created by the notable event aggregation policy. |
+| `group_description` | string | - | The default description of each episode created by the notable event aggregation policy. |
+| `title` | string | - | The title of the notable event aggregation policy. |
+| `rules` | array | - | An array of all the rules and actions to be executed for the notable event aggregation policy. |
+| `split_by_field` | string | - | A string containing all the fields to split episodes by. |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## Notable Event Comment (`notable_event_comment`)
+
+**Endpoint:** `/event_management_interface/notable_event_comment`  
+
+`notable_event_comment` contains comments associated with an episode.
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `comment` | string | - | The text of the comment. |
+| `event_id` | string | - | The episode ID that the comment is associated with. |
+| `is_group` | boolean | - | The episode ID that the comment is associated with. |
+| `filter_search` | string | - | The search to retrieve all the comments for an episode. |
+| `earliest_time` | string | - | The time, in UTC, of the first event in the episode. |
+| `latest_time` | string | - | The time, in UTC, of the last event in the episode. |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## Notable Event Email Template (`notable_event_email_template`)
+
+**Endpoint:** `/event_management_interface/notable_event_email_template`  
+
+`notable_event_email_template` contains the data for email templates for episode actions. Once you create a template it's available for selection in all aggregation policies and is not policy-specific.
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `title` | string | - | The name of the message template. This element is required. |
+| `message` | string | - | The body of the email. Supports tokens such as `$result.title$` and `$result.description$`. This element is required. |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## Notable Event Group (`notable_event_group`)
+
+**Endpoint:** `/event_management_interface/notable_event_group`  
+
+The `notable_event_group` contains information about an episode.
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `severity` | string | - | The level of importance of the episode. Values must match an integer specified in the default version of `itsi_notable_event_severity.conf` (or the local version if you created one). Default values: `1` \- Info `2` \- Normal `3` \- Low `4` \- Medium `5` \- High `6` \- Critical |
+| `status` | string | - | The triage status of the episode in Episode Review. Values must match an integer specified in the default version of `itsi_notable_event_status.conf` (or the local version if you created one). Default values: `0` \- Unassigned `1` \- New `2` \- In Progress `3` \- Pending `4` \- Resolved `5` \- Closed |
+| `owner` | string | - | The Splunk user who is the owner of the episode. |
+| `_key` | string | - | The episode ID that a change is associated with. |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## Service (`service`)
+
+**Endpoint:** `/itoa_interface/service`  
+
+An ITSI service is a representation of a real world IT service. You can configure an ITSI service to monitor various IT metrics using KPI searches, which reflect the health of a service. ITSI services can describe any real world IT service, such as a network service or email service. The `service` object contains the service definition, including entities, KPIs, and dependent services.
+
+**Subordinate objects:** `entity_rules`, `service_kpi`
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `_key` | string | - | Auto-generated unique identifier for this service. |
+| `description` | string | - | User defined description for the service. |
+| `title` | string | yes | Title of this service. |
+| `kpis` | array | - | Array of KPI descriptions for this service. *(nested: `service_kpi`)* |
+| `entity_rules` | array | - | Array of rules describing entities referenced by this service. *(nested: `entity_rules`)* |
+| `services_depends_on` | array | - | Array of service descriptions with KPIs in those services that this service depends on. |
+| `service_id` | string | - | _key value of service that this service depends on. |
+| `kpis_depending_on` | array | - | Array of _key ids for each KPI in service identified by serviceid, which this service will depend on. |
+| `services_depending_on_me` | array | - | An array of service descriptions with KPIs in this service that those services depend on. |
+| `serviceid` | string | - | _key value of service that depends on this service. |
+| `enabled` | boolean | - | If set to 1, service is enabled. If value is absent or not set to 1, service is disabled. On upgrade service is flagged as enabled. |
+| `sec_grp` | string | - | The team the object belongs to. |
+| `base_service_template_id` | string | - | The ID of the service template the service is linked to. Not required. If empty, the service is not linked to a service template. To create a service based on a service template, include this field. |
+| `service_tags` | object | - | The tags for the service. The `service_tags` object can have an array for `tags` and `template_tags`. `tags` are regular tags that are added manually and `template_tags` are tags that are populated from a service template. Tags have to be strings and can't contain the following characters: `/ \ " ' ! @ ? . , ; $ ^` Example `service_tags` object: JSONCopy ```json "service_tags": { "tags": [ "unix", "seattle" ], "template_tags": [ "cloud_systems", "us-west" ] }, ``` |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## Team (`team`)
+
+**Endpoint:** `/itoa_interface/team`  
+
+Teams are used to restrict service-level information in the following objects: - Glass tables - Service analyzers - Deep dives - Episode Review - Correlation searches - Multi-KPI alerts The team object is called `team`.
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `identifying_name` | string | read-only | The name of the team. Does not have to match `title`. |
+| `acl` | object | read-only | Access control list for the team. Must include itoa_admin. |
+| `title` | string | yes | User provided name of the team. Does not have to match `identifying_name`. |
+| `description` | string | - | User provided description of the team. |
+| `children` | array | - | List of private teams created in ITSI. For private teams, this field will be an empty list. |
+| `parents` | array | - | The parent of this team. Cannot be configured in current release. |
+| `_key` | string | - | Unique ID for the entry in KV store. |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+---
+
+# Subordinate structure schemas
+
+## Anomaly Detection Algorithm Settings (`anomaly_detection_algorithm_settings`)
+
+**Kind:** subordinate (nested) structure  
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `Sensitivity` | integer | - | Determines sensitivity of algorithm to variance in data. Note that acceptable values for both trending and cohesive algorithm sensitivity are between 0 and the `sensitivity_max` parameter value, as specified in the respective `[trending:limits]`and `[cohesive:limits`\] stanzas, in `mad.conf` in the `SA-ITSI-MetricAD` namespace. |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## Deep Dive Lane Setting (`deep_dive_lane_setting`)
+
+**Kind:** subordinate (nested) structure  
+
+Configuration settings that define what information a deep dive lane shows. Deep dive views use these settings for per lane configuration.
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `title` | string | - | Name of the lane to display. |
+| `subtitle` | string | - | The subtitle of the lane to display. |
+| `laneType` | string | - | The type of lane to render. Possible values: event, kpi, metric (the default). |
+| `graphType` | string | - | The type of graph to render |
+| `search` | string | - | The search to use to get data for the lane. |
+| `searchSource` | string | - | Represents how a search is generated. Possible values: datamodel, ad hoc search, or kpi search. |
+| `dataModelSpecification` | object | - | An object showing the selections that went into the generation of the search, null unless searchSource is data model. If defined, it is structured as {datamodel: <Data Model name> object: <Object Name>, field: <Field Info Data Structure>. |
+| `dataModelStatOp` | string | - | Stats operation used in the data model search. |
+| `dataModelWhereClause` | string | - | Where clause defined during data model search creation. |
+| `overwriteKpiTitle` | string | - | Overwrite KPI title with user specified title. |
+| `overwriteEntityTitle` | string | - | Overwrite Entity title with user specified title. |
+| `kpiTitle` | string | - | The original title of the KPI as defined in the KPI model. |
+| `kpiServiceId` | string | - | The id of the service associated with the selected KPI. |
+| `kpiUnit` | string | - | The unit of the KPI driving this lane. |
+| `kpiAddToSummary` | string | - | Add or remove from kpi summary based on user selection. \[yes, no\] Yes runs the search against kpi summary index and no runs raw search. |
+| `kpiStatsOp` | string | - | Stats operation to calculate the KPI value, avg by default \[avg, max, min, median\]. |
+| `entityAddToSummary` | string | - | Shows the accelerated output for entity lanes. Always set to "yes." |
+| `thresholdIndicationEnabled` | string | - | Enable/disable threshold indication. Disabled by default. |
+| `thresholdIndicationType` | string | - | Type of threshold indication. \[foreground/background\] Foreground selected by default. |
+| `hideGraph` | string | - | Only available with background threshold indications. If selected, hides the graph and only shows the top view with background thresholds \[yes, no\]. |
+| `verticalAxisScale` | string | - | Determines the scale of the y axis. It is linear or log. |
+| `verticalAxisBoundaryType` | string | - | Determine the extent of the y axis. It is staticValue, value, or zeroValue. |
+| `verticalAxisStaticBounds` | object | - | If static, these are the bounds to use. Otherwise this is ignored. This is an object of the form\[<min number>, <max number>\]. |
+| `dataGaps` | string | - | null values in the data can be represented as gaps or connected through the graph. |
+| `graphColor` | string | - | The color of the graph to render. |
+| `graphSeries` | string | - | The field in the data which to plot as the range, if unspecified plots all. |
+| `excludeSeries` | string | - | The series of data to omit from being displayed in graph. Series with a leading _ (indicating internal use) is always excluded. |
+| `laneOverlaySettingsModel` | object | - | Model to define the overlay lane settings. |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## Entity Rules (`entity_rules`)
+
+**Kind:** subordinate (nested) structure  
+
+`entity_rules` determine the specific entities that a KPI monitors in a service. This includes entities directly identified by title, and entities identified by regular expression-based rules.
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `rule_condition` | string | - | Uses the value AND indicating this rule appends all nested rules contained in the `rule_items` attribute. |
+| `rule_items` | array | - | Array of rules that are appended within a rule group. |
+| `field` | string | - | The field in the entity definition to compare values to evaluate this rule. |
+| `rule_type` | string | - | Takes values `not` or `matches` to indicate whether it's an inclusion or exclusion rule. Value can be `matchesblank` or `doesnotmatchblank` when used with service templates. |
+| `value` | string | - | Values to evaluate in the rule. To specify multiple values, separate them with a comma. Values are not case sensitive. |
+| `field_type` | string | - | Takes values `alias` or `info` specifying in which category of fields the `field` attribute is located. |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## Entity Type Dashboard Drilldown (`entity_type_dashboard_drilldown`)
+
+**Kind:** subordinate (nested) structure  
+
+A `dashboard_drilldown` lists the dashboards associated with an entity and its entity type.
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `title` | string | - | The name of the dashboard. |
+| `id` | string | - | A unique identifier for the dashboard. |
+| `base_url` | string | - | An internal or external URL that points to the dashboard. This setting exists because for internal purposes, navigation suggestions are treated as dashboards. This setting is only required if `is_splunk_dashboard` is `false`. |
+| `is_splunk_dashboard` | boolean | - | `true` if the dashboard is a Splunk XML dashboard. If it's another dashboard type such as a JSON dashboard from the Splunk Dashboards app, or if it's a navigation link, this value is `false`. |
+| `dashboard_type` | string | - | The type of dashboard being added. This element is required. The following options are available: - `xml_dashboard` \- a Splunk XML dashboard. Any dashboards you add must be of this type. - `navigation_link` \- a navigation URL. Should be used when `base_url` is specified. |
+| `params` | object | - | A set of parameters for the entity dashboard drilldown that provide a mapping of a URL parameter and its alias and static parameters. |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## Entity Type Data Drilldown (`entity_type_data_drilldown`)
+
+**Kind:** subordinate (nested) structure  
+
+A `data_drilldown` is a basic unit of configuration for an entity type. Entity data drilldown specifies filters that correlate raw data in Splunk indexes with an entity.
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `title` | string | - | Name of the drilldown. |
+| `type` | string | - | Type of raw data to associate with. Must be either `metrics` or `events`. |
+| `static_filter` | object | - | Filter down to a subset of raw data associated with the entity using static information like sourcetype. |
+| `entity_field_filter` | array | - | Further filter down to the raw data associated with the entity based on a set of selected entity alias or informational fields. |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## Entity Type Vital Metrics (`entity_type_vital_metrics`)
+
+**Kind:** subordinate (nested) structure  
+
+`vital_metrics` are a basic unit of configuration for an entity type. Vital metrics are statistical calculations based on SPL searches that represent the overall health of entities of that type.
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `metric_name` | string | - | The title of the vital metric. When creating vital metrics, it's a best practice to include the aggregation method and the name of the metric being calculated. For example, `Average CPU usage`. |
+| `search` | string | - | The search that computes the vital metric. The search must specify the following fields: - `val` for the value of the metric. - `_time` because the UI attempts to render changes over time. You can achieve this by adding `span={time}` to your search. - Fields as described in the `split_by_fields` configuration of this vital metric. For example, your search should be split by `host,region` if the `split_by_fields` configuration is \[ "host", "region" \]. |
+| `split_by_fields` | array | - | The fields that the `search` configuration is split on. Make sure the value matches the split by fields in the actual search. For example: search = "..... by host, region" split_by_fields = \["host", "region"\] |
+| `matching_entity_fields` | array | - | Specifies the aliases of an entity to use to match with the fields specified by `split_by_fields` in the search result. The order of values should match the order of split_by_fields and the mapping is 1 to 1, so they must be of the same length. For example: split_by_fields = \["InstanceId", "region"\] matching_entity_fields = \["instance_id, zone"\] Note: You can only use entity aliases for this field, not informational fields |
+| `is_key` | boolean | - | Indicates if the vital metric specified is a key metric. A key metric calculates the distribution of entities associated with the entity type to indicate the overall health of the entity type. The key metric is rendered as a histogram in the Infrastructure Overview. Only one vital metric can have `is_key` set to `true`. |
+| `unit` | string | - | The unit of the vital metric. For example, `KB/s`. |
+| `alert_rule` | object | - | Displays vital metric alert threshold information. The following parameters are displayed: - `suppress_time`: suppress the alert until this time - `cron_schedule`: frequency of alert search - `is_enabled`: if alert is enabled - `critical_threshold`: range of values that indicate critical severity level - `warning_threshold`: range of values that indicate warning severity level - `info_threshold`: range of values that indicate info severity level - `entity_filter`: filter entities based on the field dimensions For example: entity_filter: \[{"field":"os", "value":"Ubuntu", "field_type":"info"}\] |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## Event Management Export (`event_management_export`)
+
+**Kind:** subordinate (nested) structure  
+
+itsi\_event\_management\_export contains information about an episode.
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `export_filename` | string | - | The file name for the new file export. |
+| `object_type` | string | read-only | event_management_export |
+| `status` | string | - | The status of the CSV file export: started, in progress, failed, completed. |
+| `_owner` | string | read-only | The Splunk user who owns the CSV file. |
+| `_key` | string | - | A unique identifier to determine the CSV file object. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## Glass Table Icon (`glass_table_icon`)
+
+**Kind:** subordinate (nested) structure  
+
+Contains SVG icon definitions and metadata for glass table icons.
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `_key` | string | - | Auto-generated unique identifier for this icon. |
+| `title` | string | - | Name of the icon. |
+| `category` | string | - | Category of the icon. |
+| `default_width` | integer | - | Width of the icon. |
+| `default_height` | integer | - | Height of the icon. |
+| `svg_path` | string | - | SVG path defining shape of the icon. |
+| `immutable` | boolean | - | Should the REST API allow editing of this icon. False for all icons imported from .conf files. |
+| `_time` | string | - | Timestamp when the icon was added. |
+| `_owner` | string | read-only | Name of the user that added this icon. |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## Glass Table Widget Configuration (`glass_table_widget_configuration`)
+
+**Kind:** subordinate (nested) structure  
+
+Glass Table Widget Configuration (`content`) is an array of JSON structures that contains all of the attributes needed to render the glass table. Each element of the array represents one glass table widget, and the attributes of the element are parsed into a glass table BaseWidgetViewManager object.
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `search` | string | - | The search to power the widget. |
+| `labelVal` | string | - | The text to show in the label located beneath the widget. |
+| `labelFlag` | boolean | - | True if labelVal is to be shown with the widget, false otherwise. |
+| `vizType` | integer | - | Numeric indication of which visualization type the widget is - SingleValue, Gauge, Sparkline, SVD from 0-3, respectively |
+| `threshold_field` | string | - | Field in data to which thresholds apply. |
+| `threshold_comparator` | string | - | Comparator used for threshold severity computation |
+| `threshold_values` | array | - | Array of values to indicate the bounds of the thresholds set for the widget. |
+| `threshold_labels` | array | - | Array of labels to match the threshold values set for the widget. |
+| `context_id` | string | - | Id of service to which the widget's KPI belongs. |
+| `kpi_id` | string | - | Id of KPI the widget represents |
+| `searchSource` | string | - | Source of search for glass table widget - can be datamodel or ad hoc. |
+| `dataModelSpecification` | string | - | Data model specification for the datamodel search. |
+| `dataModelStatOp` | string | - | Datamodel stats operation for the datamodel search. |
+| `dataModelWhereClause` | string | - | Datamodel where clause for the datamodel search. |
+| `threshold_eval` | string | - | Threshold eval search clause for threshold severity evaluation. |
+| `aggregate_eval` | string | - | Aggregate eval search clause for threshold severity evaluation. |
+| `base_search` | string | - | Base search of the KPI the widget represents. |
+| `search_alert_earliest` | string | - | Earliest time for the search that powers the widget. |
+| `entities` | string | - | List of entities that the widget's KPI contains. |
+| `search_aggregate` | string | - | Aggregate search of the KPI the widget represents. |
+| `search_time_series_aggregate` | string | - | Time series search of the KPI the widget represents |
+| `search_time_compare` | string | - | Compare time series search of the KPI the widget represents (for the SVD viz type). |
+| `search_type` | string | - | Type of search the widget is powered by. Must match one of the search_\* attributes of the widget. |
+| `relativeEarliest` | string | - | Earliest time (in relative units) for the search that powers the widget. |
+| `defaultWidth` | integer | - | Initial width to use for the widget. |
+| `defaultHeight` | integer | - | Initial height to use for the widget. |
+| `existingKPI` | boolean | - | True if KPI exists in user's system, false otherwise. |
+| `alert_on` | string | - | Threshold alert type (aggregate or entities) of the KPI the widget represents. |
+| `isThresholdEnabled` | boolean | - | True if thresholds should be applied to the widget's search results, false otherwise. |
+| `useKPISummary` | boolean | - | true if widget uses the kpi_summary_index to power its search, false otherwise. |
+| `unit` | string | - | Unit string for widget to display. |
+| `gap_severity` | string | - | Gap severity value of the KPI the widget represents. |
+| `gap_severity_color` | string | - | Gap severity color of the KPI the widget represents. |
+| `drilldownSettingsModel` | string | - | Model to hold properties required for generating URLs for custom drilldown. |
+| `useCustomDrilldown` | boolean | - | True if widget has custom drilldown turned on, false otherwise. |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## KPI Threshold Levels (`kpi_threshold_levels`)
+
+**Kind:** subordinate (nested) structure  
+
+KPI Threshold Levels determine how ITSI extracts health status information from KPI searches. Threshold levels are user-configured values that can be augmented further using adaptive thresholding.
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `thresholdValue` | integer | - | Value for the threshold field stats identifying this threshold level. This is the key value that defines the levels for values derived from the KPI search metrics. |
+| `severityColor` | string | - | Severity color assigned for this threshold level. |
+| `severityColorLight` | string | - | Severity light color assigned for this threshold level. |
+| `severityValue` | integer | - | Severity value assigned for this threshold level. |
+| `severityLabel` | string | - | Severity label assigned for this threshold level like info, warning, critical, etc. |
+| `dynamicParam` | integer | - | Value of the dynamic parameter for adaptive thresholds. |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## KPI Threshold Settings (`kpi_threshold_settings`)
+
+**Kind:** subordinate (nested) structure  
+
+KPI Threshold Settings define the thresholds that a KPI uses to compute health status information. KPI Threshold Settings also contain information for rendering KPI threshold graphs.
+
+**Subordinate objects:** `kpi_threshold_levels`
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `gaugeMin` | integer | - | Minimum value for the threshold gauge specified by user. |
+| `gaugeMax` | integer | - | Maximum value for the threshold gauge specified by user. |
+| `search` | string | - | Generated search used to compute the thresholds for this KPI. |
+| `baseSeverityValue` | integer | - | Value for base threshold level. |
+| `baseSeverityColor` | string | - | Severity color assigned for the base threshold level. |
+| `baseSeverityColorLight` | string | - | Severity light color assigned for the base threshold level. |
+| `baseSeverityLabel` | string | - | Severity label assigned for the base threshold level, including info, warning, critical, etc. |
+| `metricField` | string | - | Thresholding field from the search. |
+| `renderBoundaryMin` | integer | - | Lower bound value to use to render the graph for the thresholds. |
+| `renderBoundaryMax` | integer | - | Upper bound value to use to render the graph for the thresholds. |
+| `isMaxStatic` | boolean | - | True when maximum threshold value is a static value, false otherwise. |
+| `isMinStatic` | boolean | - | True when min threshold value is a static value, false otherwise. |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## Service KPI (`service_kpi`)
+
+**Kind:** subordinate (nested) structure  
+
+KPI is the data structure that drives the monitoring of service metrics. Each KPI object contains specific information, including a user-configured base search, from which ITSI generates the search that monitors a metric. KPI objects also contain information on how to apply thresholds that determine the metric severity level. KPI objects (`kpis`) are defined and contained within the `service` object type data structure.
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `_key` | string | - | Auto-generated unique ID for this KPI. |
+| `title` | string | - | User-defined name for the KPI |
+| `description` | string | - | User-defined description for the KPI. |
+| `type` | string | - | kpi_primary |
+| `kpi_threshold_template_id` | string | - | User-defined ID for the KPI. Used to refer to KPIs within a KPI template in modules. This uniquely identifies a KPI template in ITSI. |
+| `isadhoc` | boolean | - | If true the search is split on entities and thresholds are computed for both entity and aggregate. |
+| `is_service_entity_filter` | boolean | - | If true a filter is used on the search based on the entities included in the service. |
+| `datamode` | string | - | The data model to use for search generation if this is a data model type search. |
+| `datamodel_filter` | array | - | ITSI generated clauses for user-defined filters on top of the data model fields. Used in the KPI search to filter events required by this KPI. |
+| `threshold_field` | string | - | User-specified field on which statistical operations are performed and whose value determines KPI health. |
+| `entity_statop` | string | - | Statistical operation (avg, max, mean, and so on) used to combine data for alert_values on a per entity basis (used if entity_breakdown is true). |
+| `aggregate_statop` | string | - | Statistical operation (avg, max, median, stdev, and so on) used to combine data for the aggregate alert_value (used for all KPI). |
+| `urgency` | integer | - | User-assigned importance value for this KPI. |
+| `unit` | string | - | User-defined units for the values in threshold field. |
+| `entity_id_fields` | string | - | Fields from this KPI's search events that will be mapped to the alias fields defined in entities for the service containing this KPI. This field enables the KPI search to tie the aliases of entities to the fields from the KPI events in identifying entities at search time. |
+| `entity_alias_filtering_fields` | string | - | Subset of aliases from all entities included in the service containing this KPI, to restrict this KPI to only the subset of entities matching via the subset of aliases. Helps filter entities for this KPI among the ones selected in the service containing this KPI. |
+| `cron_schedule` | string | - | The cron schedule that determines the frequency of this KPI search. |
+| `base_search` | string | - | KPI search defined by user for this KPI. All generated searches for the KPI are based on this search. |
+| `kpi_base_search` | string | - | A basic search generated for the KPI search. |
+| `search` | string | - | Generated search for this KPI for base statistics on the threshold field. |
+| `search_entities` | string | - | Generated search for this KPI for base statistics on the threshold field to use for "Per Entity" threshold type. |
+| `search_aggregate` | string | - | Generated search for this KPI for base statistics on the threshold field to use for "Aggregate" or "Both" threshold type. |
+| `search_time_series` | string | - | Generated search used primarily to show preview information in the KPI configuration page. |
+| `search_time_series_entities` | string | - | Generated search used primarily to show preview information for "Per Entity" threshold type in the KPI configuration page |
+| `search_time_series_aggregate` | string | - | Generated search used primarily to show preview information for "Aggregate" or "Both" threshold type in the KPI configuration page. |
+| `search_time_compare` | string | - | Generated search used specifically by glass table. |
+| `search_alert` | string | - | Generated search used for alerting based on KPI threshold. This is the search that runs on schedule via the saved search for this KPI. |
+| `search_alert_entities` | string | - | Generated search to use for alerting based on KPI threshold for "Per Entity" threshold type. |
+| `alert_on` | string | - | Specified if the threshold type for this KPI is "Per Entity" or "Aggregate" or "Both". Possible values: aggregate, entities, both. |
+| `alert_period` | string | - | User specified interval to run the KPI search in minutes. |
+| `alert_lag` | integer | - | Contains the number of seconds of lag to apply to the alert search. The maximum value is 30 minutes (1800 seconds). |
+| `search_alert_earliest` | string | - | Earliest time to look for events every time KPI search runs. This determines how far back each time window is during KPI search runs. |
+| `tz_offset` | string | - | ISO time zone offset. Note: Do not change this value. |
+| `time_variate_thresholds` | boolean | - | If true, thresholds for alerts are pulled from time_variate_thresholds_specification. |
+| `time_variate_thresholds_specification` | object | - | Data structure for time variate threshold specs. *(nested: `time_variate_thresholds_specification`)* |
+| `backfill_enabled` | boolean | - | Indicates if backfill has been enabled for this KPI |
+| `backfill_earliest_time` | string | - | Requested earliest time for backfill (relative time offset). Should be in the format `-Xd`, where 'd' means the time is in days, 'X' is number of days to backfill, and '-' means the date is in the past. |
+| `adaptive_thresholds_is_enabled` | boolean | - | Determines if adaptive threshold is enabled for this KPI. |
+| `adaptive_thresholding_training_window` | string | - | Earliest time for the Adaptive Threshold training algorithm to run over (latest time is always 'now') (e.g. '-7d') |
+| `anomaly_detection_is_enabled` | boolean | - | Determines if trending anomaly detection is enabled. |
+| `cohesive_anomaly_detection_is_enabled` | boolean | - | Determines if cohesive anomaly detection is enabled. |
+| `anomaly_detection_alerting_enabled` | boolean | - | Determines if anomaly detection will alert for anomalies. |
+| `anomaly_detection_training_window` | string | - | Earliest time for the training algorithm to run over (latest time is always 'now') (e.g. '-7d'). |
+| `trending_ad` | object | - | Data structure for trending anomaly detection algorithm settings. See [Anomaly Detection Algorithm Settings](https://help.splunk.com/en/splunk-it-service-intelligence/splunk-it-service-intelligence/leverage-rest-apis/4.21/itsi-rest-api-schema/itsi-rest-api-schema#id_4278bd48_f68a_48ce_8396_b710dc0c3eb2--en__Anomaly_Detection_Algorithm_Settings). *(nested: `anomaly_detection_algorithm_settings`)* |
+| `cohesive_ad` | object | - | Data structure for cohesive anomaly detection algorithm settings. See [Anomaly Detection Algorithm Settings](https://help.splunk.com/en/splunk-it-service-intelligence/splunk-it-service-intelligence/leverage-rest-apis/4.21/itsi-rest-api-schema/itsi-rest-api-schema#id_4278bd48_f68a_48ce_8396_b710dc0c3eb2--en__Anomaly_Detection_Algorithm_Settings). *(nested: `anomaly_detection_algorithm_settings`)* |
+| `gap_severity` | string | - | Severity level assigned for data gaps (info, normal, low, medium, high, critical, or unknown) |
+| `gap_severity_color` | string | - | Severity color assigned for data gaps. |
+| `gap_severity_color_light` | string | - | Severity color assigned for data gaps. |
+| `gap_severity_value` | string | - | Severity value assigned for data gaps. |
+| `entity_thresholds` | object | - | User-defined thresholding levels for "Per Entity" threshold type. For more information, see KPI Threshold Setting. *(nested: `kpi_threshold_settings`)* |
+| `aggregate_thresholds` | array | - | User-defined thresholding levels for "Aggregate" threshold type. For more information, see KPI Threshold Setting. *(nested: `kpi_threshold_settings`)* |
+| `enabled` | boolean | - | If set to 1, KPI is enabled. If absent or not set to 1, KPI is disabled. On upgrade KPI is flagged as enabled. Field is read-only. |
+| `base_service_template_id` | string | - | The key of service template object if the KPI is inherited from a service template. |
+| `entity_breakdown_id_field` | string | - | KPI search events are split by the alias field defined in entities for the service containing this KPI. |
+| `aggregate_outlier_detection_enabled` | boolean | - | Indicates if outlier exclusion is turned on for KPI. |
+| `outlier_detection_algo` | string | - | Determines the outlier detection algorithm. |
+| `outlier_detection_sensitivity` | string | - | The trigger threshold of the algorithm. For the standard deviation, this is the number of standard deviations. For interquartile range and mean absolute deviation, this is the sensitivity value. |
+| `recommendation_start_date` | string | - | The date that a KPI threshold recommendation will be applied. |
+| `recommendation_training_window` | string | - | String |
+| `threshold_direction` | string | - | Determines if your KPI should stay above or below a specific value, or constrained to a specific range. |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## Service Template KPI (`service_template_kpi`)
+
+**Kind:** subordinate (nested) structure  
+
+KPI is the data structure that drives the monitoring of service metrics. KPI objects for service templates differ slightly from KPI objects for services. For example, service template KPIs can only use base searches, not ad hoc searches or searches based on data models. You can't enable anomaly detection for service template KPIs. KPI objects, `kpis`, for service templates are defined and contained within the `base_service_template` object type data structure.
+
+**Subordinate objects:** `kpi_threshold_settings`, `time_variate_thresholds_specification`, `anomaly_detection_algorithm_settings`
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `_key` | string | - | Auto-generated unique ID for this KPI. |
+| `title` | string | - | User-defined name for the KPI |
+| `description` | string | - | User-defined description for the KPI. |
+| `type` | string | - | kpi_primary. |
+| `kpi_threshold_template_id` | string | - | User-defined ID for the KPI. Used to refer to KPIs within a KPI template in ITSI modules. This uniquely identifies a KPI template in ITSI. |
+| `is_service_entity_filter` | boolean | - | If true a filter is used on the search based on the entities included in the service. |
+| `datamode` | string | - | The data model to use for search generation if this is a data model type search. |
+| `datamodel_filter` | array | - | ITSI generated clauses for user-defined filters on top of the data model fields. Used in the KPI search to filter events required by this KPI. |
+| `threshold_field` | string | - | User-specified field on which statistical operations are performed and whose value determines KPI health. |
+| `entity_statop` | string | - | Statistical operation (avg, max, mean, and so on) used to combine data for alert_values on a per entity basis (used if entity_breakdown is true). |
+| `aggregate_statop` | string | - | Statistical operation (avg, max, median, stdev, and so on) used to combine data for the aggregate alert_value (used for all KPI). |
+| `urgency` | integer | - | User-assigned importance value for this KPI. |
+| `unit` | string | - | User-defined units for the values in threshold field. |
+| `entity_id_fields` | string | - | Fields from this KPI's search events that will be mapped to the alias fields defined in entities for the service containing this KPI. This field enables the KPI search to tie the aliases of entities to the fields from the KPI events in identifying entities at search time. |
+| `entity_alias_filtering_fields` | string | - | Subset of aliases from all entities included in the service containing this KPI, to restrict this KPI to only the subset of entities matching via the subset of aliases. Helps filter entities for this KPI among the ones selected in the service containing this KPI. |
+| `cron_schedule` | string | - | The cron schedule that determines the frequency of this KPI search. |
+| `base_search` | string | - | KPI search defined by user for this KPI. All generated searches for the KPI are based on this search. |
+| `kpi_base_search` | string | - | A basic search generated for the KPI search. |
+| `alert_on` | string | - | Specified if the threshold type for this KPI is "Per Entity" or "Aggregate" or "Both". Possible values: aggregate, entities, both. |
+| `alert_period` | string | - | User specified interval to run the KPI search in minutes. |
+| `alert_lag` | integer | - | Contains the number of seconds of lag to apply to the alert search. The maximum is 30 minutes (1800 seconds). |
+| `search_alert_earliest` | string | - | Earliest time to look for events every time KPI search runs. This determines how far back each time window is during KPI search runs. |
+| `tz_offset` | string | - | ISO time zone offset. Note: Do not change this value. |
+| `time_variate_thresholds_specification_custom` | boolean | - | If true, thresholds for alerts are pulled from time_variate_thresholds_specification. |
+| `adaptive_thresholds_is_enabled` | boolean | - | Determines if adaptive threshold is enabled for this KPI. |
+| `adaptive_thresholding_training_window` | string | - | Earliest time for the Adaptive Threshold training algorithm to run over (latest time is always 'now') (e.g. '-7d') |
+| `gap_severity` | string | - | Severity level assigned for data gaps (info, normal, low, medium, high, critical, or unknown) |
+| `gap_severity_color` | string | - | Severity color assigned for data gaps. |
+| `gap_severity_color_light` | string | - | Severity color assigned for data gaps. |
+| `gap_severity_value` | string | - | Severity value assigned for data gaps. |
+| `entity_thresholds` | object | - | User-defined thresholding levels for "Per Entity" threshold type. For more information, see KPI Threshold Setting. *(nested: `kpi_threshold_settings`)* |
+| `aggregate_thresholds` | string | - | User-defined thresholding levels for "Aggregate" threshold type. For more information, see KPI Threshold Setting. *(nested: `kpi_threshold_settings`)* |
+| `enabled` | boolean | - | If set to 1, KPI is enabled. If absent or not set to 1, KPI is disabled. On upgrade KPI is flagged as enabled. Field is read-only. |
+| `entity_breakdown_id_field` | string | - | KPI search events are split by the alias field defined in entities for the service containing this KPI. |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |
+
+## Time Variate Thresholds Specification (`time_variate_thresholds_specification`)
+
+**Kind:** subordinate (nested) structure  
+
+This data structure contains the threshold policy collection. A threshold policy includes information on which thresholds are to be applied (a threshold setting model), how those thresholds are generated, and the time periods to which the threshold policy applies. Each policy object includes a single time\_blocks attribute that contains a list of time periods with which the policy is associated. Note: In the case of static thresholding there are no parameter attributes. In the case of dynamic thresholding, parameters are stored in a simple object within the policy.
+
+| Field | Type | Req | Description |
+| --- | --- | --- | --- |
+| `title` | string | - | The title of the threshold spec. Used when creating/modifying threshold spec templates. |
+| `description` | string | - | User-defined description of the threshold specifications. |
+| `policies` | object | - | JSON object keyed by policy ID. |
+| `time_blocks` | array | - | Determines time periods with which the policy is associated. |
+| `object_type` | string | read-only | Name of the object type. |
+| `create_by` | string | read-only | The user who created this object. |
+| `create_source` | string | read-only | The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only. |
+| `create_time` | string | read-only | Timestamp at the time of creation based on UTC time zone. |
+| `mod_source` | string | read-only | Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only. |
+| `mod_time` | string | read-only | Timestamp of the last modification based on UTC time zone. |
+| `_owner` | string | read-only | Splunk user `nobody`. |
+| `_user` | string | read-only | User who performed the most recent operation on this object. |
+| `version` | string | read-only | The version of the object. Currently the same as the ITSI app version. |

--- a/mcp_itsi/knowledge/schema/__init__.py
+++ b/mcp_itsi/knowledge/schema/__init__.py
@@ -1,0 +1,32 @@
+"""Structured ITSI object schemas and payload validation.
+
+This package serves machine-usable schemas (parsed from the ITSI 4.21 REST API
+schema docs) and validates payloads against them so agents can perform CRUD on
+deeply nested ITOA objects reliably.
+
+Public surface:
+
+* :class:`~mcp_itsi.knowledge.schema.models.ObjectSchema`
+* :data:`~mcp_itsi.knowledge.schema.registry.registry` (shared instance)
+* :class:`~mcp_itsi.knowledge.schema.validator.PayloadValidator`
+"""
+
+from __future__ import annotations
+
+from mcp_itsi.knowledge.schema.models import AttributeSpec, ObjectSchema
+from mcp_itsi.knowledge.schema.registry import SchemaRegistry, registry
+from mcp_itsi.knowledge.schema.validator import (
+    PayloadValidator,
+    ValidationIssue,
+    ValidationResult,
+)
+
+__all__ = [
+    "AttributeSpec",
+    "ObjectSchema",
+    "SchemaRegistry",
+    "registry",
+    "PayloadValidator",
+    "ValidationIssue",
+    "ValidationResult",
+]

--- a/mcp_itsi/knowledge/schema/data/anomaly_detection_algorithm_settings.json
+++ b/mcp_itsi/knowledge/schema/data/anomaly_detection_algorithm_settings.json
@@ -1,0 +1,112 @@
+{
+  "slug": "anomaly_detection_algorithm_settings",
+  "title": "Anomaly Detection Algorithm Settings",
+  "kind": "subordinate",
+  "description": "",
+  "object_type": null,
+  "interface": null,
+  "endpoint": null,
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "Sensitivity",
+      "label": "Sensitivity",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Determines sensitivity of algorithm to variance in data. Note that acceptable values for both trending and cohesive algorithm sensitivity are between 0 and the `sensitivity_max` parameter value, as specified in the respective `[trending:limits]`and `[cohesive:limits`\\] stanzas, in `mad.conf` in the `SA-ITSI-MetricAD` namespace.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/base_service_template.json
+++ b/mcp_itsi/knowledge/schema/data/base_service_template.json
@@ -1,0 +1,245 @@
+{
+  "slug": "base_service_template",
+  "title": "Service Template",
+  "kind": "object",
+  "description": "ITSI service templates help you manage shared content for similar services. Services linked to a service template receive content from the service template, such as KPIs and entity rules. You must create a service template from an existing service. The `base_service_template` object contains KPI definitions, entity rules, and any linked services.",
+  "object_type": "base_service_template",
+  "interface": "/itoa_interface",
+  "endpoint": "/itoa_interface/base_service_template",
+  "subordinate_objects": [
+    "entity_rules",
+    "service_template_kpi"
+  ],
+  "attributes": [
+    {
+      "name": "_key",
+      "label": "_key",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Auto-generated unique identifier for this service template.",
+      "subordinate": null
+    },
+    {
+      "name": "description",
+      "label": "description",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User defined description for the service template.",
+      "subordinate": null
+    },
+    {
+      "name": "title",
+      "label": "title",
+      "type": "string",
+      "type_raw": "String",
+      "required": true,
+      "read_only": false,
+      "description": "Title of this service template.",
+      "subordinate": null
+    },
+    {
+      "name": "kpis",
+      "label": "kpis",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "Array of KPI descriptions for this service template.",
+      "subordinate": "service_template_kpi"
+    },
+    {
+      "name": "entity_rules",
+      "label": "entity_rules",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "Array of rules describing entities referenced by this service template.",
+      "subordinate": "entity_rules"
+    },
+    {
+      "name": "service_id",
+      "label": "service_id",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "_key value of the service this service template is generated from.",
+      "subordinate": null
+    },
+    {
+      "name": "sec_grp",
+      "label": "sec_grp",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The team the service template belongs to. Service templates can only belong to default_itsi_security_group (Global team).",
+      "subordinate": null
+    },
+    {
+      "name": "linked_services",
+      "label": "linked_services",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "Array of services linked to this service template. if the user does not have access to all linked services, the linked_services field only contains the services they have read access to.",
+      "subordinate": null
+    },
+    {
+      "name": "total_linked_services",
+      "label": "total_linked_services",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "The number of services linked to this service template.",
+      "subordinate": null
+    },
+    {
+      "name": "last_sync_error",
+      "label": "last_sync_error",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Error message if the last sync operation failed.",
+      "subordinate": null
+    },
+    {
+      "name": "sync_status",
+      "label": "sync_status",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Sync status of service template: \"synced\", \"sync_scheduled\", \"syncing\", \"sync failed\".",
+      "subordinate": null
+    },
+    {
+      "name": "scheduled_time",
+      "label": "scheduled_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The time to push service template changes to linked services if \"sync later\" is selected rather than \"sync now\".",
+      "subordinate": null
+    },
+    {
+      "name": "scheduled_job",
+      "label": "scheduled_job",
+      "type": "object",
+      "type_raw": "Dict",
+      "required": false,
+      "read_only": false,
+      "description": "Sync job detail if \"sync later\" is selected rather than \"sync now\".",
+      "subordinate": null
+    },
+    {
+      "name": "template_tags",
+      "label": "template_tags",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "The service tags contained within the template.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/correlation_search.json
+++ b/mcp_itsi/knowledge/schema/data/correlation_search.json
@@ -1,0 +1,512 @@
+{
+  "slug": "correlation_search",
+  "title": "Correlation Search",
+  "kind": "object",
+  "description": "`correlation_search` contains the data for a correlation search. A correlation search is a recurring search that generates a notable event when search results meet specific conditions. A multi-KPI alert is a type of correlation search.",
+  "object_type": "correlation_search",
+  "interface": "/event_management_interface",
+  "endpoint": "/event_management_interface/correlation_search",
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "is_scheduled",
+      "label": "is_scheduled",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Values: 1 means scheduled; 0 means not scheduled.",
+      "subordinate": null
+    },
+    {
+      "name": "disabled",
+      "label": "disabled",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Values: 1 means disabled; 0 means enabled.",
+      "subordinate": null
+    },
+    {
+      "name": "cron_schedule",
+      "label": "cron_schedule",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Schedule searches to run periodically at fixed times, dates, or intervals using a cron expression. Default value is `*/5* * * *` (every 5 minutes).",
+      "subordinate": null
+    },
+    {
+      "name": "dispatch.earliest_time",
+      "label": "dispatch.earliest_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Indicates the beginning of the time range for the search. The default value is `-15m`.",
+      "subordinate": null
+    },
+    {
+      "name": "dispatch.latest_time",
+      "label": "dispatch.latest_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Indicates the end of the time range for the search. The default value is `-now`.",
+      "subordinate": null
+    },
+    {
+      "name": "description",
+      "label": "description",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "A description of the type of issue the search is intended to detect.",
+      "subordinate": null
+    },
+    {
+      "name": "search",
+      "label": "search",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The Splunk search to run.",
+      "subordinate": null
+    },
+    {
+      "name": "name",
+      "label": "name",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "A name that describes the correlation search. For example, \"cpu_load_percent\".",
+      "subordinate": null
+    },
+    {
+      "name": "action.itsi_event_generator.param.title",
+      "label": "action.itsi_event_generator.param.title",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The title to use for the notable event in Episode Review. For example, `mysql-01 server cpu Load %`.",
+      "subordinate": null
+    },
+    {
+      "name": "action.itsi_event_generator.param.description",
+      "label": "action.itsi_event_generator.param.description",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "A brief phrase to describe the notable event. For example, \"This alert triggers when DB CPU load on the mysql-01 server reaches 80%.\"",
+      "subordinate": null
+    },
+    {
+      "name": "action.itsi_event_generator.param.status",
+      "label": "action.itsi_event_generator.param.status",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The triage status of the event in Episode Review. You can provide a token in the format `%fieldname%` to substitute the value of a third-party alert field. Values must match an integer specified in `$SPLUNK_HOME/etc/apps/SA-ITOA/local/itsi_notable_event_status.conf` or `/default/itsi_notable_event_status.conf` if a local version does not exist. By default, these values are 0-5.",
+      "subordinate": null
+    },
+    {
+      "name": "action.itsi_event_generator.param.owner",
+      "label": "action.itsi_event_generator.param.owner",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "The ITSI role to which the notable event is assigned in Episode Review.",
+      "subordinate": null
+    },
+    {
+      "name": "action.itsi_event_generator.param.severity",
+      "label": "action.itsi_event_generator.param.severity",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The level of importance of the event. You can provide a token in the format `%fieldname%` to substitute the value of a third-party alert field. Values must match an integer specified in `$SPLUNK_HOME/etc/apps/SA-ITOA/local/itsi_notable_event_severity.conf` or `/default/itsi_notable_event_severity.conf` if a local version does not exist. By default, these values are 1-6.",
+      "subordinate": null
+    },
+    {
+      "name": "action.itsi_event_generator.param.drilldown_search_title",
+      "label": "action.itsi_event_generator.param.drilldown_search_title",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The name of the drilldown search link. You can drill down to a specific Splunk search from an episode in Episode Review.",
+      "subordinate": null
+    },
+    {
+      "name": "action.itsi_event_generator.param.drilldown_search_search",
+      "label": "action.itsi_event_generator.param.drilldown_search_search",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The Splunk search you drill down to.",
+      "subordinate": null
+    },
+    {
+      "name": "action.itsi_event_generator.param.drilldown_search_latest_offset",
+      "label": "action.itsi_event_generator.param.drilldown_search_latest_offset",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Defines how far ahead from the time of the event to look for related events.",
+      "subordinate": null
+    },
+    {
+      "name": "action.itsi_event_generator.param.drilldown_search_earliest_offset",
+      "label": "action.itsi_event_generator.param.drilldown_search_earliest_offset",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Defines how far back from the time of the event to start looking for related events.",
+      "subordinate": null
+    },
+    {
+      "name": "action.itsi_event_generator.param.drilldown_title",
+      "label": "action.itsi_event_generator.param.drilldown_title",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The name of the drilldown website link if you want to drill down to a specific website from the episode in Episode Review.",
+      "subordinate": null
+    },
+    {
+      "name": "action.itsi_event_generator.param.drilldown_uri",
+      "label": "action.itsi_event_generator.param.drilldown_uri",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The website you drill down to.",
+      "subordinate": null
+    },
+    {
+      "name": "action.itsi_event_generator.param.event_identifier_fields",
+      "label": "action.itsi_event_generator.param.event_identifier_fields",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "These identifier fields form the event hash field, which is added to every notable event to help identify unique alarm types.",
+      "subordinate": null
+    },
+    {
+      "name": "action.itsi_event_generator.param.service_ids",
+      "label": "action.itsi_event_generator.param.service_ids",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "One or more ITSI services to which this correlation search applies. You can only specify services that belong to teams for which you have read access.",
+      "subordinate": null
+    },
+    {
+      "name": "action.itsi_event_generator.param.entity_lookup_field",
+      "label": "action.itsi_event_generator.param.entity_lookup_field",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The field in the data retrieved by the correlation search that is used to look up corresponding entities. For example, `host`.",
+      "subordinate": null
+    },
+    {
+      "name": "action.itsi_event_generator.param.search_type",
+      "label": "action.itsi_event_generator.param.search_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "search_type = \"basic\", \"composite_kpi_score_type\", or composite_kpi_percentage_type",
+      "subordinate": null
+    },
+    {
+      "name": "action.itsi_event_generator.param.meta_data",
+      "label": "action.itsi_event_generator.param.meta_data",
+      "type": "object",
+      "type_raw": "Object",
+      "required": false,
+      "read_only": false,
+      "description": "One of two JSON object schemas, depending on whether it is a correlation search or a multi-KPI alert. Correlation search object schema: - threshold_health_score - threshold score set by user - threshold_status - threshold status (default is undefined) - suppression criteria fields - alert_type - score or status - is_suppression - if suppression is enabled or not - is_consecutive - if count is consecutive or not - count - minimum number of times if this alert happens - suppression_period - suppression period in minute if it is non-consecutive - min_alert_period - minimum alert period of selected KPIs - run_every - frequency of search in minutes - score_based_kpis - list of KPIs which is added as part of a composite KPI. Each object in the list must have kpiid - <kpi id>, serviceid - <service id>, urgency - <urgency value> Multi-KPI alert object schema: - time_label - time label for time range - percentage_based_kpis - list of KPIs and service IDs included. Each item should contain kpiid - <kpi id>, serviceid - <service id>, label_thresholds - <threshold and operation type for trigger>. label_thresholds data format is as follows: `{ operation : 'OR', // default for now thresholds : [ { severity: <severity name>, percentage: <percentage value>, percentage_operation: '>=', // default for now } ...... ] }`",
+      "subordinate": null
+    },
+    {
+      "name": "action.itsi_event_generator.param.editor",
+      "label": "action.itsi_event_generator.param.editor",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "One of two values: advance_correlation_builder_editor or multi_kpi_alert_editor. It directs to the specific UI page to make edits based on the type of search, correlation search or multi-KPI alert.",
+      "subordinate": null
+    },
+    {
+      "name": "action.itsi_event_generator",
+      "label": "action.itsi_event_generator",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Value: 1",
+      "subordinate": null
+    },
+    {
+      "name": "actions",
+      "label": "actions",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Value: itsi_event_generator",
+      "subordinate": null
+    },
+    {
+      "name": "alert.suppress",
+      "label": "alert.suppress",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Enable suppression to minimize the number of duplicate notable events sent to Episode Review. Values: 1 (means enabled) or 0 (means disabled).",
+      "subordinate": null
+    },
+    {
+      "name": "alert.suppress.fields",
+      "label": "alert.suppress.fields",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The fields to consider when determining if another event matches the current one.",
+      "subordinate": null
+    },
+    {
+      "name": "alert.suppress.period",
+      "label": "alert.suppress.period",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The number of seconds to ignore other events that have the same field values.",
+      "subordinate": null
+    },
+    {
+      "name": "action.rss",
+      "label": "action.rss",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Included in RSS feed. Values: 1 (means enabled) or 0 (means disabled).",
+      "subordinate": null
+    },
+    {
+      "name": "action.email",
+      "label": "action.email",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Send an email when the alert is triggered. Values: 1 (means enabled) or 0 (means disabled).",
+      "subordinate": null
+    },
+    {
+      "name": "action.email.to",
+      "label": "action.email.to",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The email addresses to send the email to.",
+      "subordinate": null
+    },
+    {
+      "name": "action.email.subject",
+      "label": "action.email.subject",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The subject of the email.",
+      "subordinate": null
+    },
+    {
+      "name": "action.email.sendcsv",
+      "label": "action.email.sendcsv",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Send an email in CSV format. Values: 1 (means enabled) or 0 (means disabled).",
+      "subordinate": null
+    },
+    {
+      "name": "action.email.sendpdf",
+      "label": "action.email.sendpdf",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Send an email with a PDF attachment. Values: 1 (means enabled) or 0 (means disabled).",
+      "subordinate": null
+    },
+    {
+      "name": "action.email.inline",
+      "label": "action.email.inline",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Send an email with the text inline. Values: 1 (means enabled) or 0 (means disabled).",
+      "subordinate": null
+    },
+    {
+      "name": "action.email.format",
+      "label": "action.email.format",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Default value is pdf. Other values: html, csv.",
+      "subordinate": null
+    },
+    {
+      "name": "action.email.sendresults",
+      "label": "action.email.sendresults",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Include alert information as an email attachment. Values: 1 (means enabled) or 0 (means disabled).",
+      "subordinate": null
+    },
+    {
+      "name": "action.script",
+      "label": "action.script",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Triggers a shell script if enabled. Values: 1 (means enabled) or 0 (means disabled).",
+      "subordinate": null
+    },
+    {
+      "name": "action.script.filename",
+      "label": "action.script.filename",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Provide the file name of the shell script to run when this alert is triggered.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/deep_dive.json
+++ b/mcp_itsi/knowledge/schema/data/deep_dive.json
@@ -1,0 +1,194 @@
+{
+  "slug": "deep_dive",
+  "title": "Deep Dive",
+  "kind": "object",
+  "description": "ITSI deep dives are investigative tools that help you identify and troubleshoot issues in your IT environment. You can use deep dives to view KPI search results over time, zoom-in on KPI metrics and log events, and visually correlate root cause. You can add different types of lanes to a deep dive view, including KPI lanes, which let you view KPI metrics in detail. You can also add lanes to view ad hoc and data model searches. `deep_dive` objects contain all of the elements required to render deep dive lanes.",
+  "object_type": "deep_dive",
+  "interface": "/itoa_interface",
+  "endpoint": "/itoa_interface/deep_dive",
+  "subordinate_objects": [
+    "deep_dive_lane_setting"
+  ],
+  "attributes": [
+    {
+      "name": "_key",
+      "label": "_key",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Auto-generated unique identifier for this deep dive.",
+      "subordinate": null
+    },
+    {
+      "name": "description",
+      "label": "description",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User-defined description for this deep dive.",
+      "subordinate": null
+    },
+    {
+      "name": "title",
+      "label": "title",
+      "type": "string",
+      "type_raw": "String",
+      "required": true,
+      "read_only": false,
+      "description": "Name of the deep dive.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "deep_dive",
+      "subordinate": null
+    },
+    {
+      "name": "earliest_time",
+      "label": "earliest_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Earliest time for all of the searches in this deep dive.",
+      "subordinate": null
+    },
+    {
+      "name": "latest_time",
+      "label": "latest_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Latest time for all of the searches in this deep dive.",
+      "subordinate": null
+    },
+    {
+      "name": "focus_id",
+      "label": "focus_id",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The service id of the service in focus.",
+      "subordinate": null
+    },
+    {
+      "name": "topology_id",
+      "label": "topology_id",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Define the service to be put in focus in the deep dive topology view. If none exists then the focus_id is set as the topology_id. view sidebar",
+      "subordinate": null
+    },
+    {
+      "name": "lane_settings_collection",
+      "label": "lane_settings_collection",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "<Array of lane settings specifying each lane's configuration. See Deep Dive Lane Settings.",
+      "subordinate": "deep_dive_lane_setting"
+    },
+    {
+      "name": "is_named",
+      "label": "is_named",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "True when the deep dive is saved, false otherwise.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/deep_dive_lane_setting.json
+++ b/mcp_itsi/knowledge/schema/data/deep_dive_lane_setting.json
@@ -1,0 +1,382 @@
+{
+  "slug": "deep_dive_lane_setting",
+  "title": "Deep Dive Lane Setting",
+  "kind": "subordinate",
+  "description": "Configuration settings that define what information a deep dive lane shows. Deep dive views use these settings for per lane configuration.",
+  "object_type": null,
+  "interface": null,
+  "endpoint": null,
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "title",
+      "label": "title",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Name of the lane to display.",
+      "subordinate": null
+    },
+    {
+      "name": "subtitle",
+      "label": "subtitle",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The subtitle of the lane to display.",
+      "subordinate": null
+    },
+    {
+      "name": "laneType",
+      "label": "laneType",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The type of lane to render. Possible values: event, kpi, metric (the default).",
+      "subordinate": null
+    },
+    {
+      "name": "graphType",
+      "label": "graphType",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The type of graph to render",
+      "subordinate": null
+    },
+    {
+      "name": "search",
+      "label": "search",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The search to use to get data for the lane.",
+      "subordinate": null
+    },
+    {
+      "name": "searchSource",
+      "label": "searchSource",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Represents how a search is generated. Possible values: datamodel, ad hoc search, or kpi search.",
+      "subordinate": null
+    },
+    {
+      "name": "dataModelSpecification",
+      "label": "dataModelSpecification",
+      "type": "object",
+      "type_raw": "Object",
+      "required": false,
+      "read_only": false,
+      "description": "An object showing the selections that went into the generation of the search, null unless searchSource is data model. If defined, it is structured as {datamodel: <Data Model name> object: <Object Name>, field: <Field Info Data Structure>.",
+      "subordinate": null
+    },
+    {
+      "name": "dataModelStatOp",
+      "label": "dataModelStatOp",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Stats operation used in the data model search.",
+      "subordinate": null
+    },
+    {
+      "name": "dataModelWhereClause",
+      "label": "dataModelWhereClause",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Where clause defined during data model search creation.",
+      "subordinate": null
+    },
+    {
+      "name": "overwriteKpiTitle",
+      "label": "overwriteKpiTitle",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Overwrite KPI title with user specified title.",
+      "subordinate": null
+    },
+    {
+      "name": "overwriteEntityTitle",
+      "label": "overwriteEntityTitle",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Overwrite Entity title with user specified title.",
+      "subordinate": null
+    },
+    {
+      "name": "kpiTitle",
+      "label": "kpiTitle",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The original title of the KPI as defined in the KPI model.",
+      "subordinate": null
+    },
+    {
+      "name": "kpiServiceId",
+      "label": "kpiServiceId",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The id of the service associated with the selected KPI.",
+      "subordinate": null
+    },
+    {
+      "name": "kpiUnit",
+      "label": "kpiUnit",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The unit of the KPI driving this lane.",
+      "subordinate": null
+    },
+    {
+      "name": "kpiAddToSummary",
+      "label": "kpiAddToSummary",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Add or remove from kpi summary based on user selection. \\[yes, no\\] Yes runs the search against kpi summary index and no runs raw search.",
+      "subordinate": null
+    },
+    {
+      "name": "kpiStatsOp",
+      "label": "kpiStatsOp",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Stats operation to calculate the KPI value, avg by default \\[avg, max, min, median\\].",
+      "subordinate": null
+    },
+    {
+      "name": "entityAddToSummary",
+      "label": "entityAddToSummary",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Shows the accelerated output for entity lanes. Always set to \"yes.\"",
+      "subordinate": null
+    },
+    {
+      "name": "thresholdIndicationEnabled",
+      "label": "thresholdIndicationEnabled",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Enable/disable threshold indication. Disabled by default.",
+      "subordinate": null
+    },
+    {
+      "name": "thresholdIndicationType",
+      "label": "thresholdIndicationType",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Type of threshold indication. \\[foreground/background\\] Foreground selected by default.",
+      "subordinate": null
+    },
+    {
+      "name": "hideGraph",
+      "label": "hideGraph",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Only available with background threshold indications. If selected, hides the graph and only shows the top view with background thresholds \\[yes, no\\].",
+      "subordinate": null
+    },
+    {
+      "name": "verticalAxisScale",
+      "label": "verticalAxisScale",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Determines the scale of the y axis. It is linear or log.",
+      "subordinate": null
+    },
+    {
+      "name": "verticalAxisBoundaryType",
+      "label": "verticalAxisBoundaryType",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Determine the extent of the y axis. It is staticValue, value, or zeroValue.",
+      "subordinate": null
+    },
+    {
+      "name": "verticalAxisStaticBounds",
+      "label": "verticalAxisStaticBounds",
+      "type": "object",
+      "type_raw": "Object",
+      "required": false,
+      "read_only": false,
+      "description": "If static, these are the bounds to use. Otherwise this is ignored. This is an object of the form\\[<min number>, <max number>\\].",
+      "subordinate": null
+    },
+    {
+      "name": "dataGaps",
+      "label": "dataGaps",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "null values in the data can be represented as gaps or connected through the graph.",
+      "subordinate": null
+    },
+    {
+      "name": "graphColor",
+      "label": "graphColor",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The color of the graph to render.",
+      "subordinate": null
+    },
+    {
+      "name": "graphSeries",
+      "label": "graphSeries",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The field in the data which to plot as the range, if unspecified plots all.",
+      "subordinate": null
+    },
+    {
+      "name": "excludeSeries",
+      "label": "excludeSeries",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The series of data to omit from being displayed in graph. Series with a leading _ (indicating internal use) is always excluded.",
+      "subordinate": null
+    },
+    {
+      "name": "laneOverlaySettingsModel",
+      "label": "laneOverlaySettingsModel",
+      "type": "object",
+      "type_raw": "Object",
+      "required": false,
+      "read_only": false,
+      "description": "Model to define the overlay lane settings.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/entity.json
+++ b/mcp_itsi/knowledge/schema/data/entity.json
@@ -1,0 +1,192 @@
+{
+  "slug": "entity",
+  "title": "Entity",
+  "kind": "object",
+  "description": "An entity is a basic unit of configuration in an IT environment that meets a specific need for an IT service. Entities are usually servers, but can be other IT infrastructure components, such as network devices, storage subsystems, applications, and so on. Entities are optional. The `entity` object contains field aliases and values that identify the entity in KPI searches.",
+  "object_type": "entity",
+  "interface": "/itoa_interface",
+  "endpoint": "/itoa_interface/entity",
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "_key",
+      "label": "_key",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Auto-generated unique identifier for this entity. Can be any unique value.",
+      "subordinate": null
+    },
+    {
+      "name": "title",
+      "label": "title",
+      "type": "string",
+      "type_raw": "String",
+      "required": true,
+      "read_only": false,
+      "description": "Name of the entity. Can be any unique value.",
+      "subordinate": null
+    },
+    {
+      "name": "description",
+      "label": "description",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User defined description of the entity.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "entity",
+      "subordinate": null
+    },
+    {
+      "name": "identifier",
+      "label": "identifier",
+      "type": "object",
+      "type_raw": "Object",
+      "required": false,
+      "read_only": false,
+      "description": "_values_: Array of alias values that identify the entity _fields_: Array of search fields that identify events for the entity.",
+      "subordinate": null
+    },
+    {
+      "name": "informational",
+      "label": "informational",
+      "type": "object",
+      "type_raw": "Object",
+      "required": false,
+      "read_only": false,
+      "description": "_values_: Array of alias values that provide information/description for the entity. _fields_: Array of search fields to extract information/description of the entity.",
+      "subordinate": null
+    },
+    {
+      "name": "services",
+      "label": "services",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "Array of sub-objects with _key and title fields of services monitoring this entity via rules configured in services.",
+      "subordinate": null
+    },
+    {
+      "name": "sec_grp",
+      "label": "sec_grp",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The team the object belongs to. The entity object can only belong to default_itsi_security_group (Global team).",
+      "subordinate": null
+    },
+    {
+      "name": "sai_entity_key",
+      "label": "sai_entity_key",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "This field exists in ITSI entities that have been merged with SAI entities. It symbolizes the original SAI entities's _key and is used for drilldowns to SAI.",
+      "subordinate": null
+    },
+    {
+      "name": "entity_type_ids",
+      "label": "entity_type_ids",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "Array of _key values for each entity type associated with the entity.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/entity_rules.json
+++ b/mcp_itsi/knowledge/schema/data/entity_rules.json
@@ -1,0 +1,162 @@
+{
+  "slug": "entity_rules",
+  "title": "Entity Rules",
+  "kind": "subordinate",
+  "description": "`entity_rules` determine the specific entities that a KPI monitors in a service. This includes entities directly identified by title, and entities identified by regular expression-based rules.",
+  "object_type": null,
+  "interface": null,
+  "endpoint": null,
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "rule_condition",
+      "label": "rule_condition",
+      "type": "string",
+      "type_raw": "Boolean operator",
+      "required": false,
+      "read_only": false,
+      "description": "Uses the value AND indicating this rule appends all nested rules contained in the `rule_items` attribute.",
+      "subordinate": null
+    },
+    {
+      "name": "rule_items",
+      "label": "rule_items",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "Array of rules that are appended within a rule group.",
+      "subordinate": null
+    },
+    {
+      "name": "field",
+      "label": "field",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The field in the entity definition to compare values to evaluate this rule.",
+      "subordinate": null
+    },
+    {
+      "name": "rule_type",
+      "label": "rule_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Takes values `not` or `matches` to indicate whether it's an inclusion or exclusion rule. Value can be `matchesblank` or `doesnotmatchblank` when used with service templates.",
+      "subordinate": null
+    },
+    {
+      "name": "value",
+      "label": "value",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Values to evaluate in the rule. To specify multiple values, separate them with a comma. Values are not case sensitive.",
+      "subordinate": null
+    },
+    {
+      "name": "field_type",
+      "label": "field_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Takes values `alias` or `info` specifying in which category of fields the `field` attribute is located.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/entity_type.json
+++ b/mcp_itsi/knowledge/schema/data/entity_type.json
@@ -1,0 +1,156 @@
+{
+  "slug": "entity_type",
+  "title": "Entity Type",
+  "kind": "object",
+  "description": "An `entity_type` defines how to classify a type of data source. For example, you can create a Linux, Windows, Unix/Linux add-on, VMware, or Kubernetes entity type. An entity type can include zero or more data drilldowns and zero or more dashboard drilldowns. You can use a single data drilldown or dashboard drilldown for multiple entity types.",
+  "object_type": "entity_type",
+  "interface": "/itoa_interface",
+  "endpoint": "/itoa_interface/entity_type",
+  "subordinate_objects": [
+    "entity_type_dashboard_drilldown",
+    "entity_type_data_drilldown",
+    "entity_type_vital_metrics"
+  ],
+  "attributes": [
+    {
+      "name": "title",
+      "label": "title",
+      "type": "string",
+      "type_raw": "String",
+      "required": true,
+      "read_only": false,
+      "description": "The name of the entity type.",
+      "subordinate": null
+    },
+    {
+      "name": "description",
+      "label": "description",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "A description of the entity type.",
+      "subordinate": null
+    },
+    {
+      "name": "dashboard_drilldowns",
+      "label": "dashboard_drilldowns",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "An array of dashboard drilldown objects. Each dashboard drilldown defines an internal or external resource you specify with a URL and parameters that map to one of an entity fields. The parameters are passed to the resource when you open the URL. See [Entity Type Dashboard Drilldown](https://help.splunk.com/en/splunk-it-service-intelligence/splunk-it-service-intelligence/leverage-rest-apis/4.21/itsi-rest-api-schema/itsi-rest-api-schema#db5a9c8d_7a60_4c88_9385_44cf3fb415b5--en__ITSI_REST_API_schema).",
+      "subordinate": "entity_type_dashboard_drilldown"
+    },
+    {
+      "name": "data_drilldown",
+      "label": "data_drilldown",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "An array of data drilldown objects. Each data drilldown defines filters for raw data associated with entities that belong to the entity type. See [Entity Type Data Drilldown](https://help.splunk.com/en/splunk-it-service-intelligence/splunk-it-service-intelligence/leverage-rest-apis/4.21/itsi-rest-api-schema/itsi-rest-api-schema#ade3ea81_9cb7_4514_a0c4_dedaa2e5e9f1--en__Entity_Type_Data_Drilldown).",
+      "subordinate": "entity_type_data_drilldown"
+    },
+    {
+      "name": "vital_metrics",
+      "label": "vital_metrics",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "An array of vital metric objects. Vital metrics are statistical calculations based on SPL searches that represent the overall health of entities of that type. See [Entity Type Vital Metrics](https://help.splunk.com/en/splunk-it-service-intelligence/splunk-it-service-intelligence/leverage-rest-apis/4.21/itsi-rest-api-schema/itsi-rest-api-schema#id_76df76d8_0f87_4b90_b28d_1cda9f70b7cc--en__Entity_Type_Vital_Metrics).",
+      "subordinate": "entity_type_vital_metrics"
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/entity_type_dashboard_drilldown.json
+++ b/mcp_itsi/knowledge/schema/data/entity_type_dashboard_drilldown.json
@@ -1,0 +1,162 @@
+{
+  "slug": "entity_type_dashboard_drilldown",
+  "title": "Entity Type Dashboard Drilldown",
+  "kind": "subordinate",
+  "description": "A `dashboard_drilldown` lists the dashboards associated with an entity and its entity type.",
+  "object_type": null,
+  "interface": null,
+  "endpoint": null,
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "title",
+      "label": "title",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The name of the dashboard.",
+      "subordinate": null
+    },
+    {
+      "name": "id",
+      "label": "id",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "A unique identifier for the dashboard.",
+      "subordinate": null
+    },
+    {
+      "name": "base_url",
+      "label": "base_url",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "An internal or external URL that points to the dashboard. This setting exists because for internal purposes, navigation suggestions are treated as dashboards. This setting is only required if `is_splunk_dashboard` is `false`.",
+      "subordinate": null
+    },
+    {
+      "name": "is_splunk_dashboard",
+      "label": "is_splunk_dashboard",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "`true` if the dashboard is a Splunk XML dashboard. If it's another dashboard type such as a JSON dashboard from the Splunk Dashboards app, or if it's a navigation link, this value is `false`.",
+      "subordinate": null
+    },
+    {
+      "name": "dashboard_type",
+      "label": "dashboard_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The type of dashboard being added. This element is required. The following options are available: - `xml_dashboard` \\- a Splunk XML dashboard. Any dashboards you add must be of this type. - `navigation_link` \\- a navigation URL. Should be used when `base_url` is specified.",
+      "subordinate": null
+    },
+    {
+      "name": "params",
+      "label": "params",
+      "type": "object",
+      "type_raw": "Object",
+      "required": false,
+      "read_only": false,
+      "description": "A set of parameters for the entity dashboard drilldown that provide a mapping of a URL parameter and its alias and static parameters.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/entity_type_data_drilldown.json
+++ b/mcp_itsi/knowledge/schema/data/entity_type_data_drilldown.json
@@ -1,0 +1,142 @@
+{
+  "slug": "entity_type_data_drilldown",
+  "title": "Entity Type Data Drilldown",
+  "kind": "subordinate",
+  "description": "A `data_drilldown` is a basic unit of configuration for an entity type. Entity data drilldown specifies filters that correlate raw data in Splunk indexes with an entity.",
+  "object_type": null,
+  "interface": null,
+  "endpoint": null,
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "title",
+      "label": "title",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Name of the drilldown.",
+      "subordinate": null
+    },
+    {
+      "name": "type",
+      "label": "type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Type of raw data to associate with. Must be either `metrics` or `events`.",
+      "subordinate": null
+    },
+    {
+      "name": "static_filter",
+      "label": "static_filter",
+      "type": "object",
+      "type_raw": "Object",
+      "required": false,
+      "read_only": false,
+      "description": "Filter down to a subset of raw data associated with the entity using static information like sourcetype.",
+      "subordinate": null
+    },
+    {
+      "name": "entity_field_filter",
+      "label": "entity_field_filter",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "Further filter down to the raw data associated with the entity based on a set of selected entity alias or informational fields.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/entity_type_vital_metrics.json
+++ b/mcp_itsi/knowledge/schema/data/entity_type_vital_metrics.json
@@ -1,0 +1,172 @@
+{
+  "slug": "entity_type_vital_metrics",
+  "title": "Entity Type Vital Metrics",
+  "kind": "subordinate",
+  "description": "`vital_metrics` are a basic unit of configuration for an entity type. Vital metrics are statistical calculations based on SPL searches that represent the overall health of entities of that type.",
+  "object_type": null,
+  "interface": null,
+  "endpoint": null,
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "metric_name",
+      "label": "metric_name",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The title of the vital metric. When creating vital metrics, it's a best practice to include the aggregation method and the name of the metric being calculated. For example, `Average CPU usage`.",
+      "subordinate": null
+    },
+    {
+      "name": "search",
+      "label": "search",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The search that computes the vital metric. The search must specify the following fields: - `val` for the value of the metric. - `_time` because the UI attempts to render changes over time. You can achieve this by adding `span={time}` to your search. - Fields as described in the `split_by_fields` configuration of this vital metric. For example, your search should be split by `host,region` if the `split_by_fields` configuration is \\[ \"host\", \"region\" \\].",
+      "subordinate": null
+    },
+    {
+      "name": "split_by_fields",
+      "label": "split_by_fields",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "The fields that the `search` configuration is split on. Make sure the value matches the split by fields in the actual search. For example: search = \"..... by host, region\" split_by_fields = \\[\"host\", \"region\"\\]",
+      "subordinate": null
+    },
+    {
+      "name": "matching_entity_fields",
+      "label": "matching_entity_fields",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "Specifies the aliases of an entity to use to match with the fields specified by `split_by_fields` in the search result. The order of values should match the order of split_by_fields and the mapping is 1 to 1, so they must be of the same length. For example: split_by_fields = \\[\"InstanceId\", \"region\"\\] matching_entity_fields = \\[\"instance_id, zone\"\\] Note: You can only use entity aliases for this field, not informational fields",
+      "subordinate": null
+    },
+    {
+      "name": "is_key",
+      "label": "is_key",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "Indicates if the vital metric specified is a key metric. A key metric calculates the distribution of entities associated with the entity type to indicate the overall health of the entity type. The key metric is rendered as a histogram in the Infrastructure Overview. Only one vital metric can have `is_key` set to `true`.",
+      "subordinate": null
+    },
+    {
+      "name": "unit",
+      "label": "unit",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The unit of the vital metric. For example, `KB/s`.",
+      "subordinate": null
+    },
+    {
+      "name": "alert_rule",
+      "label": "alert_rule",
+      "type": "object",
+      "type_raw": "Object",
+      "required": false,
+      "read_only": false,
+      "description": "Displays vital metric alert threshold information. The following parameters are displayed: - `suppress_time`: suppress the alert until this time - `cron_schedule`: frequency of alert search - `is_enabled`: if alert is enabled - `critical_threshold`: range of values that indicate critical severity level - `warning_threshold`: range of values that indicate warning severity level - `info_threshold`: range of values that indicate info severity level - `entity_filter`: filter entities based on the field dimensions For example: entity_filter: \\[{\"field\":\"os\", \"value\":\"Ubuntu\", \"field_type\":\"info\"}\\]",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/event_management_export.json
+++ b/mcp_itsi/knowledge/schema/data/event_management_export.json
@@ -1,0 +1,132 @@
+{
+  "slug": "event_management_export",
+  "title": "Event Management Export",
+  "kind": "subordinate",
+  "description": "itsi\\_event\\_management\\_export contains information about an episode.",
+  "object_type": null,
+  "interface": null,
+  "endpoint": null,
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "export_filename",
+      "label": "export_filename",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The file name for the new file export.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "event_management_export",
+      "subordinate": null
+    },
+    {
+      "name": "status",
+      "label": "status",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The status of the CSV file export: started, in progress, failed, completed.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The Splunk user who owns the CSV file.",
+      "subordinate": null
+    },
+    {
+      "name": "_key",
+      "label": "_key",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "A unique identifier to determine the CSV file object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/event_management_state.json
+++ b/mcp_itsi/knowledge/schema/data/event_management_state.json
@@ -1,0 +1,222 @@
+{
+  "slug": "event_management_state",
+  "title": "Event Management State",
+  "kind": "object",
+  "description": "The `event_management_state` object stores user settings for custom saved views of Episode Review. For instructions to save custom views through the UI, see [Save a custom view of Episode Review](https://help.splunk.com/?resourceId=ITSI_EA_CustomizeEpisode) in the _User Manual_.",
+  "object_type": "event_management_state",
+  "interface": "/event_management_interface",
+  "endpoint": "/event_management_interface/event_management_state",
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "_key",
+      "label": "_key",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The unique ID for Episode Review view in the KV store.",
+      "subordinate": null
+    },
+    {
+      "name": "title",
+      "label": "title",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "A user-defined name for the custom episode review.",
+      "subordinate": null
+    },
+    {
+      "name": "earliest",
+      "label": "earliest",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The earliest time for the main search in the Episode Review custom view.",
+      "subordinate": null
+    },
+    {
+      "name": "latest",
+      "label": "latest",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The latest time for the main search in the Episode Review custom view.",
+      "subordinate": null
+    },
+    {
+      "name": "fetchLimit",
+      "label": "fetchLimit",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "The maximum number of notable events to fetch in a single request.",
+      "subordinate": null
+    },
+    {
+      "name": "sortField",
+      "label": "sortField",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The field in the data (column in Episode Review) to sort notable events by.",
+      "subordinate": null
+    },
+    {
+      "name": "sortDirection",
+      "label": "sortDirection",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Whether to sort notable events in ascending or descending order.",
+      "subordinate": null
+    },
+    {
+      "name": "arbitrarySearch",
+      "label": "arbitrarySearch",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The Splunk search string used to filter raw notable events.",
+      "subordinate": null
+    },
+    {
+      "name": "filterCollection",
+      "label": "filterCollection",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "A set of filters that represent the Episode Review page filters.",
+      "subordinate": null
+    },
+    {
+      "name": "viewingOption",
+      "label": "viewingOption",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Whether to display notable events as standard or prominent mode in Episode Review.",
+      "subordinate": null
+    },
+    {
+      "name": "eventDeduplication",
+      "label": "eventDeduplication",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "If true, episode view is turned on. Otherwise individual notable events are displayed.",
+      "subordinate": null
+    },
+    {
+      "name": "columnsShown",
+      "label": "columnsShown",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "A list of fields in the data (columns in Episode Review) to display.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/glass_table.json
+++ b/mcp_itsi/knowledge/schema/data/glass_table.json
@@ -1,0 +1,205 @@
+{
+  "slug": "glass_table",
+  "title": "Glass Table",
+  "kind": "object",
+  "description": "ITSI glass tables are custom visualizations that let you monitor KPI search results. `glass_table` objects define all widgets and drawing elements that appear in the glass table.",
+  "object_type": "glass_table",
+  "interface": "/itoa_interface",
+  "endpoint": "/itoa_interface/glass_table",
+  "subordinate_objects": [
+    "glass_table_widget_configuration",
+    "glass_table_icon"
+  ],
+  "attributes": [
+    {
+      "name": "_key",
+      "label": "_key",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Unique identifier for this glass table.",
+      "subordinate": null
+    },
+    {
+      "name": "title",
+      "label": "title",
+      "type": "string",
+      "type_raw": "String",
+      "required": true,
+      "read_only": false,
+      "description": "Name of this glass table.",
+      "subordinate": null
+    },
+    {
+      "name": "description",
+      "label": "description",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User-defined description for this glass table.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "glass_table.",
+      "subordinate": null
+    },
+    {
+      "name": "latest",
+      "label": "latest",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Latest time for all of the widget searches on the glass table.",
+      "subordinate": null
+    },
+    {
+      "name": "latest_label",
+      "label": "latest_label",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Latest label displayed in the glass table instant picker. Matches latest attribute.",
+      "subordinate": null
+    },
+    {
+      "name": "svg_coordinates",
+      "label": "svg_coordinates",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "x and y viewbox offsets for the glass table.",
+      "subordinate": null
+    },
+    {
+      "name": "content",
+      "label": "content",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "Array of JSON structures containing all attributes needed to draw the glass table. See Glass Table Widget Configuration.",
+      "subordinate": null
+    },
+    {
+      "name": "is_epoch",
+      "label": "is_epoch",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "True when the glass table uses a custom (non-preset) time, false otherwise.",
+      "subordinate": null
+    },
+    {
+      "name": "templateSelectedServiceId",
+      "label": "templateSelectedServiceId",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The id of the service currently in focus if templatization is enabled.",
+      "subordinate": null
+    },
+    {
+      "name": "templateSwappableServiceIds",
+      "label": "templateSwappableServiceIds",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "The array of services available to be swapped to for templatization.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/glass_table_icon.json
+++ b/mcp_itsi/knowledge/schema/data/glass_table_icon.json
@@ -1,0 +1,182 @@
+{
+  "slug": "glass_table_icon",
+  "title": "Glass Table Icon",
+  "kind": "subordinate",
+  "description": "Contains SVG icon definitions and metadata for glass table icons.",
+  "object_type": null,
+  "interface": null,
+  "endpoint": null,
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "_key",
+      "label": "_key",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Auto-generated unique identifier for this icon.",
+      "subordinate": null
+    },
+    {
+      "name": "title",
+      "label": "title",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Name of the icon.",
+      "subordinate": null
+    },
+    {
+      "name": "category",
+      "label": "category",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Category of the icon.",
+      "subordinate": null
+    },
+    {
+      "name": "default_width",
+      "label": "default_width",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Width of the icon.",
+      "subordinate": null
+    },
+    {
+      "name": "default_height",
+      "label": "default_height",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Height of the icon.",
+      "subordinate": null
+    },
+    {
+      "name": "svg_path",
+      "label": "svg_path",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "SVG path defining shape of the icon.",
+      "subordinate": null
+    },
+    {
+      "name": "immutable",
+      "label": "immutable",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "Should the REST API allow editing of this icon. False for all icons imported from .conf files.",
+      "subordinate": null
+    },
+    {
+      "name": "_time",
+      "label": "_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Timestamp when the icon was added.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the user that added this icon.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/glass_table_widget_configuration.json
+++ b/mcp_itsi/knowledge/schema/data/glass_table_widget_configuration.json
@@ -1,0 +1,452 @@
+{
+  "slug": "glass_table_widget_configuration",
+  "title": "Glass Table Widget Configuration",
+  "kind": "subordinate",
+  "description": "Glass Table Widget Configuration (`content`) is an array of JSON structures that contains all of the attributes needed to render the glass table. Each element of the array represents one glass table widget, and the attributes of the element are parsed into a glass table BaseWidgetViewManager object.",
+  "object_type": null,
+  "interface": null,
+  "endpoint": null,
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "search",
+      "label": "search",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The search to power the widget.",
+      "subordinate": null
+    },
+    {
+      "name": "labelVal",
+      "label": "labelVal",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The text to show in the label located beneath the widget.",
+      "subordinate": null
+    },
+    {
+      "name": "labelFlag",
+      "label": "labelFlag",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "True if labelVal is to be shown with the widget, false otherwise.",
+      "subordinate": null
+    },
+    {
+      "name": "vizType",
+      "label": "vizType",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Numeric indication of which visualization type the widget is - SingleValue, Gauge, Sparkline, SVD from 0-3, respectively",
+      "subordinate": null
+    },
+    {
+      "name": "threshold_field",
+      "label": "threshold_field",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Field in data to which thresholds apply.",
+      "subordinate": null
+    },
+    {
+      "name": "threshold_comparator",
+      "label": "threshold_comparator",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Comparator used for threshold severity computation",
+      "subordinate": null
+    },
+    {
+      "name": "threshold_values",
+      "label": "threshold_values",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "Array of values to indicate the bounds of the thresholds set for the widget.",
+      "subordinate": null
+    },
+    {
+      "name": "threshold_labels",
+      "label": "threshold_labels",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "Array of labels to match the threshold values set for the widget.",
+      "subordinate": null
+    },
+    {
+      "name": "context_id",
+      "label": "context_id",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Id of service to which the widget's KPI belongs.",
+      "subordinate": null
+    },
+    {
+      "name": "kpi_id",
+      "label": "kpi_id",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Id of KPI the widget represents",
+      "subordinate": null
+    },
+    {
+      "name": "searchSource",
+      "label": "searchSource",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Source of search for glass table widget - can be datamodel or ad hoc.",
+      "subordinate": null
+    },
+    {
+      "name": "dataModelSpecification",
+      "label": "dataModelSpecification",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Data model specification for the datamodel search.",
+      "subordinate": null
+    },
+    {
+      "name": "dataModelStatOp",
+      "label": "dataModelStatOp",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Datamodel stats operation for the datamodel search.",
+      "subordinate": null
+    },
+    {
+      "name": "dataModelWhereClause",
+      "label": "dataModelWhereClause",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Datamodel where clause for the datamodel search.",
+      "subordinate": null
+    },
+    {
+      "name": "threshold_eval",
+      "label": "threshold_eval",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Threshold eval search clause for threshold severity evaluation.",
+      "subordinate": null
+    },
+    {
+      "name": "aggregate_eval",
+      "label": "aggregate_eval",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Aggregate eval search clause for threshold severity evaluation.",
+      "subordinate": null
+    },
+    {
+      "name": "base_search",
+      "label": "base_search",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Base search of the KPI the widget represents.",
+      "subordinate": null
+    },
+    {
+      "name": "search_alert_earliest",
+      "label": "search_alert_earliest",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Earliest time for the search that powers the widget.",
+      "subordinate": null
+    },
+    {
+      "name": "entities",
+      "label": "entities",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "List of entities that the widget's KPI contains.",
+      "subordinate": null
+    },
+    {
+      "name": "search_aggregate",
+      "label": "search_aggregate",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Aggregate search of the KPI the widget represents.",
+      "subordinate": null
+    },
+    {
+      "name": "search_time_series_aggregate",
+      "label": "search_time_series_aggregate",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Time series search of the KPI the widget represents",
+      "subordinate": null
+    },
+    {
+      "name": "search_time_compare",
+      "label": "search_time_compare",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Compare time series search of the KPI the widget represents (for the SVD viz type).",
+      "subordinate": null
+    },
+    {
+      "name": "search_type",
+      "label": "search_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Type of search the widget is powered by. Must match one of the search_\\* attributes of the widget.",
+      "subordinate": null
+    },
+    {
+      "name": "relativeEarliest",
+      "label": "relativeEarliest",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Earliest time (in relative units) for the search that powers the widget.",
+      "subordinate": null
+    },
+    {
+      "name": "defaultWidth",
+      "label": "defaultWidth",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Initial width to use for the widget.",
+      "subordinate": null
+    },
+    {
+      "name": "defaultHeight",
+      "label": "defaultHeight",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Initial height to use for the widget.",
+      "subordinate": null
+    },
+    {
+      "name": "existingKPI",
+      "label": "existingKPI",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "True if KPI exists in user's system, false otherwise.",
+      "subordinate": null
+    },
+    {
+      "name": "alert_on",
+      "label": "alert_on",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Threshold alert type (aggregate or entities) of the KPI the widget represents.",
+      "subordinate": null
+    },
+    {
+      "name": "isThresholdEnabled",
+      "label": "isThresholdEnabled",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "True if thresholds should be applied to the widget's search results, false otherwise.",
+      "subordinate": null
+    },
+    {
+      "name": "useKPISummary",
+      "label": "useKPISummary",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "true if widget uses the kpi_summary_index to power its search, false otherwise.",
+      "subordinate": null
+    },
+    {
+      "name": "unit",
+      "label": "unit",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Unit string for widget to display.",
+      "subordinate": null
+    },
+    {
+      "name": "gap_severity",
+      "label": "gap_severity",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Gap severity value of the KPI the widget represents.",
+      "subordinate": null
+    },
+    {
+      "name": "gap_severity_color",
+      "label": "gap_severity_color",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Gap severity color of the KPI the widget represents.",
+      "subordinate": null
+    },
+    {
+      "name": "drilldownSettingsModel",
+      "label": "drilldownSettingsModel",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Model to hold properties required for generating URLs for custom drilldown.",
+      "subordinate": null
+    },
+    {
+      "name": "useCustomDrilldown",
+      "label": "useCustomDrilldown",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "True if widget has custom drilldown turned on, false otherwise.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/home_view.json
+++ b/mcp_itsi/knowledge/schema/data/home_view.json
@@ -1,0 +1,242 @@
+{
+  "slug": "home_view",
+  "title": "Service Analyzer",
+  "kind": "object",
+  "description": "Service Analyzer is the ITSI UI home page. It displays service and KPI health scores that are trending at top severity levels. You can configure Service Analyzer to filter the display of services and KPIs relevant to the user. The Service Analyzer object is called `home_view`.",
+  "object_type": "home_view",
+  "interface": "/itoa_interface",
+  "endpoint": "/itoa_interface/home_view",
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "_key",
+      "label": "_key",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Unique ID for the entry in KV store.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "home_view",
+      "subordinate": null
+    },
+    {
+      "name": "-owner",
+      "label": "-owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User that creates the saved service analyzer.",
+      "subordinate": null
+    },
+    {
+      "name": "title",
+      "label": "title",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User given title for the service analyzer.",
+      "subordinate": null
+    },
+    {
+      "name": "earliest_time",
+      "label": "earliest_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Earliest time for the searches.",
+      "subordinate": null
+    },
+    {
+      "name": "latest_time",
+      "label": "latest_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Latest time for the searches.",
+      "subordinate": null
+    },
+    {
+      "name": "serviceWhitelist",
+      "label": "serviceWhitelist",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "List of filtered services.",
+      "subordinate": null
+    },
+    {
+      "name": "kpiWhitelist",
+      "label": "kpiWhitelist",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "List of filtered kpis.",
+      "subordinate": null
+    },
+    {
+      "name": "isServiceFilterEnabled",
+      "label": "isServiceFilterEnabled",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "True if services are filtered, false by default.",
+      "subordinate": null
+    },
+    {
+      "name": "isKpiFilterEnabled",
+      "label": "isKpiFilterEnabled",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "True if kpis are filtered, false by default.",
+      "subordinate": null
+    },
+    {
+      "name": "serviceTilesSettings",
+      "label": "serviceTilesSettings",
+      "type": "object",
+      "type_raw": "Object",
+      "required": false,
+      "read_only": false,
+      "description": "SeverityTilesSettingModel with number of kpi tiles and filter.",
+      "subordinate": null
+    },
+    {
+      "name": "view",
+      "label": "view",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Determines if service analyzer view is standard or full screen. Standard is default.",
+      "subordinate": null
+    },
+    {
+      "name": "isDefault",
+      "label": "isDefault",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "True if it is the default (standard) service analyzer, false otherwise.",
+      "subordinate": null
+    },
+    {
+      "name": "titleSize",
+      "label": "titleSize",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "medium\\|large\\], large by default.",
+      "subordinate": null
+    },
+    {
+      "name": "searchType",
+      "label": "searchType",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "maxseverity\\] \\[aggregate\\|maxseverity\\] aggregate shows the most recent service value and the max severity is service value unless there is an entity value with worst severity.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/index.json
+++ b/mcp_itsi/knowledge/schema/data/index.json
@@ -1,0 +1,310 @@
+{
+  "version": "4.21",
+  "source": "https://help.splunk.com/en/splunk-it-service-intelligence/splunk-it-service-intelligence/leverage-rest-apis/4.21/itsi-rest-api-schema/itsi-rest-api-schema",
+  "object_types": [
+    "base_service_template",
+    "correlation_search",
+    "deep_dive",
+    "entity",
+    "entity_type",
+    "event_management_state",
+    "glass_table",
+    "home_view",
+    "kpi_base_search",
+    "kpi_threshold_template",
+    "maintenance_calendar",
+    "notable_event_aggregation_policy",
+    "notable_event_comment",
+    "notable_event_email_template",
+    "notable_event_group",
+    "service",
+    "team"
+  ],
+  "subordinate_structures": [
+    "anomaly_detection_algorithm_settings",
+    "deep_dive_lane_setting",
+    "entity_rules",
+    "entity_type_dashboard_drilldown",
+    "entity_type_data_drilldown",
+    "entity_type_vital_metrics",
+    "event_management_export",
+    "glass_table_icon",
+    "glass_table_widget_configuration",
+    "kpi_threshold_levels",
+    "kpi_threshold_settings",
+    "service_kpi",
+    "service_template_kpi",
+    "time_variate_thresholds_specification"
+  ],
+  "entries": {
+    "anomaly_detection_algorithm_settings": {
+      "title": "Anomaly Detection Algorithm Settings",
+      "kind": "subordinate",
+      "object_type": null,
+      "endpoint": null,
+      "attribute_count": 10,
+      "subordinate_objects": []
+    },
+    "base_service_template": {
+      "title": "Service Template",
+      "kind": "object",
+      "object_type": "base_service_template",
+      "endpoint": "/itoa_interface/base_service_template",
+      "attribute_count": 23,
+      "subordinate_objects": [
+        "entity_rules",
+        "service_template_kpi"
+      ]
+    },
+    "correlation_search": {
+      "title": "Correlation Search",
+      "kind": "object",
+      "object_type": "correlation_search",
+      "endpoint": "/event_management_interface/correlation_search",
+      "attribute_count": 50,
+      "subordinate_objects": []
+    },
+    "deep_dive": {
+      "title": "Deep Dive",
+      "kind": "object",
+      "object_type": "deep_dive",
+      "endpoint": "/itoa_interface/deep_dive",
+      "attribute_count": 18,
+      "subordinate_objects": [
+        "deep_dive_lane_setting"
+      ]
+    },
+    "deep_dive_lane_setting": {
+      "title": "Deep Dive Lane Setting",
+      "kind": "subordinate",
+      "object_type": null,
+      "endpoint": null,
+      "attribute_count": 37,
+      "subordinate_objects": []
+    },
+    "entity": {
+      "title": "Entity",
+      "kind": "object",
+      "object_type": "entity",
+      "endpoint": "/itoa_interface/entity",
+      "attribute_count": 18,
+      "subordinate_objects": []
+    },
+    "entity_rules": {
+      "title": "Entity Rules",
+      "kind": "subordinate",
+      "object_type": null,
+      "endpoint": null,
+      "attribute_count": 15,
+      "subordinate_objects": []
+    },
+    "entity_type": {
+      "title": "Entity Type",
+      "kind": "object",
+      "object_type": "entity_type",
+      "endpoint": "/itoa_interface/entity_type",
+      "attribute_count": 14,
+      "subordinate_objects": [
+        "entity_type_dashboard_drilldown",
+        "entity_type_data_drilldown",
+        "entity_type_vital_metrics"
+      ]
+    },
+    "entity_type_dashboard_drilldown": {
+      "title": "Entity Type Dashboard Drilldown",
+      "kind": "subordinate",
+      "object_type": null,
+      "endpoint": null,
+      "attribute_count": 15,
+      "subordinate_objects": []
+    },
+    "entity_type_data_drilldown": {
+      "title": "Entity Type Data Drilldown",
+      "kind": "subordinate",
+      "object_type": null,
+      "endpoint": null,
+      "attribute_count": 13,
+      "subordinate_objects": []
+    },
+    "entity_type_vital_metrics": {
+      "title": "Entity Type Vital Metrics",
+      "kind": "subordinate",
+      "object_type": null,
+      "endpoint": null,
+      "attribute_count": 16,
+      "subordinate_objects": []
+    },
+    "event_management_export": {
+      "title": "Event Management Export",
+      "kind": "subordinate",
+      "object_type": null,
+      "endpoint": null,
+      "attribute_count": 12,
+      "subordinate_objects": []
+    },
+    "event_management_state": {
+      "title": "Event Management State",
+      "kind": "object",
+      "object_type": "event_management_state",
+      "endpoint": "/event_management_interface/event_management_state",
+      "attribute_count": 21,
+      "subordinate_objects": []
+    },
+    "glass_table": {
+      "title": "Glass Table",
+      "kind": "object",
+      "object_type": "glass_table",
+      "endpoint": "/itoa_interface/glass_table",
+      "attribute_count": 19,
+      "subordinate_objects": [
+        "glass_table_widget_configuration",
+        "glass_table_icon"
+      ]
+    },
+    "glass_table_icon": {
+      "title": "Glass Table Icon",
+      "kind": "subordinate",
+      "object_type": null,
+      "endpoint": null,
+      "attribute_count": 17,
+      "subordinate_objects": []
+    },
+    "glass_table_widget_configuration": {
+      "title": "Glass Table Widget Configuration",
+      "kind": "subordinate",
+      "object_type": null,
+      "endpoint": null,
+      "attribute_count": 44,
+      "subordinate_objects": []
+    },
+    "home_view": {
+      "title": "Service Analyzer",
+      "kind": "object",
+      "object_type": "home_view",
+      "endpoint": "/itoa_interface/home_view",
+      "attribute_count": 23,
+      "subordinate_objects": []
+    },
+    "kpi_base_search": {
+      "title": "KPI Base Search",
+      "kind": "object",
+      "object_type": "kpi_base_search",
+      "endpoint": "/itoa_interface/kpi_base_search",
+      "attribute_count": 32,
+      "subordinate_objects": []
+    },
+    "kpi_threshold_levels": {
+      "title": "KPI Threshold Levels",
+      "kind": "subordinate",
+      "object_type": null,
+      "endpoint": null,
+      "attribute_count": 15,
+      "subordinate_objects": []
+    },
+    "kpi_threshold_settings": {
+      "title": "KPI Threshold Settings",
+      "kind": "subordinate",
+      "object_type": null,
+      "endpoint": null,
+      "attribute_count": 21,
+      "subordinate_objects": [
+        "kpi_threshold_levels"
+      ]
+    },
+    "kpi_threshold_template": {
+      "title": "KPI Threshold Templates",
+      "kind": "object",
+      "object_type": "kpi_threshold_template",
+      "endpoint": "/itoa_interface/kpi_threshold_template",
+      "attribute_count": 16,
+      "subordinate_objects": []
+    },
+    "maintenance_calendar": {
+      "title": "Maintenance Calendar",
+      "kind": "object",
+      "object_type": "maintenance_calendar",
+      "endpoint": "/maintenance_services_interface/maintenance_calendar",
+      "attribute_count": 15,
+      "subordinate_objects": []
+    },
+    "notable_event_aggregation_policy": {
+      "title": "Notable Event Aggregation Policy",
+      "kind": "object",
+      "object_type": "notable_event_aggregation_policy",
+      "endpoint": "/event_management_interface/notable_event_aggregation_policy",
+      "attribute_count": 21,
+      "subordinate_objects": []
+    },
+    "notable_event_comment": {
+      "title": "Notable Event Comment",
+      "kind": "object",
+      "object_type": "notable_event_comment",
+      "endpoint": "/event_management_interface/notable_event_comment",
+      "attribute_count": 15,
+      "subordinate_objects": []
+    },
+    "notable_event_email_template": {
+      "title": "Notable Event Email Template",
+      "kind": "object",
+      "object_type": "notable_event_email_template",
+      "endpoint": "/event_management_interface/notable_event_email_template",
+      "attribute_count": 11,
+      "subordinate_objects": []
+    },
+    "notable_event_group": {
+      "title": "Notable Event Group",
+      "kind": "object",
+      "object_type": "notable_event_group",
+      "endpoint": "/event_management_interface/notable_event_group",
+      "attribute_count": 13,
+      "subordinate_objects": []
+    },
+    "service": {
+      "title": "Service",
+      "kind": "object",
+      "object_type": "service",
+      "endpoint": "/itoa_interface/service",
+      "attribute_count": 23,
+      "subordinate_objects": [
+        "entity_rules",
+        "service_kpi"
+      ]
+    },
+    "service_kpi": {
+      "title": "Service KPI",
+      "kind": "subordinate",
+      "object_type": null,
+      "endpoint": null,
+      "attribute_count": 69,
+      "subordinate_objects": []
+    },
+    "service_template_kpi": {
+      "title": "Service Template KPI",
+      "kind": "subordinate",
+      "object_type": null,
+      "endpoint": null,
+      "attribute_count": 43,
+      "subordinate_objects": [
+        "kpi_threshold_settings",
+        "time_variate_thresholds_specification",
+        "anomaly_detection_algorithm_settings"
+      ]
+    },
+    "team": {
+      "title": "Team",
+      "kind": "object",
+      "object_type": "team",
+      "endpoint": "/itoa_interface/team",
+      "attribute_count": 16,
+      "subordinate_objects": []
+    },
+    "time_variate_thresholds_specification": {
+      "title": "Time Variate Thresholds Specification",
+      "kind": "subordinate",
+      "object_type": null,
+      "endpoint": null,
+      "attribute_count": 13,
+      "subordinate_objects": []
+    }
+  }
+}

--- a/mcp_itsi/knowledge/schema/data/kpi_base_search.json
+++ b/mcp_itsi/knowledge/schema/data/kpi_base_search.json
@@ -1,0 +1,332 @@
+{
+  "slug": "kpi_base_search",
+  "title": "KPI Base Search",
+  "kind": "object",
+  "description": "Searches that can be aggregated together to reduce overall search load. KPI Base Searches include the core attributes of a KPI for search generation. `kpi_base_search` objects are contained within the KPI (`kpis`) object data structure.",
+  "object_type": "kpi_base_search",
+  "interface": "/itoa_interface",
+  "endpoint": "/itoa_interface/kpi_base_search",
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "entity_alias_filtering_fields",
+      "label": "entity_alias_filtering_fields",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The fields to filter on. See KPI definition.",
+      "subordinate": null
+    },
+    {
+      "name": "_version",
+      "label": "_version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "ITSI version number of this KPI base search.",
+      "subordinate": null
+    },
+    {
+      "name": "description",
+      "label": "description",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "General description for this KPI base search.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Source of the last modification.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The time of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "is_service_entity_filter",
+      "label": "is_service_entity_filter",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "If true a filter is used on the search based on the entities included in the service.",
+      "subordinate": null
+    },
+    {
+      "name": "actions",
+      "label": "actions",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "kpi_base_search",
+      "subordinate": null
+    },
+    {
+      "name": "is_entity_breakdown",
+      "label": "is_entity_breakdown",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "Determines if search breaks down by entities.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "KV store owner.",
+      "subordinate": null
+    },
+    {
+      "name": "source_itsi_da",
+      "label": "source_itsi_da",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Source of DA used for this search. See KPI Threshold Templates.",
+      "subordinate": null
+    },
+    {
+      "name": "metrics",
+      "label": "metrics",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "Set of statistical operations performed on threshold field.",
+      "subordinate": null
+    },
+    {
+      "name": "aggregate_statop",
+      "label": "aggregate_statop",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Statistical operation (avg, max, median, stdev, and so on) used to combine data for the aggregate alert_value (used for all KPI).",
+      "subordinate": null
+    },
+    {
+      "name": "unit",
+      "label": "unit",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User-defined units for the values in threshold field.",
+      "subordinate": null
+    },
+    {
+      "name": "title",
+      "label": "title",
+      "type": "string",
+      "type_raw": "String",
+      "required": true,
+      "read_only": false,
+      "description": "Name of this metric",
+      "subordinate": null
+    },
+    {
+      "name": "_key",
+      "label": "_key",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Internal identifier.",
+      "subordinate": null
+    },
+    {
+      "name": "threshold_field",
+      "label": "threshold_field",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The field on which the statistical operation runs.",
+      "subordinate": null
+    },
+    {
+      "name": "entity_statop",
+      "label": "entity_statop",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Statistical operation (avg, max, mean, and so on) used to combine data for alert_values on a per entity basis (used if is_entity_breakdown is true).",
+      "subordinate": null
+    },
+    {
+      "name": "search_alert_earliest",
+      "label": "search_alert_earliest",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Earliest time to look for events every time KPI search runs. This determines how far back each time window is during KPI search runs.",
+      "subordinate": null
+    },
+    {
+      "name": "alert_period",
+      "label": "alert_period",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User specified interval to run the KPI search in minutes.",
+      "subordinate": null
+    },
+    {
+      "name": "alert_lag",
+      "label": "alert_lag",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Contains the number of seconds of lag to apply to the alert search, max is 30 minutes (1800 seconds).",
+      "subordinate": null
+    },
+    {
+      "name": "base_search",
+      "label": "base_search",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "KPI search defined by user for this KPI. All generated searches for the KPI are based on this search.",
+      "subordinate": null
+    },
+    {
+      "name": "entity_id_fields",
+      "label": "entity_id_fields",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Fields from this KPI's search events that will be mapped to the alias fields defined in entities for the service containing this KPI. This field enables the KPI search to tie the aliases of entities to the fields from the KPI events in identifying entities at search time.",
+      "subordinate": null
+    },
+    {
+      "name": "identifying_name",
+      "label": "identifying_name",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Internal only",
+      "subordinate": null
+    },
+    {
+      "name": "mod_timestamp",
+      "label": "mod_timestamp",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "acl",
+      "label": "acl",
+      "type": "object",
+      "type_raw": "Object",
+      "required": false,
+      "read_only": true,
+      "description": "Access control blob.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Like owner, but different.",
+      "subordinate": null
+    },
+    {
+      "name": "sec_grp",
+      "label": "sec_grp",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The team the object belongs to. This object can only belong to default_itsi_security_group (Global team).",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/kpi_threshold_levels.json
+++ b/mcp_itsi/knowledge/schema/data/kpi_threshold_levels.json
@@ -1,0 +1,162 @@
+{
+  "slug": "kpi_threshold_levels",
+  "title": "KPI Threshold Levels",
+  "kind": "subordinate",
+  "description": "KPI Threshold Levels determine how ITSI extracts health status information from KPI searches. Threshold levels are user-configured values that can be augmented further using adaptive thresholding.",
+  "object_type": null,
+  "interface": null,
+  "endpoint": null,
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "thresholdValue",
+      "label": "thresholdValue",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Value for the threshold field stats identifying this threshold level. This is the key value that defines the levels for values derived from the KPI search metrics.",
+      "subordinate": null
+    },
+    {
+      "name": "severityColor",
+      "label": "severityColor",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Severity color assigned for this threshold level.",
+      "subordinate": null
+    },
+    {
+      "name": "severityColorLight",
+      "label": "severityColorLight",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Severity light color assigned for this threshold level.",
+      "subordinate": null
+    },
+    {
+      "name": "severityValue",
+      "label": "severityValue",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Severity value assigned for this threshold level.",
+      "subordinate": null
+    },
+    {
+      "name": "severityLabel",
+      "label": "severityLabel",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Severity label assigned for this threshold level like info, warning, critical, etc.",
+      "subordinate": null
+    },
+    {
+      "name": "dynamicParam",
+      "label": "dynamicParam",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Value of the dynamic parameter for adaptive thresholds.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/kpi_threshold_settings.json
+++ b/mcp_itsi/knowledge/schema/data/kpi_threshold_settings.json
@@ -1,0 +1,224 @@
+{
+  "slug": "kpi_threshold_settings",
+  "title": "KPI Threshold Settings",
+  "kind": "subordinate",
+  "description": "KPI Threshold Settings define the thresholds that a KPI uses to compute health status information. KPI Threshold Settings also contain information for rendering KPI threshold graphs.",
+  "object_type": null,
+  "interface": null,
+  "endpoint": null,
+  "subordinate_objects": [
+    "kpi_threshold_levels"
+  ],
+  "attributes": [
+    {
+      "name": "gaugeMin",
+      "label": "gaugeMin",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Minimum value for the threshold gauge specified by user.",
+      "subordinate": null
+    },
+    {
+      "name": "gaugeMax",
+      "label": "gaugeMax",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Maximum value for the threshold gauge specified by user.",
+      "subordinate": null
+    },
+    {
+      "name": "search",
+      "label": "search",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Generated search used to compute the thresholds for this KPI.",
+      "subordinate": null
+    },
+    {
+      "name": "baseSeverityValue",
+      "label": "baseSeverityValue",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Value for base threshold level.",
+      "subordinate": null
+    },
+    {
+      "name": "baseSeverityColor",
+      "label": "baseSeverityColor",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Severity color assigned for the base threshold level.",
+      "subordinate": null
+    },
+    {
+      "name": "baseSeverityColorLight",
+      "label": "baseSeverityColorLight",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Severity light color assigned for the base threshold level.",
+      "subordinate": null
+    },
+    {
+      "name": "baseSeverityLabel",
+      "label": "baseSeverityLabel",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Severity label assigned for the base threshold level, including info, warning, critical, etc.",
+      "subordinate": null
+    },
+    {
+      "name": "metricField",
+      "label": "metricField",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Thresholding field from the search.",
+      "subordinate": null
+    },
+    {
+      "name": "renderBoundaryMin",
+      "label": "renderBoundaryMin",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Lower bound value to use to render the graph for the thresholds.",
+      "subordinate": null
+    },
+    {
+      "name": "renderBoundaryMax",
+      "label": "renderBoundaryMax",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Upper bound value to use to render the graph for the thresholds.",
+      "subordinate": null
+    },
+    {
+      "name": "isMaxStatic",
+      "label": "isMaxStatic",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "True when maximum threshold value is a static value, false otherwise.",
+      "subordinate": null
+    },
+    {
+      "name": "isMinStatic",
+      "label": "isMinStatic",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "True when min threshold value is a static value, false otherwise.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/kpi_threshold_template.json
+++ b/mcp_itsi/knowledge/schema/data/kpi_threshold_template.json
@@ -1,0 +1,172 @@
+{
+  "slug": "kpi_threshold_template",
+  "title": "KPI Threshold Templates",
+  "kind": "object",
+  "description": "A `kpi_threshold_template` is a set of predefined threshold values that you can apply to multiple KPIs.",
+  "object_type": "kpi_threshold_template",
+  "interface": "/itoa_interface",
+  "endpoint": "/itoa_interface/kpi_threshold_template",
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "title",
+      "label": "title",
+      "type": "string",
+      "type_raw": "String",
+      "required": true,
+      "read_only": false,
+      "description": "Name of this template.",
+      "subordinate": null
+    },
+    {
+      "name": "description",
+      "label": "description",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Description of this particular template.",
+      "subordinate": null
+    },
+    {
+      "name": "adaptive_thresholding_training_window",
+      "label": "adaptive_thresholding_training_window",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Earliest time for the adaptive threshold training algorithm to run over. The latest time is always `now`.",
+      "subordinate": null
+    },
+    {
+      "name": "time_variate_thresholds",
+      "label": "time_variate_thresholds",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "If true, thresholds for alerts are pulled from time_variate_thresholds_specification.",
+      "subordinate": null
+    },
+    {
+      "name": "time_variate_thresholds_specification",
+      "label": "time_variate_thresholds_specification",
+      "type": "object",
+      "type_raw": "Object",
+      "required": false,
+      "read_only": false,
+      "description": "Data structure for time variate threshold specification.",
+      "subordinate": null
+    },
+    {
+      "name": "adaptive_thresholds_is_enabled",
+      "label": "adaptive_thresholds_is_enabled",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "If true, adaptive thresholding is enabled for this KPI.",
+      "subordinate": null
+    },
+    {
+      "name": "sec_grp",
+      "label": "sec_grp",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The team the object belongs to. This object can only belong to default_itsi_security_group (Global team).",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/maintenance_calendar.json
+++ b/mcp_itsi/knowledge/schema/data/maintenance_calendar.json
@@ -1,0 +1,162 @@
+{
+  "slug": "maintenance_calendar",
+  "title": "Maintenance Calendar",
+  "kind": "object",
+  "description": "Use `maintenance_calendar` to put services and entities in maintenance mode at required intervals.",
+  "object_type": "maintenance_calendar",
+  "interface": "/maintenance_services_interface",
+  "endpoint": "/maintenance_services_interface/maintenance_calendar",
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "_key",
+      "label": "_key",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Unique ID for the entry in the KV store.",
+      "subordinate": null
+    },
+    {
+      "name": "title",
+      "label": "title",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Title of the maintenance window.",
+      "subordinate": null
+    },
+    {
+      "name": "comment",
+      "label": "comment",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Optional description of the maintenance window.",
+      "subordinate": null
+    },
+    {
+      "name": "objects",
+      "label": "objects",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "Array of dictionaries describing the objects put in maintenance by this maintenance window. The schema for each object definition in the array: `_key`: Unique if assigned to the object currently. `object_type`: Type of object being identified. Currently only `entity` and `service` are supported.",
+      "subordinate": null
+    },
+    {
+      "name": "start_time",
+      "label": "start_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Timestamp that marks the beginning of maintenance window. Based on UTC time.",
+      "subordinate": null
+    },
+    {
+      "name": "end_time",
+      "label": "end_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Timestamp that marks the end of maintenance window. Based on UTC time.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/notable_event_aggregation_policy.json
+++ b/mcp_itsi/knowledge/schema/data/notable_event_aggregation_policy.json
@@ -1,0 +1,222 @@
+{
+  "slug": "notable_event_aggregation_policy",
+  "title": "Notable Event Aggregation Policy",
+  "kind": "object",
+  "description": "`notable_event_aggregation_policy` contains the data for a notable event aggregation policy which aggregates notable events into episodes.",
+  "object_type": "notable_event_aggregation_policy",
+  "interface": "/event_management_interface",
+  "endpoint": "/event_management_interface/notable_event_aggregation_policy",
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "disabled",
+      "label": "disabled",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "`1` if the aggregation policy is disabled and `0` if enabled.",
+      "subordinate": null
+    },
+    {
+      "name": "breaking_criteria",
+      "label": "breaking_criteria",
+      "type": "object",
+      "type_raw": "Object",
+      "required": false,
+      "read_only": false,
+      "description": "A JSON blob of all the criteria used to break an episode.",
+      "subordinate": null
+    },
+    {
+      "name": "filter_criteria",
+      "label": "filter_criteria",
+      "type": "object",
+      "type_raw": "Object",
+      "required": false,
+      "read_only": false,
+      "description": "A JSON blob of all the criteria used to filter events into an episode.",
+      "subordinate": null
+    },
+    {
+      "name": "is_default",
+      "label": "is_default",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "Indicates if this is the default aggregation policy. `1` if it's the default policy and `0` if not.",
+      "subordinate": null
+    },
+    {
+      "name": "description",
+      "label": "description",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The description of the notable event aggregation policy.",
+      "subordinate": null
+    },
+    {
+      "name": "group_severity",
+      "label": "group_severity",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The default severity of each episode created by the notable event aggregation policy.",
+      "subordinate": null
+    },
+    {
+      "name": "group_status",
+      "label": "group_status",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The default status of each episode created by the notable event aggregation policy.",
+      "subordinate": null
+    },
+    {
+      "name": "group_asignee",
+      "label": "group_asignee",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The default owner of each episode created by the notable event aggregation policy.",
+      "subordinate": null
+    },
+    {
+      "name": "group_description",
+      "label": "group_description",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The default description of each episode created by the notable event aggregation policy.",
+      "subordinate": null
+    },
+    {
+      "name": "title",
+      "label": "title",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The title of the notable event aggregation policy.",
+      "subordinate": null
+    },
+    {
+      "name": "rules",
+      "label": "rules",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "An array of all the rules and actions to be executed for the notable event aggregation policy.",
+      "subordinate": null
+    },
+    {
+      "name": "split_by_field",
+      "label": "split_by_field",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "A string containing all the fields to split episodes by.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/notable_event_comment.json
+++ b/mcp_itsi/knowledge/schema/data/notable_event_comment.json
@@ -1,0 +1,162 @@
+{
+  "slug": "notable_event_comment",
+  "title": "Notable Event Comment",
+  "kind": "object",
+  "description": "`notable_event_comment` contains comments associated with an episode.",
+  "object_type": "notable_event_comment",
+  "interface": "/event_management_interface",
+  "endpoint": "/event_management_interface/notable_event_comment",
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "comment",
+      "label": "comment",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The text of the comment.",
+      "subordinate": null
+    },
+    {
+      "name": "event_id",
+      "label": "event_id",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The episode ID that the comment is associated with.",
+      "subordinate": null
+    },
+    {
+      "name": "is_group",
+      "label": "is_group",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "The episode ID that the comment is associated with.",
+      "subordinate": null
+    },
+    {
+      "name": "filter_search",
+      "label": "filter_search",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The search to retrieve all the comments for an episode.",
+      "subordinate": null
+    },
+    {
+      "name": "earliest_time",
+      "label": "earliest_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The time, in UTC, of the first event in the episode.",
+      "subordinate": null
+    },
+    {
+      "name": "latest_time",
+      "label": "latest_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The time, in UTC, of the last event in the episode.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/notable_event_email_template.json
+++ b/mcp_itsi/knowledge/schema/data/notable_event_email_template.json
@@ -1,0 +1,122 @@
+{
+  "slug": "notable_event_email_template",
+  "title": "Notable Event Email Template",
+  "kind": "object",
+  "description": "`notable_event_email_template` contains the data for email templates for episode actions. Once you create a template it's available for selection in all aggregation policies and is not policy-specific.",
+  "object_type": "notable_event_email_template",
+  "interface": "/event_management_interface",
+  "endpoint": "/event_management_interface/notable_event_email_template",
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "title",
+      "label": "title",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The name of the message template. This element is required.",
+      "subordinate": null
+    },
+    {
+      "name": "message",
+      "label": "message",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The body of the email. Supports tokens such as `$result.title$` and `$result.description$`. This element is required.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/notable_event_group.json
+++ b/mcp_itsi/knowledge/schema/data/notable_event_group.json
@@ -1,0 +1,142 @@
+{
+  "slug": "notable_event_group",
+  "title": "Notable Event Group",
+  "kind": "object",
+  "description": "The `notable_event_group` contains information about an episode.",
+  "object_type": "notable_event_group",
+  "interface": "/event_management_interface",
+  "endpoint": "/event_management_interface/notable_event_group",
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "severity",
+      "label": "severity",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The level of importance of the episode. Values must match an integer specified in the default version of `itsi_notable_event_severity.conf` (or the local version if you created one). Default values: `1` \\- Info `2` \\- Normal `3` \\- Low `4` \\- Medium `5` \\- High `6` \\- Critical",
+      "subordinate": null
+    },
+    {
+      "name": "status",
+      "label": "status",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The triage status of the episode in Episode Review. Values must match an integer specified in the default version of `itsi_notable_event_status.conf` (or the local version if you created one). Default values: `0` \\- Unassigned `1` \\- New `2` \\- In Progress `3` \\- Pending `4` \\- Resolved `5` \\- Closed",
+      "subordinate": null
+    },
+    {
+      "name": "owner",
+      "label": "owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The Splunk user who is the owner of the episode.",
+      "subordinate": null
+    },
+    {
+      "name": "_key",
+      "label": "_key",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The episode ID that a change is associated with.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/service.json
+++ b/mcp_itsi/knowledge/schema/data/service.json
@@ -1,0 +1,245 @@
+{
+  "slug": "service",
+  "title": "Service",
+  "kind": "object",
+  "description": "An ITSI service is a representation of a real world IT service. You can configure an ITSI service to monitor various IT metrics using KPI searches, which reflect the health of a service. ITSI services can describe any real world IT service, such as a network service or email service. The `service` object contains the service definition, including entities, KPIs, and dependent services.",
+  "object_type": "service",
+  "interface": "/itoa_interface",
+  "endpoint": "/itoa_interface/service",
+  "subordinate_objects": [
+    "entity_rules",
+    "service_kpi"
+  ],
+  "attributes": [
+    {
+      "name": "_key",
+      "label": "_key",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Auto-generated unique identifier for this service.",
+      "subordinate": null
+    },
+    {
+      "name": "description",
+      "label": "description",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User defined description for the service.",
+      "subordinate": null
+    },
+    {
+      "name": "title",
+      "label": "title",
+      "type": "string",
+      "type_raw": "String",
+      "required": true,
+      "read_only": false,
+      "description": "Title of this service.",
+      "subordinate": null
+    },
+    {
+      "name": "kpis",
+      "label": "kpis",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "Array of KPI descriptions for this service.",
+      "subordinate": "service_kpi"
+    },
+    {
+      "name": "entity_rules",
+      "label": "entity_rules",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "Array of rules describing entities referenced by this service.",
+      "subordinate": "entity_rules"
+    },
+    {
+      "name": "services_depends_on",
+      "label": "services_depends_on",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "Array of service descriptions with KPIs in those services that this service depends on.",
+      "subordinate": null
+    },
+    {
+      "name": "service_id",
+      "label": "service_id",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "_key value of service that this service depends on.",
+      "subordinate": null
+    },
+    {
+      "name": "kpis_depending_on",
+      "label": "kpis_depending_on",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "Array of _key ids for each KPI in service identified by serviceid, which this service will depend on.",
+      "subordinate": null
+    },
+    {
+      "name": "services_depending_on_me",
+      "label": "services_depending_on_me",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "An array of service descriptions with KPIs in this service that those services depend on.",
+      "subordinate": null
+    },
+    {
+      "name": "serviceid",
+      "label": "serviceid",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "_key value of service that depends on this service.",
+      "subordinate": null
+    },
+    {
+      "name": "enabled",
+      "label": "enabled",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "If set to 1, service is enabled. If value is absent or not set to 1, service is disabled. On upgrade service is flagged as enabled.",
+      "subordinate": null
+    },
+    {
+      "name": "sec_grp",
+      "label": "sec_grp",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The team the object belongs to.",
+      "subordinate": null
+    },
+    {
+      "name": "base_service_template_id",
+      "label": "base_service_template_id",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The ID of the service template the service is linked to. Not required. If empty, the service is not linked to a service template. To create a service based on a service template, include this field.",
+      "subordinate": null
+    },
+    {
+      "name": "service_tags",
+      "label": "service_tags",
+      "type": "object",
+      "type_raw": "Object",
+      "required": false,
+      "read_only": false,
+      "description": "The tags for the service. The `service_tags` object can have an array for `tags` and `template_tags`. `tags` are regular tags that are added manually and `template_tags` are tags that are populated from a service template. Tags have to be strings and can't contain the following characters: `/ \\ \" ' ! @ ? . , ; $ ^` Example `service_tags` object: JSONCopy ```json \"service_tags\": { \"tags\": [ \"unix\", \"seattle\" ], \"template_tags\": [ \"cloud_systems\", \"us-west\" ] }, ```",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/service_kpi.json
+++ b/mcp_itsi/knowledge/schema/data/service_kpi.json
@@ -1,0 +1,702 @@
+{
+  "slug": "service_kpi",
+  "title": "Service KPI",
+  "kind": "subordinate",
+  "description": "KPI is the data structure that drives the monitoring of service metrics. Each KPI object contains specific information, including a user-configured base search, from which ITSI generates the search that monitors a metric. KPI objects also contain information on how to apply thresholds that determine the metric severity level. KPI objects (`kpis`) are defined and contained within the `service` object type data structure.",
+  "object_type": null,
+  "interface": null,
+  "endpoint": null,
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "_key",
+      "label": "_key",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Auto-generated unique ID for this KPI.",
+      "subordinate": null
+    },
+    {
+      "name": "title",
+      "label": "title",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User-defined name for the KPI",
+      "subordinate": null
+    },
+    {
+      "name": "description",
+      "label": "description",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User-defined description for the KPI.",
+      "subordinate": null
+    },
+    {
+      "name": "type",
+      "label": "type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "kpi_primary",
+      "subordinate": null
+    },
+    {
+      "name": "kpi_threshold_template_id",
+      "label": "kpi_threshold_template_id",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User-defined ID for the KPI. Used to refer to KPIs within a KPI template in modules. This uniquely identifies a KPI template in ITSI.",
+      "subordinate": null
+    },
+    {
+      "name": "isadhoc",
+      "label": "isadhoc",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "If true the search is split on entities and thresholds are computed for both entity and aggregate.",
+      "subordinate": null
+    },
+    {
+      "name": "is_service_entity_filter",
+      "label": "is_service_entity_filter",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "If true a filter is used on the search based on the entities included in the service.",
+      "subordinate": null
+    },
+    {
+      "name": "datamode",
+      "label": "datamode",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The data model to use for search generation if this is a data model type search.",
+      "subordinate": null
+    },
+    {
+      "name": "datamodel_filter",
+      "label": "datamodel_filter",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "ITSI generated clauses for user-defined filters on top of the data model fields. Used in the KPI search to filter events required by this KPI.",
+      "subordinate": null
+    },
+    {
+      "name": "threshold_field",
+      "label": "threshold_field",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User-specified field on which statistical operations are performed and whose value determines KPI health.",
+      "subordinate": null
+    },
+    {
+      "name": "entity_statop",
+      "label": "entity_statop",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Statistical operation (avg, max, mean, and so on) used to combine data for alert_values on a per entity basis (used if entity_breakdown is true).",
+      "subordinate": null
+    },
+    {
+      "name": "aggregate_statop",
+      "label": "aggregate_statop",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Statistical operation (avg, max, median, stdev, and so on) used to combine data for the aggregate alert_value (used for all KPI).",
+      "subordinate": null
+    },
+    {
+      "name": "urgency",
+      "label": "urgency",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "User-assigned importance value for this KPI.",
+      "subordinate": null
+    },
+    {
+      "name": "unit",
+      "label": "unit",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User-defined units for the values in threshold field.",
+      "subordinate": null
+    },
+    {
+      "name": "entity_id_fields",
+      "label": "entity_id_fields",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Fields from this KPI's search events that will be mapped to the alias fields defined in entities for the service containing this KPI. This field enables the KPI search to tie the aliases of entities to the fields from the KPI events in identifying entities at search time.",
+      "subordinate": null
+    },
+    {
+      "name": "entity_alias_filtering_fields",
+      "label": "entity_alias_filtering_fields",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Subset of aliases from all entities included in the service containing this KPI, to restrict this KPI to only the subset of entities matching via the subset of aliases. Helps filter entities for this KPI among the ones selected in the service containing this KPI.",
+      "subordinate": null
+    },
+    {
+      "name": "cron_schedule",
+      "label": "cron_schedule",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The cron schedule that determines the frequency of this KPI search.",
+      "subordinate": null
+    },
+    {
+      "name": "base_search",
+      "label": "base_search",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "KPI search defined by user for this KPI. All generated searches for the KPI are based on this search.",
+      "subordinate": null
+    },
+    {
+      "name": "kpi_base_search",
+      "label": "kpi_base_search",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "A basic search generated for the KPI search.",
+      "subordinate": null
+    },
+    {
+      "name": "search",
+      "label": "search",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Generated search for this KPI for base statistics on the threshold field.",
+      "subordinate": null
+    },
+    {
+      "name": "search_entities",
+      "label": "search_entities",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Generated search for this KPI for base statistics on the threshold field to use for \"Per Entity\" threshold type.",
+      "subordinate": null
+    },
+    {
+      "name": "search_aggregate",
+      "label": "search_aggregate",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Generated search for this KPI for base statistics on the threshold field to use for \"Aggregate\" or \"Both\" threshold type.",
+      "subordinate": null
+    },
+    {
+      "name": "search_time_series",
+      "label": "search_time_series",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Generated search used primarily to show preview information in the KPI configuration page.",
+      "subordinate": null
+    },
+    {
+      "name": "search_time_series_entities",
+      "label": "search_time_series_entities",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Generated search used primarily to show preview information for \"Per Entity\" threshold type in the KPI configuration page",
+      "subordinate": null
+    },
+    {
+      "name": "search_time_series_aggregate",
+      "label": "search_time_series_aggregate",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Generated search used primarily to show preview information for \"Aggregate\" or \"Both\" threshold type in the KPI configuration page.",
+      "subordinate": null
+    },
+    {
+      "name": "search_time_compare",
+      "label": "search_time_compare",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Generated search used specifically by glass table.",
+      "subordinate": null
+    },
+    {
+      "name": "search_alert",
+      "label": "search_alert",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Generated search used for alerting based on KPI threshold. This is the search that runs on schedule via the saved search for this KPI.",
+      "subordinate": null
+    },
+    {
+      "name": "search_alert_entities",
+      "label": "search_alert_entities",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Generated search to use for alerting based on KPI threshold for \"Per Entity\" threshold type.",
+      "subordinate": null
+    },
+    {
+      "name": "alert_on",
+      "label": "alert_on",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Specified if the threshold type for this KPI is \"Per Entity\" or \"Aggregate\" or \"Both\". Possible values: aggregate, entities, both.",
+      "subordinate": null
+    },
+    {
+      "name": "alert_period",
+      "label": "alert_period",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User specified interval to run the KPI search in minutes.",
+      "subordinate": null
+    },
+    {
+      "name": "alert_lag",
+      "label": "alert_lag",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Contains the number of seconds of lag to apply to the alert search. The maximum value is 30 minutes (1800 seconds).",
+      "subordinate": null
+    },
+    {
+      "name": "search_alert_earliest",
+      "label": "search_alert_earliest",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Earliest time to look for events every time KPI search runs. This determines how far back each time window is during KPI search runs.",
+      "subordinate": null
+    },
+    {
+      "name": "tz_offset",
+      "label": "tz_offset",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "ISO time zone offset. Note: Do not change this value.",
+      "subordinate": null
+    },
+    {
+      "name": "time_variate_thresholds",
+      "label": "time_variate_thresholds",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "If true, thresholds for alerts are pulled from time_variate_thresholds_specification.",
+      "subordinate": null
+    },
+    {
+      "name": "time_variate_thresholds_specification",
+      "label": "time_variate_thresholds_specification",
+      "type": "object",
+      "type_raw": "Object",
+      "required": false,
+      "read_only": false,
+      "description": "Data structure for time variate threshold specs.",
+      "subordinate": "time_variate_thresholds_specification"
+    },
+    {
+      "name": "backfill_enabled",
+      "label": "backfill_enabled",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "Indicates if backfill has been enabled for this KPI",
+      "subordinate": null
+    },
+    {
+      "name": "backfill_earliest_time",
+      "label": "backfill_earliest_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Requested earliest time for backfill (relative time offset). Should be in the format `-Xd`, where 'd' means the time is in days, 'X' is number of days to backfill, and '-' means the date is in the past.",
+      "subordinate": null
+    },
+    {
+      "name": "adaptive_thresholds_is_enabled",
+      "label": "adaptive_thresholds_is_enabled",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "Determines if adaptive threshold is enabled for this KPI.",
+      "subordinate": null
+    },
+    {
+      "name": "adaptive_thresholding_training_window",
+      "label": "adaptive_thresholding_training_window",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Earliest time for the Adaptive Threshold training algorithm to run over (latest time is always 'now') (e.g. '-7d')",
+      "subordinate": null
+    },
+    {
+      "name": "anomaly_detection_is_enabled",
+      "label": "anomaly_detection_is_enabled",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "Determines if trending anomaly detection is enabled.",
+      "subordinate": null
+    },
+    {
+      "name": "cohesive_anomaly_detection_is_enabled",
+      "label": "cohesive_anomaly_detection_is_enabled",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "Determines if cohesive anomaly detection is enabled.",
+      "subordinate": null
+    },
+    {
+      "name": "anomaly_detection_alerting_enabled",
+      "label": "anomaly_detection_alerting_enabled",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "Determines if anomaly detection will alert for anomalies.",
+      "subordinate": null
+    },
+    {
+      "name": "anomaly_detection_training_window",
+      "label": "anomaly_detection_training_window",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Earliest time for the training algorithm to run over (latest time is always 'now') (e.g. '-7d').",
+      "subordinate": null
+    },
+    {
+      "name": "trending_ad",
+      "label": "trending_ad",
+      "type": "object",
+      "type_raw": "Object",
+      "required": false,
+      "read_only": false,
+      "description": "Data structure for trending anomaly detection algorithm settings. See [Anomaly Detection Algorithm Settings](https://help.splunk.com/en/splunk-it-service-intelligence/splunk-it-service-intelligence/leverage-rest-apis/4.21/itsi-rest-api-schema/itsi-rest-api-schema#id_4278bd48_f68a_48ce_8396_b710dc0c3eb2--en__Anomaly_Detection_Algorithm_Settings).",
+      "subordinate": "anomaly_detection_algorithm_settings"
+    },
+    {
+      "name": "cohesive_ad",
+      "label": "cohesive_ad",
+      "type": "object",
+      "type_raw": "Object",
+      "required": false,
+      "read_only": false,
+      "description": "Data structure for cohesive anomaly detection algorithm settings. See [Anomaly Detection Algorithm Settings](https://help.splunk.com/en/splunk-it-service-intelligence/splunk-it-service-intelligence/leverage-rest-apis/4.21/itsi-rest-api-schema/itsi-rest-api-schema#id_4278bd48_f68a_48ce_8396_b710dc0c3eb2--en__Anomaly_Detection_Algorithm_Settings).",
+      "subordinate": "anomaly_detection_algorithm_settings"
+    },
+    {
+      "name": "gap_severity",
+      "label": "gap_severity",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Severity level assigned for data gaps (info, normal, low, medium, high, critical, or unknown)",
+      "subordinate": null
+    },
+    {
+      "name": "gap_severity_color",
+      "label": "gap_severity_color",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Severity color assigned for data gaps.",
+      "subordinate": null
+    },
+    {
+      "name": "gap_severity_color_light",
+      "label": "gap_severity_color_light",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Severity color assigned for data gaps.",
+      "subordinate": null
+    },
+    {
+      "name": "gap_severity_value",
+      "label": "gap_severity_value",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Severity value assigned for data gaps.",
+      "subordinate": null
+    },
+    {
+      "name": "entity_thresholds",
+      "label": "entity_thresholds",
+      "type": "object",
+      "type_raw": "Object",
+      "required": false,
+      "read_only": false,
+      "description": "User-defined thresholding levels for \"Per Entity\" threshold type. For more information, see KPI Threshold Setting.",
+      "subordinate": "kpi_threshold_settings"
+    },
+    {
+      "name": "aggregate_thresholds",
+      "label": "aggregate_thresholds",
+      "type": "array",
+      "type_raw": "Objects",
+      "required": false,
+      "read_only": false,
+      "description": "User-defined thresholding levels for \"Aggregate\" threshold type. For more information, see KPI Threshold Setting.",
+      "subordinate": "kpi_threshold_settings"
+    },
+    {
+      "name": "enabled",
+      "label": "enabled",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "If set to 1, KPI is enabled. If absent or not set to 1, KPI is disabled. On upgrade KPI is flagged as enabled. Field is read-only.",
+      "subordinate": null
+    },
+    {
+      "name": "base_service_template_id",
+      "label": "base_service_template_id",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The key of service template object if the KPI is inherited from a service template.",
+      "subordinate": null
+    },
+    {
+      "name": "entity_breakdown_id_field",
+      "label": "entity_breakdown_id_field",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "KPI search events are split by the alias field defined in entities for the service containing this KPI.",
+      "subordinate": null
+    },
+    {
+      "name": "aggregate_outlier_detection_enabled",
+      "label": "aggregate_outlier_detection_enabled",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "Indicates if outlier exclusion is turned on for KPI.",
+      "subordinate": null
+    },
+    {
+      "name": "outlier_detection_algo",
+      "label": "outlier_detection_algo",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Determines the outlier detection algorithm.",
+      "subordinate": null
+    },
+    {
+      "name": "outlier_detection_sensitivity",
+      "label": "outlier_detection_sensitivity",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The trigger threshold of the algorithm. For the standard deviation, this is the number of standard deviations. For interquartile range and mean absolute deviation, this is the sensitivity value.",
+      "subordinate": null
+    },
+    {
+      "name": "recommendation_start_date",
+      "label": "recommendation_start_date",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The date that a KPI threshold recommendation will be applied.",
+      "subordinate": null
+    },
+    {
+      "name": "recommendation_training_window",
+      "label": "recommendation_training_window",
+      "type": "string",
+      "type_raw": "The period of time analyzed to generate threshold recommendations with machine learning.",
+      "required": false,
+      "read_only": false,
+      "description": "String",
+      "subordinate": null
+    },
+    {
+      "name": "threshold_direction",
+      "label": "threshold_direction",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Determines if your KPI should stay above or below a specific value, or constrained to a specific range.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/service_template_kpi.json
+++ b/mcp_itsi/knowledge/schema/data/service_template_kpi.json
@@ -1,0 +1,446 @@
+{
+  "slug": "service_template_kpi",
+  "title": "Service Template KPI",
+  "kind": "subordinate",
+  "description": "KPI is the data structure that drives the monitoring of service metrics. KPI objects for service templates differ slightly from KPI objects for services. For example, service template KPIs can only use base searches, not ad hoc searches or searches based on data models. You can't enable anomaly detection for service template KPIs. KPI objects, `kpis`, for service templates are defined and contained within the `base_service_template` object type data structure.",
+  "object_type": null,
+  "interface": null,
+  "endpoint": null,
+  "subordinate_objects": [
+    "kpi_threshold_settings",
+    "time_variate_thresholds_specification",
+    "anomaly_detection_algorithm_settings"
+  ],
+  "attributes": [
+    {
+      "name": "_key",
+      "label": "_key",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Auto-generated unique ID for this KPI.",
+      "subordinate": null
+    },
+    {
+      "name": "title",
+      "label": "title",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User-defined name for the KPI",
+      "subordinate": null
+    },
+    {
+      "name": "description",
+      "label": "description",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User-defined description for the KPI.",
+      "subordinate": null
+    },
+    {
+      "name": "type",
+      "label": "type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "kpi_primary.",
+      "subordinate": null
+    },
+    {
+      "name": "kpi_threshold_template_id",
+      "label": "kpi_threshold_template_id",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User-defined ID for the KPI. Used to refer to KPIs within a KPI template in ITSI modules. This uniquely identifies a KPI template in ITSI.",
+      "subordinate": null
+    },
+    {
+      "name": "is_service_entity_filter",
+      "label": "is_service_entity_filter",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "If true a filter is used on the search based on the entities included in the service.",
+      "subordinate": null
+    },
+    {
+      "name": "datamode",
+      "label": "datamode",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The data model to use for search generation if this is a data model type search.",
+      "subordinate": null
+    },
+    {
+      "name": "datamodel_filter",
+      "label": "datamodel_filter",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "ITSI generated clauses for user-defined filters on top of the data model fields. Used in the KPI search to filter events required by this KPI.",
+      "subordinate": null
+    },
+    {
+      "name": "threshold_field",
+      "label": "threshold_field",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User-specified field on which statistical operations are performed and whose value determines KPI health.",
+      "subordinate": null
+    },
+    {
+      "name": "entity_statop",
+      "label": "entity_statop",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Statistical operation (avg, max, mean, and so on) used to combine data for alert_values on a per entity basis (used if entity_breakdown is true).",
+      "subordinate": null
+    },
+    {
+      "name": "aggregate_statop",
+      "label": "aggregate_statop",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Statistical operation (avg, max, median, stdev, and so on) used to combine data for the aggregate alert_value (used for all KPI).",
+      "subordinate": null
+    },
+    {
+      "name": "urgency",
+      "label": "urgency",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "User-assigned importance value for this KPI.",
+      "subordinate": null
+    },
+    {
+      "name": "unit",
+      "label": "unit",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User-defined units for the values in threshold field.",
+      "subordinate": null
+    },
+    {
+      "name": "entity_id_fields",
+      "label": "entity_id_fields",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Fields from this KPI's search events that will be mapped to the alias fields defined in entities for the service containing this KPI. This field enables the KPI search to tie the aliases of entities to the fields from the KPI events in identifying entities at search time.",
+      "subordinate": null
+    },
+    {
+      "name": "entity_alias_filtering_fields",
+      "label": "entity_alias_filtering_fields",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Subset of aliases from all entities included in the service containing this KPI, to restrict this KPI to only the subset of entities matching via the subset of aliases. Helps filter entities for this KPI among the ones selected in the service containing this KPI.",
+      "subordinate": null
+    },
+    {
+      "name": "cron_schedule",
+      "label": "cron_schedule",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The cron schedule that determines the frequency of this KPI search.",
+      "subordinate": null
+    },
+    {
+      "name": "base_search",
+      "label": "base_search",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "KPI search defined by user for this KPI. All generated searches for the KPI are based on this search.",
+      "subordinate": null
+    },
+    {
+      "name": "kpi_base_search",
+      "label": "kpi_base_search",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "A basic search generated for the KPI search.",
+      "subordinate": null
+    },
+    {
+      "name": "alert_on",
+      "label": "alert_on",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Specified if the threshold type for this KPI is \"Per Entity\" or \"Aggregate\" or \"Both\". Possible values: aggregate, entities, both.",
+      "subordinate": null
+    },
+    {
+      "name": "alert_period",
+      "label": "alert_period",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User specified interval to run the KPI search in minutes.",
+      "subordinate": null
+    },
+    {
+      "name": "alert_lag",
+      "label": "alert_lag",
+      "type": "integer",
+      "type_raw": "Integer",
+      "required": false,
+      "read_only": false,
+      "description": "Contains the number of seconds of lag to apply to the alert search. The maximum is 30 minutes (1800 seconds).",
+      "subordinate": null
+    },
+    {
+      "name": "search_alert_earliest",
+      "label": "search_alert_earliest",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Earliest time to look for events every time KPI search runs. This determines how far back each time window is during KPI search runs.",
+      "subordinate": null
+    },
+    {
+      "name": "tz_offset",
+      "label": "tz_offset",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "ISO time zone offset. Note: Do not change this value.",
+      "subordinate": null
+    },
+    {
+      "name": "time_variate_thresholds_specification_custom",
+      "label": "time_variate_thresholds_specification_custom",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "If true, thresholds for alerts are pulled from time_variate_thresholds_specification.",
+      "subordinate": null
+    },
+    {
+      "name": "adaptive_thresholds_is_enabled",
+      "label": "adaptive_thresholds_is_enabled",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "Determines if adaptive threshold is enabled for this KPI.",
+      "subordinate": null
+    },
+    {
+      "name": "adaptive_thresholding_training_window",
+      "label": "adaptive_thresholding_training_window",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Earliest time for the Adaptive Threshold training algorithm to run over (latest time is always 'now') (e.g. '-7d')",
+      "subordinate": null
+    },
+    {
+      "name": "gap_severity",
+      "label": "gap_severity",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Severity level assigned for data gaps (info, normal, low, medium, high, critical, or unknown)",
+      "subordinate": null
+    },
+    {
+      "name": "gap_severity_color",
+      "label": "gap_severity_color",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Severity color assigned for data gaps.",
+      "subordinate": null
+    },
+    {
+      "name": "gap_severity_color_light",
+      "label": "gap_severity_color_light",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Severity color assigned for data gaps.",
+      "subordinate": null
+    },
+    {
+      "name": "gap_severity_value",
+      "label": "gap_severity_value",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Severity value assigned for data gaps.",
+      "subordinate": null
+    },
+    {
+      "name": "entity_thresholds",
+      "label": "entity_thresholds",
+      "type": "object",
+      "type_raw": "Object",
+      "required": false,
+      "read_only": false,
+      "description": "User-defined thresholding levels for \"Per Entity\" threshold type. For more information, see KPI Threshold Setting.",
+      "subordinate": "kpi_threshold_settings"
+    },
+    {
+      "name": "aggregate_thresholds",
+      "label": "aggregate_thresholds",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User-defined thresholding levels for \"Aggregate\" threshold type. For more information, see KPI Threshold Setting.",
+      "subordinate": "kpi_threshold_settings"
+    },
+    {
+      "name": "enabled",
+      "label": "enabled",
+      "type": "boolean",
+      "type_raw": "Boolean",
+      "required": false,
+      "read_only": false,
+      "description": "If set to 1, KPI is enabled. If absent or not set to 1, KPI is disabled. On upgrade KPI is flagged as enabled. Field is read-only.",
+      "subordinate": null
+    },
+    {
+      "name": "entity_breakdown_id_field",
+      "label": "entity_breakdown_id_field",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "KPI search events are split by the alias field defined in entities for the service containing this KPI.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/team.json
+++ b/mcp_itsi/knowledge/schema/data/team.json
@@ -1,0 +1,172 @@
+{
+  "slug": "team",
+  "title": "Team",
+  "kind": "object",
+  "description": "Teams are used to restrict service-level information in the following objects: - Glass tables - Service analyzers - Deep dives - Episode Review - Correlation searches - Multi-KPI alerts The team object is called `team`.",
+  "object_type": "team",
+  "interface": "/itoa_interface",
+  "endpoint": "/itoa_interface/team",
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "identifying_name",
+      "label": "identifying_name",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The name of the team. Does not have to match `title`.",
+      "subordinate": null
+    },
+    {
+      "name": "acl",
+      "label": "acl",
+      "type": "object",
+      "type_raw": "Object",
+      "required": false,
+      "read_only": true,
+      "description": "Access control list for the team. Must include itoa_admin.",
+      "subordinate": null
+    },
+    {
+      "name": "title",
+      "label": "title",
+      "type": "string",
+      "type_raw": "String",
+      "required": true,
+      "read_only": false,
+      "description": "User provided name of the team. Does not have to match `identifying_name`.",
+      "subordinate": null
+    },
+    {
+      "name": "description",
+      "label": "description",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User provided description of the team.",
+      "subordinate": null
+    },
+    {
+      "name": "children",
+      "label": "children",
+      "type": "array",
+      "type_raw": "List",
+      "required": false,
+      "read_only": false,
+      "description": "List of private teams created in ITSI. For private teams, this field will be an empty list.",
+      "subordinate": null
+    },
+    {
+      "name": "parents",
+      "label": "parents",
+      "type": "array",
+      "type_raw": "List",
+      "required": false,
+      "read_only": false,
+      "description": "The parent of this team. Cannot be configured in current release.",
+      "subordinate": null
+    },
+    {
+      "name": "_key",
+      "label": "_key",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "Unique ID for the entry in KV store.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/data/time_variate_thresholds_specification.json
+++ b/mcp_itsi/knowledge/schema/data/time_variate_thresholds_specification.json
@@ -1,0 +1,142 @@
+{
+  "slug": "time_variate_thresholds_specification",
+  "title": "Time Variate Thresholds Specification",
+  "kind": "subordinate",
+  "description": "This data structure contains the threshold policy collection. A threshold policy includes information on which thresholds are to be applied (a threshold setting model), how those thresholds are generated, and the time periods to which the threshold policy applies. Each policy object includes a single time\\_blocks attribute that contains a list of time periods with which the policy is associated. Note: In the case of static thresholding there are no parameter attributes. In the case of dynamic thresholding, parameters are stored in a simple object within the policy.",
+  "object_type": null,
+  "interface": null,
+  "endpoint": null,
+  "subordinate_objects": [],
+  "attributes": [
+    {
+      "name": "title",
+      "label": "title",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "The title of the threshold spec. Used when creating/modifying threshold spec templates.",
+      "subordinate": null
+    },
+    {
+      "name": "description",
+      "label": "description",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": false,
+      "description": "User-defined description of the threshold specifications.",
+      "subordinate": null
+    },
+    {
+      "name": "policies",
+      "label": "policies",
+      "type": "object",
+      "type_raw": "Object",
+      "required": false,
+      "read_only": false,
+      "description": "JSON object keyed by policy ID.",
+      "subordinate": null
+    },
+    {
+      "name": "time_blocks",
+      "label": "time_blocks",
+      "type": "array",
+      "type_raw": "Array",
+      "required": false,
+      "read_only": false,
+      "description": "Determines time periods with which the policy is associated.",
+      "subordinate": null
+    },
+    {
+      "name": "object_type",
+      "label": "object_type",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Name of the object type.",
+      "subordinate": null
+    },
+    {
+      "name": "create_by",
+      "label": "create_by",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The user who created this object.",
+      "subordinate": null
+    },
+    {
+      "name": "create_source",
+      "label": "create_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The sourcetype initiating create. Has value `manual` for user-initiated creates. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "create_time",
+      "label": "create_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp at the time of creation based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_source",
+      "label": "mod_source",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Sourcetype initiating modification. Has value `manual` for user-initiated modifications. For internal use only.",
+      "subordinate": null
+    },
+    {
+      "name": "mod_time",
+      "label": "mod_time",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Timestamp of the last modification based on UTC time zone.",
+      "subordinate": null
+    },
+    {
+      "name": "_owner",
+      "label": "_owner",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "Splunk user `nobody`.",
+      "subordinate": null
+    },
+    {
+      "name": "_user",
+      "label": "_user",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "User who performed the most recent operation on this object.",
+      "subordinate": null
+    },
+    {
+      "name": "version",
+      "label": "version",
+      "type": "string",
+      "type_raw": "String",
+      "required": false,
+      "read_only": true,
+      "description": "The version of the object. Currently the same as the ITSI app version.",
+      "subordinate": null
+    }
+  ]
+}

--- a/mcp_itsi/knowledge/schema/examples.py
+++ b/mcp_itsi/knowledge/schema/examples.py
@@ -1,0 +1,147 @@
+"""Build example/skeleton payloads from object schemas.
+
+Two flavors are produced:
+
+* ``minimal`` — only required fields, ready to fill in.
+* ``full`` — every writable field with a typed placeholder, including one
+  example item for each subordinate array/object.
+
+Curated, known-good examples are provided for the two showcase object types
+(``service`` and ``kpi_base_search``); everything else is generated.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp_itsi.knowledge.schema.models import AttributeSpec, ObjectSchema
+from mcp_itsi.knowledge.schema.registry import SchemaRegistry
+from mcp_itsi.knowledge.schema.registry import registry as _default_registry
+
+_PLACEHOLDERS: dict[str, Any] = {
+    "string": "",
+    "integer": 0,
+    "number": 0,
+    "boolean": False,
+    "object": {},
+    "array": [],
+}
+
+
+def _placeholder(attr: AttributeSpec) -> Any:
+    return _PLACEHOLDERS.get(attr.type, "")
+
+
+def build_skeleton(
+    schema: ObjectSchema,
+    *,
+    mode: str = "minimal",
+    schema_registry: SchemaRegistry | None = None,
+) -> dict[str, Any]:
+    reg = schema_registry or _default_registry
+    return _build(schema, mode, reg, _seen=set())
+
+
+def _build(
+    schema: ObjectSchema,
+    mode: str,
+    reg: SchemaRegistry,
+    _seen: set[str],
+) -> dict[str, Any]:
+    if schema.slug in _seen:
+        return {}
+    seen = _seen | {schema.slug}
+    out: dict[str, Any] = {}
+    for attr in schema.attributes:
+        if attr.read_only:
+            continue
+        include = attr.required or mode == "full"
+        if not include:
+            continue
+        if attr.subordinate:
+            child = reg.get(attr.subordinate)
+            if child is None:
+                out[attr.name] = _placeholder(attr)
+                continue
+            child_skel = _build(child, mode, reg, seen)
+            out[attr.name] = [child_skel] if attr.type == "array" else child_skel
+        else:
+            out[attr.name] = _placeholder(attr)
+    return out
+
+
+# Hand-tuned, valid minimal payloads for the showcase object types.
+CURATED_EXAMPLES: dict[str, dict[str, Any]] = {
+    "service": {
+        "title": "Buttercup Store",
+        "description": "Customer-facing storefront.",
+        "enabled": 1,
+        "sec_grp": "default_itsi_security_group",
+        "entity_rules": [
+            {
+                "rule_condition": "AND",
+                "rule_items": [
+                    {
+                        "field": "category",
+                        "rule_type": "matches",
+                        "value": "*Web*",
+                        "field_type": "alias",
+                    }
+                ],
+            }
+        ],
+        "kpis": [
+            {
+                "title": "Average response time",
+                "type": "kpi_primary",
+                "kpi_base_search": "<kpi_base_search _key>",
+                "base_search": "index=web | stats avg(response_time) as response_time by host",
+                "threshold_field": "response_time",
+                "entity_statop": "avg",
+                "aggregate_statop": "avg",
+                "alert_on": "aggregate",
+                "alert_period": "5",
+                "urgency": 5,
+                "entity_breakdown_id_field": "host",
+            }
+        ],
+    },
+    "kpi_base_search": {
+        "title": "Web server response times",
+        "description": "Base search powering web latency KPIs.",
+        "base_search": "index=web sourcetype=access_combined | stats avg(response_time) as response_time by host",
+        "is_entity_breakdown": True,
+        "entity_id_fields": "host",
+        "entity_alias_filtering_fields": "host",
+        "alert_period": "5",
+        "search_alert_earliest": "5",
+        "metrics": [
+            {
+                "title": "Average response time",
+                "threshold_field": "response_time",
+                "aggregate_statop": "avg",
+                "entity_statop": "avg",
+                "unit": "ms",
+            }
+        ],
+        "sec_grp": "default_itsi_security_group",
+    },
+}
+
+
+def examples_for(
+    schema: ObjectSchema,
+    *,
+    schema_registry: SchemaRegistry | None = None,
+) -> dict[str, Any]:
+    """Return ``{minimal, full, curated?}`` example payloads for a schema."""
+    examples: dict[str, Any] = {
+        "minimal": build_skeleton(
+            schema, mode="minimal", schema_registry=schema_registry
+        ),
+        "full": build_skeleton(schema, mode="full", schema_registry=schema_registry),
+    }
+    curated = CURATED_EXAMPLES.get(schema.slug)
+    if curated is not None:
+        examples["curated"] = curated
+    return examples

--- a/mcp_itsi/knowledge/schema/models.py
+++ b/mcp_itsi/knowledge/schema/models.py
@@ -1,0 +1,140 @@
+"""Dataclasses describing a single ITSI object-type schema.
+
+These mirror the JSON produced by ``scripts/itsi_schema`` and add convenience
+methods (case-insensitive attribute lookup, JSON-Schema projection).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+_JSON_SCHEMA_TYPES = {
+    "string": "string",
+    "integer": "integer",
+    "number": "number",
+    "boolean": "boolean",
+    "object": "object",
+    "array": "array",
+}
+
+
+@dataclass(frozen=True)
+class AttributeSpec:
+    """One documented field of an ITSI object type."""
+
+    name: str
+    type: str
+    description: str = ""
+    required: bool = False
+    read_only: bool = False
+    subordinate: str | None = None
+    type_raw: str = ""
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AttributeSpec:
+        return cls(
+            name=data["name"],
+            type=data.get("type", "string"),
+            description=data.get("description", ""),
+            required=bool(data.get("required", False)),
+            read_only=bool(data.get("read_only", False)),
+            subordinate=data.get("subordinate"),
+            type_raw=data.get("type_raw", ""),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "type": self.type,
+            "description": self.description,
+            "required": self.required,
+            "read_only": self.read_only,
+            "subordinate": self.subordinate,
+        }
+
+
+@dataclass(frozen=True)
+class ObjectSchema:
+    """Structured schema for an ITSI object type or subordinate structure."""
+
+    slug: str
+    title: str
+    kind: str  # "object" | "subordinate"
+    description: str = ""
+    object_type: str | None = None
+    interface: str | None = None
+    endpoint: str | None = None
+    subordinate_objects: tuple[str, ...] = ()
+    attributes: tuple[AttributeSpec, ...] = ()
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ObjectSchema:
+        return cls(
+            slug=data["slug"],
+            title=data.get("title", data["slug"]),
+            kind=data.get("kind", "object"),
+            description=data.get("description", ""),
+            object_type=data.get("object_type"),
+            interface=data.get("interface"),
+            endpoint=data.get("endpoint"),
+            subordinate_objects=tuple(data.get("subordinate_objects", ())),
+            attributes=tuple(
+                AttributeSpec.from_dict(a) for a in data.get("attributes", ())
+            ),
+        )
+
+    def attribute(self, name: str) -> AttributeSpec | None:
+        """Case-insensitive attribute lookup."""
+        lowered = name.lower()
+        for attr in self.attributes:
+            if attr.name.lower() == lowered:
+                return attr
+        return None
+
+    @property
+    def field_names(self) -> list[str]:
+        return [a.name for a in self.attributes]
+
+    @property
+    def required_fields(self) -> list[str]:
+        return [a.name for a in self.attributes if a.required]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "slug": self.slug,
+            "title": self.title,
+            "kind": self.kind,
+            "object_type": self.object_type,
+            "interface": self.interface,
+            "endpoint": self.endpoint,
+            "description": self.description,
+            "subordinate_objects": list(self.subordinate_objects),
+            "attributes": [a.to_dict() for a in self.attributes],
+        }
+
+    def to_json_schema(self) -> dict[str, Any]:
+        """Project the schema into a (lightweight) JSON-Schema object."""
+        properties: dict[str, Any] = {}
+        for attr in self.attributes:
+            prop: dict[str, Any] = {
+                "type": _JSON_SCHEMA_TYPES.get(attr.type, "string"),
+                "description": attr.description,
+            }
+            if attr.read_only:
+                prop["readOnly"] = True
+            if attr.subordinate:
+                prop["x-itsi-subordinate"] = attr.subordinate
+                if attr.type == "array":
+                    prop["items"] = {"$ref": f"#/$defs/{attr.subordinate}"}
+            properties[attr.name] = prop
+        schema: dict[str, Any] = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "title": self.title,
+            "type": "object",
+            "properties": properties,
+        }
+        required = self.required_fields
+        if required:
+            schema["required"] = required
+        return schema

--- a/mcp_itsi/knowledge/schema/registry.py
+++ b/mcp_itsi/knowledge/schema/registry.py
@@ -1,0 +1,100 @@
+"""Load and serve bundled ITSI object schemas.
+
+The registry lazily loads the generated ``data/*.json`` files once and exposes
+lookup, listing and search. A module-level :data:`registry` instance is shared
+across tools.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable
+from functools import cached_property
+from pathlib import Path
+
+from mcp_itsi.knowledge.schema.models import ObjectSchema
+
+logger = logging.getLogger(__name__)
+
+_DATA_DIR = Path(__file__).parent / "data"
+_INDEX_FILE = "index.json"
+
+
+class SchemaRegistry:
+    """In-memory store of parsed ITSI object schemas (manager)."""
+
+    def __init__(self, data_dir: Path = _DATA_DIR) -> None:
+        self._data_dir = data_dir
+
+    @cached_property
+    def _schemas(self) -> dict[str, ObjectSchema]:
+        schemas: dict[str, ObjectSchema] = {}
+        if not self._data_dir.is_dir():
+            logger.warning("Schema data dir missing: %s", self._data_dir)
+            return schemas
+        for path in sorted(self._data_dir.glob("*.json")):
+            if path.name == _INDEX_FILE:
+                continue
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+                schema = ObjectSchema.from_dict(data)
+                schemas[schema.slug] = schema
+            except (OSError, ValueError, KeyError):
+                logger.exception("Failed to load schema file %s", path)
+        return schemas
+
+    @cached_property
+    def index(self) -> dict:
+        path = self._data_dir / _INDEX_FILE
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            logger.warning("Schema index missing or invalid: %s", path)
+            return {}
+
+    def get(self, slug: str) -> ObjectSchema | None:
+        """Look up a schema by slug or object_type id (case-insensitive)."""
+        if not slug:
+            return None
+        direct = self._schemas.get(slug)
+        if direct is not None:
+            return direct
+        lowered = slug.lower()
+        for schema in self._schemas.values():
+            if schema.slug.lower() == lowered or (
+                schema.object_type and schema.object_type.lower() == lowered
+            ):
+                return schema
+        return None
+
+    def list_object_types(self) -> list[ObjectSchema]:
+        return sorted(
+            (s for s in self._schemas.values() if s.kind == "object"),
+            key=lambda s: s.slug,
+        )
+
+    def list_all(self) -> list[ObjectSchema]:
+        return sorted(self._schemas.values(), key=lambda s: s.slug)
+
+    def known_slugs(self) -> Iterable[str]:
+        return self._schemas.keys()
+
+    def search(self, query: str, *, limit: int = 20) -> list[ObjectSchema]:
+        q = query.strip().lower()
+        if not q:
+            return []
+        scored: list[tuple[int, ObjectSchema]] = []
+        for schema in self._schemas.values():
+            haystack = " ".join(
+                [schema.slug, schema.title, schema.description]
+                + [a.name for a in schema.attributes]
+            ).lower()
+            score = haystack.count(q)
+            if score:
+                scored.append((score, schema))
+        scored.sort(key=lambda x: x[0], reverse=True)
+        return [s for _, s in scored[:limit]]
+
+
+registry = SchemaRegistry()

--- a/mcp_itsi/knowledge/schema/validator.py
+++ b/mcp_itsi/knowledge/schema/validator.py
@@ -1,0 +1,261 @@
+"""Validate ITSI payloads against bundled object schemas.
+
+The validator distinguishes hard errors (which should block a write) from
+warnings (which should not). It recurses into subordinate objects so that, for
+example, every KPI inside ``service.kpis[]`` is checked too.
+"""
+
+from __future__ import annotations
+
+import difflib
+from dataclasses import dataclass, field
+from typing import Any
+
+from mcp_itsi.knowledge.schema.models import ObjectSchema
+from mcp_itsi.knowledge.schema.registry import SchemaRegistry
+from mcp_itsi.knowledge.schema.registry import registry as _default_registry
+
+# Map JSON-Schema type names to the Python types we accept for them.
+# ITSI documents many flags as "Boolean" but stores/accepts integer 1/0, so
+# boolean fields accept both bool and int.
+_PY_TYPES: dict[str, tuple[type, ...]] = {
+    "string": (str,),
+    "integer": (int,),
+    "number": (int, float),
+    "boolean": (bool, int),
+    "object": (dict,),
+    "array": (list,),
+}
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    path: str
+    field: str
+    message: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"path": self.path, "field": self.field, "message": self.message}
+
+
+@dataclass
+class ValidationResult:
+    ok: bool = True
+    errors: list[ValidationIssue] = field(default_factory=list)
+    warnings: list[ValidationIssue] = field(default_factory=list)
+
+    def add_error(self, issue: ValidationIssue) -> None:
+        self.errors.append(issue)
+        self.ok = False
+
+    def add_warning(self, issue: ValidationIssue) -> None:
+        self.warnings.append(issue)
+
+    def merge(self, other: ValidationResult) -> None:
+        self.errors.extend(other.errors)
+        self.warnings.extend(other.warnings)
+        if other.errors:
+            self.ok = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "errors": [e.to_dict() for e in self.errors],
+            "warnings": [w.to_dict() for w in self.warnings],
+        }
+
+
+class PayloadValidator:
+    """Validate a payload dict against an :class:`ObjectSchema`."""
+
+    def __init__(self, schema_registry: SchemaRegistry | None = None) -> None:
+        self._registry = schema_registry or _default_registry
+
+    def validate(
+        self,
+        object_type: str,
+        payload: Any,
+        *,
+        is_partial: bool = False,
+    ) -> ValidationResult:
+        result = ValidationResult()
+        schema = self._registry.get(object_type)
+        if schema is None:
+            result.add_error(
+                ValidationIssue(
+                    path="$",
+                    field=object_type,
+                    message=(
+                        f"Unknown object type '{object_type}'. Call "
+                        "itsi_list_object_schemas to see supported types."
+                    ),
+                )
+            )
+            return result
+        self._validate_object(schema, payload, "$", is_partial, result)
+        return result
+
+    def _validate_object(
+        self,
+        schema: ObjectSchema,
+        payload: Any,
+        path: str,
+        is_partial: bool,
+        result: ValidationResult,
+    ) -> None:
+        if not isinstance(payload, dict):
+            result.add_error(
+                ValidationIssue(
+                    path=path,
+                    field=schema.slug,
+                    message=f"Expected a JSON object for '{schema.title}', got {_kind(payload)}.",
+                )
+            )
+            return
+
+        for key, value in payload.items():
+            self._validate_field(schema, key, value, path, is_partial, result)
+
+        if not is_partial:
+            for required in schema.required_fields:
+                if not _has_key(payload, required):
+                    result.add_error(
+                        ValidationIssue(
+                            path=path,
+                            field=required,
+                            message=f"Missing required field '{required}' for '{schema.title}'.",
+                        )
+                    )
+
+    def _validate_field(
+        self,
+        schema: ObjectSchema,
+        key: str,
+        value: Any,
+        path: str,
+        is_partial: bool,
+        result: ValidationResult,
+    ) -> None:
+        child_path = f"{path}.{key}"
+        attr = schema.attribute(key)
+        if attr is None:
+            # The 4.21 docs are not exhaustive (real objects carry extra
+            # generated fields), so an unrecognized field is only a hard error
+            # when it looks like a typo of a known field. Otherwise warn.
+            suggestion = _suggest(key, schema.field_names)
+            if suggestion is not None:
+                result.add_error(
+                    ValidationIssue(
+                        path=child_path,
+                        field=key,
+                        message=(
+                            f"Unknown field '{key}' for '{schema.title}'. "
+                            f"Did you mean '{suggestion}'?"
+                        ),
+                    )
+                )
+            else:
+                result.add_warning(
+                    ValidationIssue(
+                        path=child_path,
+                        field=key,
+                        message=(
+                            f"Field '{key}' is not in the documented ITSI 4.21 "
+                            f"schema for '{schema.title}'. It may be valid; "
+                            "verify the spelling."
+                        ),
+                    )
+                )
+            return
+
+        if attr.read_only:
+            result.add_warning(
+                ValidationIssue(
+                    path=child_path,
+                    field=key,
+                    message=(
+                        f"Field '{key}' is server-generated/read-only and is "
+                        "typically ignored or rejected on write."
+                    ),
+                )
+            )
+
+        if value is None:
+            return
+
+        expected = _PY_TYPES.get(attr.type)
+        if expected and not _type_ok(value, expected):
+            result.add_error(
+                ValidationIssue(
+                    path=child_path,
+                    field=key,
+                    message=(
+                        f"Field '{key}' should be {attr.type} "
+                        f"(doc type '{attr.type_raw or attr.type}'), got {_kind(value)}."
+                    ),
+                )
+            )
+            return
+
+        if attr.subordinate:
+            self._validate_subordinate(attr.subordinate, value, child_path, result)
+
+    def _validate_subordinate(
+        self,
+        slug: str,
+        value: Any,
+        path: str,
+        result: ValidationResult,
+    ) -> None:
+        child_schema = self._registry.get(slug)
+        if child_schema is None:
+            return
+        if isinstance(value, list):
+            for idx, item in enumerate(value):
+                self._validate_object(
+                    child_schema, item, f"{path}[{idx}]", False, result
+                )
+        elif isinstance(value, dict):
+            self._validate_object(child_schema, value, path, False, result)
+
+
+def _has_key(payload: dict[str, Any], name: str) -> bool:
+    lowered = name.lower()
+    return any(k.lower() == lowered for k in payload)
+
+
+def _type_ok(value: Any, expected: tuple[type, ...]) -> bool:
+    # bool is a subclass of int; guard so True is not accepted as integer.
+    if bool not in expected and isinstance(value, bool):
+        return False
+    return isinstance(value, expected)
+
+
+def _kind(value: Any) -> str:
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, dict):
+        return "object"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    return type(value).__name__
+
+
+def _suggest(name: str, candidates: list[str]) -> str | None:
+    # High cutoff: only flag near-identical names as typos, so genuinely
+    # different (possibly undocumented) field names fall through to a warning.
+    matches = difflib.get_close_matches(
+        name.lower(), [c.lower() for c in candidates], n=1, cutoff=0.8
+    )
+    if not matches:
+        return None
+    for c in candidates:
+        if c.lower() == matches[0]:
+            return c
+    return None

--- a/mcp_itsi/llms.txt
+++ b/mcp_itsi/llms.txt
@@ -1,0 +1,59 @@
+# ITSI MCP Server
+
+> Model Context Protocol server for Splunk IT Service Intelligence (ITSI 4.21). It exposes ~73 `itsi_*` tools for full CRUD on ITSI configuration objects (services, KPIs, entities, glass tables, notable events, ...), a bundled schema for every object type, and a knowledge corpus distilled from the official Splunk docs. This file tells an LLM agent how to use the server reliably.
+
+ITSI configuration objects (ITOA objects) are deeply nested JSON. A `service` contains `kpis[]` and `entity_rules[]`; a KPI contains threshold settings; and so on. Guessing field names is the main source of failed writes. The server solves this with bundled schemas and pre-flight validation — always work schema-first.
+
+## Golden path (do this for every create/update)
+
+1. Discover the type: call `itsi_list_object_schemas` to see all object types, their REST endpoints, required fields, and nested objects.
+2. Get the schema: call `itsi_get_object_schema(object_type)`. It returns every documented field (type + description), inlined schemas for nested objects, a derived JSON Schema, and minimal/full/curated example payloads. Pass `include_live_example=True` to also fetch one real object from the connected instance to copy the exact shape.
+3. Build the payload from the returned examples — do not invent field names.
+4. Dry-run validate: call `itsi_validate_object_payload(object_type, payload)`. Fix every `error`; review every `warning`. Use `is_partial=True` to skip required-field checks for partial updates.
+5. Write: call `itsi_create_*` / `itsi_update_*`. The server re-validates server-side: hard errors block before the API call and return structured `validation_errors`; non-fatal warnings (read-only or undocumented fields) are returned inline under `validation_warnings`.
+
+## Tool families
+
+- Discovery & schema: `itsi_get_supported_object_types`, `itsi_get_alias_list`, `itsi_list_object_schemas`, `itsi_get_object_schema`, `itsi_validate_object_payload`.
+- Service Insights: `itsi_list_services`, `itsi_get_service`, `itsi_create_service`, `itsi_update_service`, `itsi_delete_service`, `itsi_count_services`, plus service templates (`itsi_*_service_template`, `itsi_templatize_service`).
+- Entities: `itsi_list_entities`, `itsi_get_entity`, `itsi_create_entity`, `itsi_update_entity`, `itsi_delete_entity`, and entity types (`itsi_*_entity_type`).
+- KPI config: `itsi_*_kpi_base_search`, `itsi_*_kpi_threshold_template`.
+- Visualisation: `itsi_*_glass_table`, `itsi_*_home_view`, `itsi_*_deep_dive`.
+- Event Analytics: `itsi_list_notable_events`, `itsi_get_notable_event`, `itsi_acknowledge_notable_event`, `itsi_close_notable_event`, and `itsi_*_aggregation_policy`, `itsi_*_correlation_search`.
+- Maintenance & RBAC: `itsi_list_maintenance_windows`, `itsi_get_maintenance_window`, `itsi_list_teams`, `itsi_get_team`.
+- Docs as tools: `itsi_list_docs`, `itsi_read_doc`, `itsi_search_docs`.
+
+## Resources (read with the MCP resources API, no credentials needed)
+
+- `itsi://schema/<object_type>`: structured schema JSON for one object type (e.g. `itsi://schema/service`, `itsi://schema/kpi_base_search`). Same data as `itsi_get_object_schema`.
+- `itsi://docs/overview`: map of the bundled knowledge corpus — read this to orient.
+- `itsi://docs/api/schema` and `itsi://docs/api/reference`: full ITSI 4.21 REST schema and endpoint/filter reference.
+- `itsi://docs/service-insights`, `itsi://docs/entity-integrations`, `itsi://docs/event-analytics`, `itsi://docs/best-practices`: concept guides.
+- `itsi://docs/cookbook/header-auth`: how credentials reach the server.
+
+## Reading data efficiently
+
+- Filter with MongoDB-style queries: pass `filter_query` as an object or JSON string, e.g. `{"title": {"$regex": ".*Web.*"}}`.
+- Limit response size: pass `fields` (comma-separated) to project only what you need; use `limit`/`offset` to page and `sort_key`/`sort_dir` to order.
+- Objects are addressed by `_key` (notable events use `event_id`). List or count first to resolve a `_key` before get/update/delete.
+
+## Rules and gotchas
+
+- Always schema-first. The #1 failure mode is misspelled or invented field names; `itsi_get_object_schema` + `itsi_validate_object_payload` prevent it.
+- Updates are partial by default (only fields you send change). Set `is_partial=False` for a full overwrite.
+- Some ITSI endpoints validate the full document even on partial update; if a partial update 5xxs, GET the object, merge your change, and PUT it back with `is_partial=False`.
+- Booleans accept `true/false` or `1/0`. Read-only/server-generated fields (`_key`, `object_type`, `create_time`, `mod_time`, `acl`, ...) are ignored on write and produce a warning, not an error.
+- Entities: every alias field named in `identifier.fields` must also appear at the document root, e.g. `"host": ["web-1"]`.
+- Deletes are permanent — confirm intent with the user first.
+
+## Workflow prompts
+
+- `itsi_service_onboarding`: end-to-end service onboarding playbook.
+- `itsi_kpi_design`: KPI design with thresholds and urgency.
+- `itsi_episode_triage`: notable-event / episode triage runbook.
+
+## Optional
+
+- User guide: `docs/guides/itsi/user-guide.md` (task-oriented walk-throughs and recipes).
+- Getting started / deployment: `docs/guides/itsi/getting-started.md`, `docs/guides/itsi/deployment.md`.
+- Package reference (tool catalog, auth headers, env vars): `mcp_itsi/README.md`.

--- a/mcp_itsi/resources/__init__.py
+++ b/mcp_itsi/resources/__init__.py
@@ -9,12 +9,17 @@ from __future__ import annotations
 
 from mcp_itsi.core.base import BaseITSIResource
 from mcp_itsi.resources.docs_resource import build_doc_resources
+from mcp_itsi.resources.llms_resource import build_llms_resources
 from mcp_itsi.resources.schema_resource import build_schema_resources
 
 
 def all_resources() -> list[type[BaseITSIResource]]:
     """Return every concrete ITSI resource class."""
-    return [*build_doc_resources(), *build_schema_resources()]
+    return [
+        *build_llms_resources(),
+        *build_doc_resources(),
+        *build_schema_resources(),
+    ]
 
 
 __all__ = ["all_resources"]

--- a/mcp_itsi/resources/__init__.py
+++ b/mcp_itsi/resources/__init__.py
@@ -9,11 +9,12 @@ from __future__ import annotations
 
 from mcp_itsi.core.base import BaseITSIResource
 from mcp_itsi.resources.docs_resource import build_doc_resources
+from mcp_itsi.resources.schema_resource import build_schema_resources
 
 
 def all_resources() -> list[type[BaseITSIResource]]:
     """Return every concrete ITSI resource class."""
-    return list(build_doc_resources())
+    return [*build_doc_resources(), *build_schema_resources()]
 
 
 __all__ = ["all_resources"]

--- a/mcp_itsi/resources/llms_resource.py
+++ b/mcp_itsi/resources/llms_resource.py
@@ -1,0 +1,47 @@
+"""Expose the bundled ``llms.txt`` as an MCP resource.
+
+``llms.txt`` (https://llmstxt.org/) is a concise, agent-facing map of how to
+use this server effectively. Serving it at ``itsi://llms.txt`` lets a connected
+LLM read the golden-path workflow before it starts calling tools.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from pathlib import Path
+
+from fastmcp import Context
+
+from mcp_itsi.core.base import BaseITSIResource, ResourceMetadata
+
+logger = logging.getLogger(__name__)
+
+_LLMS_TXT_PATH = Path(__file__).resolve().parents[1] / "llms.txt"
+
+
+class LlmsTxtResource(BaseITSIResource):
+    """Serve the bundled ``llms.txt`` usage guide for LLM agents."""
+
+    METADATA = ResourceMetadata(
+        uri="itsi://llms.txt",
+        name="ITSI MCP — llms.txt usage guide",
+        description=(
+            "Agent-facing guide to using this server effectively: the "
+            "schema-first golden path, tool families, resources, and gotchas."
+        ),
+        mime_type="text/markdown",
+        category="overview",
+        tags=("llms-txt", "overview", "guide"),
+    )
+
+    async def read(self, mcp_ctx: Context) -> str:
+        try:
+            return _LLMS_TXT_PATH.read_text(encoding="utf-8")
+        except FileNotFoundError:  # pragma: no cover - packaging guard
+            logger.warning("llms.txt missing at %s", _LLMS_TXT_PATH)
+            return "# ITSI MCP Server\n\n_(llms.txt not bundled)_\n"
+
+
+def build_llms_resources() -> Iterable[type[BaseITSIResource]]:
+    return [LlmsTxtResource]

--- a/mcp_itsi/resources/schema_resource.py
+++ b/mcp_itsi/resources/schema_resource.py
@@ -1,0 +1,48 @@
+"""Expose each ITSI object schema as a read-only resource.
+
+Resources are addressable at ``itsi://schema/<object_type>`` and return the
+structured schema (plus example payloads) as JSON. This mirrors the doc
+resources in :mod:`mcp_itsi.resources.docs_resource`.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+
+from fastmcp import Context
+
+from mcp_itsi.core.base import BaseITSIResource, ResourceMetadata
+from mcp_itsi.knowledge.schema import ObjectSchema, registry
+from mcp_itsi.knowledge.schema.examples import examples_for
+
+
+def _make_class(schema: ObjectSchema) -> type[BaseITSIResource]:
+    metadata = ResourceMetadata(
+        uri=f"itsi://schema/{schema.object_type}",
+        name=f"ITSI schema: {schema.title}",
+        description=f"Structured schema and examples for the ITSI '{schema.object_type}' object.",
+        mime_type="application/json",
+        category="schema",
+        tags=("itsi", "schema", schema.object_type or "object"),
+    )
+
+    class _SchemaResource(BaseITSIResource):
+        METADATA = metadata
+        _schema: ObjectSchema = schema
+
+        async def read(self, mcp_ctx: Context) -> str:
+            payload = {
+                "schema": self._schema.to_dict(),
+                "json_schema": self._schema.to_json_schema(),
+                "examples": examples_for(self._schema),
+            }
+            return json.dumps(payload, indent=2, ensure_ascii=False)
+
+    _SchemaResource.__name__ = f"SchemaResource_{schema.object_type}"
+    _SchemaResource.__qualname__ = _SchemaResource.__name__
+    return _SchemaResource
+
+
+def build_schema_resources() -> Iterable[type[BaseITSIResource]]:
+    return [_make_class(s) for s in registry.list_object_types()]

--- a/mcp_itsi/tools/__init__.py
+++ b/mcp_itsi/tools/__init__.py
@@ -80,6 +80,11 @@ from mcp_itsi.tools.kpi_threshold_template import (
 )
 from mcp_itsi.tools.maintenance import GetMaintenanceWindow, ListMaintenanceWindows
 from mcp_itsi.tools.meta import GetAliasList, GetSupportedObjectTypes
+from mcp_itsi.tools.schema import (
+    GetObjectSchema,
+    ListObjectSchemas,
+    ValidateObjectPayload,
+)
 from mcp_itsi.tools.service import (
     CountServices,
     CreateService,
@@ -105,6 +110,10 @@ def all_tools() -> list[type[BaseITSITool]]:
         # Meta / discovery
         GetAliasList,
         GetSupportedObjectTypes,
+        # Schema / validation
+        ListObjectSchemas,
+        GetObjectSchema,
+        ValidateObjectPayload,
         # Service Insights
         ListServices,
         GetService,

--- a/mcp_itsi/tools/_itoa_ops.py
+++ b/mcp_itsi/tools/_itoa_ops.py
@@ -16,6 +16,7 @@ from mcp_itsi.client.endpoints import (
     itoa_templatize,
 )
 from mcp_itsi.core.context import ITSICallContext
+from mcp_itsi.tools._validation import preflight
 
 logger = logging.getLogger(__name__)
 
@@ -96,8 +97,14 @@ async def get_object(ctx: ITSICallContext, object_type: str, key: str) -> dict[s
 
 
 async def create_object(
-    ctx: ITSICallContext, object_type: str, payload: dict[str, Any]
+    ctx: ITSICallContext,
+    object_type: str,
+    payload: dict[str, Any],
+    *,
+    validate: bool = True,
 ) -> dict[str, Any]:
+    if validate:
+        preflight(object_type, payload, is_partial=False)
     async with ctx.client() as client:
         result = await client.post_json(itoa_collection(object_type), body=payload)
     return result if isinstance(result, dict) else {"raw": result}
@@ -110,7 +117,10 @@ async def update_object(
     payload: dict[str, Any],
     *,
     is_partial: bool = True,
+    validate: bool = True,
 ) -> dict[str, Any]:
+    if validate:
+        preflight(object_type, payload, is_partial=is_partial)
     params = {"is_partial_data": 1 if is_partial else 0}
     async with ctx.client() as client:
         result = await client.post_json(itoa_item(object_type, key), body=payload, params=params)

--- a/mcp_itsi/tools/_validation.py
+++ b/mcp_itsi/tools/_validation.py
@@ -1,0 +1,62 @@
+"""Write-path pre-flight validation for ITSI mutating operations.
+
+Hard validation errors raise :class:`PayloadValidationError` (converted to an
+error response by :class:`~mcp_itsi.core.base.BaseITSITool`). Non-fatal warnings
+are pushed onto a request-scoped buffer and merged into the success response by
+the same base class, so every create/update tool surfaces warnings inline with
+no per-tool code.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import Any
+
+from mcp_itsi.knowledge.schema import PayloadValidator, registry
+from mcp_itsi.knowledge.schema.validator import ValidationResult
+
+_pending_warnings: ContextVar[list[dict[str, str]] | None] = ContextVar(
+    "itsi_validation_warnings", default=None
+)
+
+
+class PayloadValidationError(Exception):
+    """Raised when a payload fails hard pre-flight validation."""
+
+    def __init__(self, object_type: str, result: ValidationResult) -> None:
+        self.object_type = object_type
+        self.result = result
+        count = len(result.errors)
+        super().__init__(
+            f"Payload for '{object_type}' failed validation with {count} error(s)."
+        )
+
+
+def reset_warnings() -> None:
+    """Clear the request-scoped warnings buffer (call at request start)."""
+    _pending_warnings.set([])
+
+
+def drain_warnings() -> list[dict[str, str]]:
+    """Return and clear any accumulated warnings."""
+    warnings = _pending_warnings.get() or []
+    _pending_warnings.set([])
+    return warnings
+
+
+def preflight(object_type: str, payload: Any, *, is_partial: bool) -> None:
+    """Validate a payload before a write.
+
+    Raises :class:`PayloadValidationError` on hard errors. Records warnings on
+    the request-scoped buffer. Unknown object types are skipped (no schema to
+    validate against), preserving forward compatibility.
+    """
+    if registry.get(object_type) is None or not isinstance(payload, dict):
+        return
+    result = PayloadValidator().validate(object_type, payload, is_partial=is_partial)
+    if result.warnings:
+        buffer = list(_pending_warnings.get() or [])
+        buffer.extend(w.to_dict() for w in result.warnings)
+        _pending_warnings.set(buffer)
+    if not result.ok:
+        raise PayloadValidationError(object_type, result)

--- a/mcp_itsi/tools/deep_dive.py
+++ b/mcp_itsi/tools/deep_dive.py
@@ -79,8 +79,8 @@ class CreateDeepDive(BaseITSITool):
     async def execute(
         self, mcp_ctx: Context, ctx: ITSICallContext, payload: dict[str, Any]
     ) -> dict[str, Any]:
-        if not isinstance(payload, dict) or not payload.get("title"):
-            return error_response("payload.title is required to create a deep dive")
+        if not isinstance(payload, dict):
+            return error_response("`payload` must be a JSON object")
         result = await ops.create_object(ctx, _OBJECT_TYPE, payload)
         return success_response(deep_dive=result)
 

--- a/mcp_itsi/tools/entity.py
+++ b/mcp_itsi/tools/entity.py
@@ -92,8 +92,8 @@ class CreateEntity(BaseITSITool):
         ctx: ITSICallContext,
         payload: dict[str, Any],
     ) -> dict[str, Any]:
-        if not isinstance(payload, dict) or not payload.get("title"):
-            return error_response("payload.title is required to create an entity")
+        if not isinstance(payload, dict):
+            return error_response("`payload` must be a JSON object")
         if "identifier" not in payload:
             return error_response("payload.identifier is required to create an entity")
         result = await ops.create_object(ctx, _OBJECT_TYPE, payload)

--- a/mcp_itsi/tools/entity_type.py
+++ b/mcp_itsi/tools/entity_type.py
@@ -78,8 +78,8 @@ class CreateEntityType(BaseITSITool):
     async def execute(
         self, mcp_ctx: Context, ctx: ITSICallContext, payload: dict[str, Any]
     ) -> dict[str, Any]:
-        if not isinstance(payload, dict) or not payload.get("title"):
-            return error_response("payload.title is required to create an entity type")
+        if not isinstance(payload, dict):
+            return error_response("`payload` must be a JSON object")
         result = await ops.create_object(ctx, _OBJECT_TYPE, payload)
         return success_response(entity_type=result)
 

--- a/mcp_itsi/tools/glass_table.py
+++ b/mcp_itsi/tools/glass_table.py
@@ -77,8 +77,8 @@ class CreateGlassTable(BaseITSITool):
     async def execute(
         self, mcp_ctx: Context, ctx: ITSICallContext, payload: dict[str, Any]
     ) -> dict[str, Any]:
-        if not isinstance(payload, dict) or not payload.get("title"):
-            return error_response("payload.title is required to create a glass table")
+        if not isinstance(payload, dict):
+            return error_response("`payload` must be a JSON object")
         result = await ops.create_object(ctx, _OBJECT_TYPE, payload)
         return success_response(glass_table=result)
 

--- a/mcp_itsi/tools/kpi_base_search.py
+++ b/mcp_itsi/tools/kpi_base_search.py
@@ -69,7 +69,10 @@ class CreateKpiBaseSearch(BaseITSITool):
             "Create a new KPI base search. `payload` must follow the ITSI "
             "`kpi_base_search` schema (`title`, `base_search`, `metrics`, "
             "`entity_id_fields`, `entity_alias_filtering_fields`, "
-            "`alert_period`, ...). Returns the new `_key`."
+            "`alert_period`, ...). Call itsi_get_object_schema('kpi_base_search') "
+            "for the full schema + examples and itsi_validate_object_payload to "
+            "check it first. The payload is validated before submission. Returns "
+            "the new `_key`."
         ),
         category="kpi",
         tags=("itsi", "kpi", "base-search", "create"),
@@ -78,8 +81,8 @@ class CreateKpiBaseSearch(BaseITSITool):
     async def execute(
         self, mcp_ctx: Context, ctx: ITSICallContext, payload: dict[str, Any]
     ) -> dict[str, Any]:
-        if not isinstance(payload, dict) or not payload.get("title"):
-            return error_response("payload.title is required to create a KPI base search")
+        if not isinstance(payload, dict):
+            return error_response("`payload` must be a JSON object")
         result = await ops.create_object(ctx, _OBJECT_TYPE, payload)
         return success_response(kpi_base_search=result)
 
@@ -89,7 +92,9 @@ class UpdateKpiBaseSearch(BaseITSITool):
         name="itsi_update_kpi_base_search",
         description=(
             "Update an existing KPI base search by `_key`. Defaults to a "
-            "partial update; set `is_partial=False` for a full overwrite."
+            "partial update; set `is_partial=False` for a full overwrite. The "
+            "payload is validated against the kpi_base_search schema before "
+            "submission."
         ),
         category="kpi",
         tags=("itsi", "kpi", "base-search", "update"),

--- a/mcp_itsi/tools/kpi_threshold_template.py
+++ b/mcp_itsi/tools/kpi_threshold_template.py
@@ -80,8 +80,8 @@ class CreateKpiThresholdTemplate(BaseITSITool):
     async def execute(
         self, mcp_ctx: Context, ctx: ITSICallContext, payload: dict[str, Any]
     ) -> dict[str, Any]:
-        if not isinstance(payload, dict) or not payload.get("title"):
-            return error_response("payload.title is required to create a threshold template")
+        if not isinstance(payload, dict):
+            return error_response("`payload` must be a JSON object")
         result = await ops.create_object(ctx, _OBJECT_TYPE, payload)
         return success_response(threshold_template=result)
 

--- a/mcp_itsi/tools/schema.py
+++ b/mcp_itsi/tools/schema.py
@@ -1,0 +1,159 @@
+"""Tools that expose ITSI object schemas and validate payloads.
+
+These make CRUD on deeply nested ITOA objects reliable: agents can fetch the
+schema for any object type, get annotated example payloads, and dry-run
+validate a payload before calling a create/update tool.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastmcp import Context
+
+from mcp_itsi.core.base import BaseITSITool, ToolMetadata
+from mcp_itsi.core.context import ITSICallContext, build_call_context
+from mcp_itsi.core.responses import error_response, success_response
+from mcp_itsi.knowledge.schema import PayloadValidator, registry
+from mcp_itsi.knowledge.schema.examples import examples_for
+from mcp_itsi.tools import _itoa_ops as ops
+
+logger = logging.getLogger(__name__)
+
+
+class ListObjectSchemas(BaseITSITool):
+    METADATA = ToolMetadata(
+        name="itsi_list_object_schemas",
+        description=(
+            "List every ITSI object type that has a documented schema (ITSI "
+            "4.21). Returns the object_type id, title, REST endpoint, attribute "
+            "count and subordinate (nested) objects. Call this first to discover "
+            "which type to inspect with itsi_get_object_schema."
+        ),
+        category="schema",
+        tags=("itsi", "schema", "discovery"),
+        requires_connection=False,
+    )
+
+    async def execute(self, mcp_ctx: Context, ctx: ITSICallContext) -> dict[str, Any]:
+        entries = [
+            {
+                "object_type": s.object_type,
+                "title": s.title,
+                "endpoint": s.endpoint,
+                "description": s.description,
+                "attribute_count": len(s.attributes),
+                "required_fields": s.required_fields,
+                "subordinate_objects": list(s.subordinate_objects),
+            }
+            for s in registry.list_object_types()
+        ]
+        return success_response(count=len(entries), object_types=entries)
+
+
+class GetObjectSchema(BaseITSITool):
+    METADATA = ToolMetadata(
+        name="itsi_get_object_schema",
+        description=(
+            "Return the full schema for an ITSI object type (e.g. 'service', "
+            "'kpi_base_search', 'entity'). Includes every documented field with "
+            "type/description, inlined schemas for subordinate (nested) objects "
+            "like service KPIs and entity rules, a derived JSON Schema, and "
+            "minimal/full/curated example payloads. Set include_live_example=True "
+            "to also fetch one real object from the connected ITSI instance. Use "
+            "this before creating or updating an object."
+        ),
+        category="schema",
+        tags=("itsi", "schema", "get"),
+        requires_connection=False,
+    )
+
+    async def execute(
+        self,
+        mcp_ctx: Context,
+        ctx: ITSICallContext,
+        object_type: str,
+        include_examples: bool = True,
+        include_json_schema: bool = True,
+        include_live_example: bool = False,
+    ) -> dict[str, Any]:
+        if not object_type:
+            return error_response("`object_type` is required")
+        schema = registry.get(object_type)
+        if schema is None:
+            return error_response(
+                f"No schema for object type '{object_type}'.",
+                hint="Call itsi_list_object_schemas to see supported types.",
+            )
+
+        subordinates = {
+            slug: sub.to_dict()
+            for slug in schema.subordinate_objects
+            if (sub := registry.get(slug)) is not None
+        }
+
+        response: dict[str, Any] = {
+            "object_type": schema.object_type,
+            "title": schema.title,
+            "endpoint": schema.endpoint,
+            "schema": schema.to_dict(),
+            "subordinate_schemas": subordinates,
+        }
+        if include_json_schema:
+            response["json_schema"] = schema.to_json_schema()
+        if include_examples:
+            response["examples"] = examples_for(schema)
+        if include_live_example:
+            response["live_example"] = await self._live_example(mcp_ctx, schema.object_type)
+
+        return success_response(**response)
+
+    async def _live_example(self, mcp_ctx: Context, object_type: str | None) -> Any:
+        if not object_type:
+            return {"available": False, "reason": "Not a top-level REST object type."}
+        try:
+            call_ctx = build_call_context(mcp_ctx)
+        except ValueError as exc:
+            return {"available": False, "reason": f"No ITSI connection: {exc}"}
+        try:
+            items = await ops.list_objects(call_ctx, object_type, limit=1)
+        except Exception as exc:  # noqa: BLE001 - best-effort enrichment
+            logger.warning("Live example fetch failed for %s: %s", object_type, exc)
+            return {"available": False, "reason": str(exc)}
+        if not items:
+            return {"available": False, "reason": "No objects of this type exist yet."}
+        return {"available": True, "object": items[0]}
+
+
+class ValidateObjectPayload(BaseITSITool):
+    METADATA = ToolMetadata(
+        name="itsi_validate_object_payload",
+        description=(
+            "Dry-run validate a payload against an ITSI object schema WITHOUT "
+            "writing anything. Returns ok plus structured errors (unknown/"
+            "misspelled fields, wrong types, missing required fields) and "
+            "warnings (read-only or undocumented fields). Recurses into nested "
+            "objects such as service KPIs and entity rules. Set is_partial=True "
+            "to skip required-field checks (for partial updates). Call this "
+            "before itsi_create_* / itsi_update_*."
+        ),
+        category="schema",
+        tags=("itsi", "schema", "validate"),
+        requires_connection=False,
+    )
+
+    async def execute(
+        self,
+        mcp_ctx: Context,
+        ctx: ITSICallContext,
+        object_type: str,
+        payload: dict[str, Any],
+        is_partial: bool = False,
+    ) -> dict[str, Any]:
+        if not object_type:
+            return error_response("`object_type` is required")
+        if not isinstance(payload, dict):
+            return error_response("`payload` must be a JSON object")
+        result = PayloadValidator().validate(object_type, payload, is_partial=is_partial)
+        return success_response(object_type=object_type, **result.to_dict())

--- a/mcp_itsi/tools/service.py
+++ b/mcp_itsi/tools/service.py
@@ -104,10 +104,13 @@ class CreateService(BaseITSITool):
     METADATA = ToolMetadata(
         name="itsi_create_service",
         description=(
-            "Create a new ITSI service. `payload` must follow the ITSI REST API "
-            "schema for service objects (title, description, kpis, entity_rules, "
-            "services_depends_on, sec_grp, enabled, ...). See the embedded "
-            "knowledge resource itsi://docs/api/schema for the full schema."
+            "Create a new ITSI service. `payload` must follow the ITSI service "
+            "schema (title, description, kpis[], entity_rules[], "
+            "services_depends_on, sec_grp, enabled, ...). Call "
+            "itsi_get_object_schema('service') for the full schema + examples and "
+            "itsi_validate_object_payload('service', payload) to check it first. "
+            "The payload is validated before submission: structural errors are "
+            "rejected and any warnings are returned alongside the result."
         ),
         category="service-insights",
         tags=("itsi", "service", "create"),
@@ -119,8 +122,8 @@ class CreateService(BaseITSITool):
         ctx: ITSICallContext,
         payload: dict[str, Any],
     ) -> dict[str, Any]:
-        if not isinstance(payload, dict) or not payload.get("title"):
-            return error_response("payload.title is required to create a service")
+        if not isinstance(payload, dict):
+            return error_response("`payload` must be a JSON object")
         result = await ops.create_object(ctx, _OBJECT_TYPE, payload)
         return success_response(service=result)
 
@@ -133,7 +136,10 @@ class UpdateService(BaseITSITool):
         description=(
             "Update an existing ITSI service identified by `key`. Defaults to a "
             "partial update (only the fields you send are changed). Set "
-            "`is_partial=False` for a full replacement of the service document."
+            "`is_partial=False` for a full replacement of the service document. "
+            "The payload is validated against the service schema before "
+            "submission (use itsi_get_object_schema / itsi_validate_object_payload "
+            "to prepare it)."
         ),
         category="service-insights",
         tags=("itsi", "service", "update"),

--- a/mcp_itsi/tools/service_template.py
+++ b/mcp_itsi/tools/service_template.py
@@ -111,8 +111,8 @@ class CreateServiceTemplate(BaseITSITool):
     async def execute(
         self, mcp_ctx: Context, ctx: ITSICallContext, payload: dict[str, Any]
     ) -> dict[str, Any]:
-        if not isinstance(payload, dict) or not payload.get("title"):
-            return error_response("payload.title is required to create a service template")
+        if not isinstance(payload, dict):
+            return error_response("`payload` must be a JSON object")
         result = await ops.create_object(ctx, _OBJECT_TYPE, payload)
         return success_response(template=result)
 

--- a/packaging/mcp-itsi-server/evals/schema_tools_eval.xml
+++ b/packaging/mcp-itsi-server/evals/schema_tools_eval.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Evaluation set for the ITSI schema tools (itsi_list_object_schemas,
+  itsi_get_object_schema, itsi_validate_object_payload).
+
+  All questions are read-only, deterministic and answerable from the bundled
+  ITSI 4.21 schema corpus alone (no live Splunk instance required), so answers
+  are stable and verifiable by string comparison.
+-->
+<evaluation>
+  <qa_pair>
+    <question>Using the ITSI schema tools, what is the REST endpoint path for the kpi_base_search object type?</question>
+    <answer>/itoa_interface/kpi_base_search</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>The correlation_search object is not on the ITOA interface. According to its schema, what is its full REST endpoint path?</question>
+    <answer>/event_management_interface/correlation_search</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>A service object contains a nested array under its kpis field. What is the object-type slug of the subordinate structure used for each item in that array?</question>
+    <answer>service_kpi</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Inside a Service KPI, the entity_thresholds field references which subordinate schema slug?</question>
+    <answer>kpi_threshold_settings</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>How many ITSI object types (top-level REST object types, not subordinate structures) have a documented schema in the bundled 4.21 corpus?</question>
+    <answer>17</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>For a service, which single field does the schema mark as required?</question>
+    <answer>title</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>According to the Service KPI schema, what are the three possible values of the alert_on field?</question>
+    <answer>aggregate, entities, both</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>If you validate the service payload {"titel": "Web"} with itsi_validate_object_payload, which existing field name does the tool suggest you meant instead of "titel"?</question>
+    <answer>title</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>When you validate a service payload that sets the read-only field object_type, does itsi_validate_object_payload report ok=true with a warning, or ok=false? Answer with just the value of ok.</question>
+    <answer>true</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>In an entity_rules rule item, the field_type attribute takes which two values according to the schema description?</question>
+    <answer>alias, info</answer>
+  </qa_pair>
+</evaluation>

--- a/scripts/itsi_schema/__init__.py
+++ b/scripts/itsi_schema/__init__.py
@@ -1,0 +1,6 @@
+"""Dev-time tooling to generate bundled ITSI object schemas from Splunk docs.
+
+These modules are NOT imported at runtime. They parse a locally-scraped copy
+of the ITSI 4.21 REST API schema page into the structured JSON consumed by
+``mcp_itsi.knowledge.schema``.
+"""

--- a/scripts/itsi_schema/mapping.py
+++ b/scripts/itsi_schema/mapping.py
@@ -1,0 +1,148 @@
+"""Static mapping between schema-doc section titles and ITSI object types.
+
+The ITSI REST API schema page documents object types and their subordinate
+data structures using human-readable section titles (e.g. "Service Template",
+"Service KPI"). The REST API itself addresses objects by machine ids
+(``base_service_template``, and ``kpis`` nested inside ``service``).
+
+This module is the single source of truth for reconciling the two, plus the
+``interface`` an object lives under and the nesting relationships used to
+validate deeply nested payloads.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+ITOA_INTERFACE: Final = "/itoa_interface"
+EVENT_MGMT_INTERFACE: Final = "/event_management_interface"
+MAINTENANCE_INTERFACE: Final = "/maintenance_services_interface"
+
+# Doc section title -> top-level REST object type id.
+TOP_LEVEL_OBJECTS: Final[dict[str, str]] = {
+    "Entity": "entity",
+    "Service": "service",
+    "Service Template": "base_service_template",
+    "Entity Type": "entity_type",
+    "KPI Threshold Templates": "kpi_threshold_template",
+    "KPI Base Search": "kpi_base_search",
+    "Glass Table": "glass_table",
+    "Deep Dive": "deep_dive",
+    "Maintenance Calendar": "maintenance_calendar",
+    "Event Management State": "event_management_state",
+    "Notable Event Group": "notable_event_group",
+    "Notable Event Comment": "notable_event_comment",
+    "Notable Event Aggregation Policy": "notable_event_aggregation_policy",
+    "Notable Event Email Template": "notable_event_email_template",
+    "Correlation Search": "correlation_search",
+    "Service Analyzer": "home_view",
+    "Team": "team",
+}
+
+# Doc section title -> subordinate (nested) structure slug.
+SUBORDINATE_OBJECTS: Final[dict[str, str]] = {
+    "Entity Rules": "entity_rules",
+    "Entity Type Dashboard Drilldown": "entity_type_dashboard_drilldown",
+    "Entity Type Data Drilldown": "entity_type_data_drilldown",
+    "Entity Type Vital Metrics": "entity_type_vital_metrics",
+    "Service KPI": "service_kpi",
+    "Service Template KPI": "service_template_kpi",
+    "KPI Threshold Settings": "kpi_threshold_settings",
+    "KPI Threshold Levels": "kpi_threshold_levels",
+    "Glass Table Widget Configuration": "glass_table_widget_configuration",
+    "Glass Table Icon": "glass_table_icon",
+    "Deep Dive Lane Setting": "deep_dive_lane_setting",
+    "Time Variate Thresholds Specification": "time_variate_thresholds_specification",
+    "Anomaly Detection Algorithm Settings": "anomaly_detection_algorithm_settings",
+    "Event Management Export": "event_management_export",
+}
+
+# Sections that are not object schemas.
+SKIP_SECTIONS: Final[frozenset[str]] = frozenset({"General details"})
+
+# Doc capitalises some fields whose real API name is lower-cased. Most camelCase
+# fields (gaugeMin, thresholdValue, severityColor, laneType, ...) are genuine,
+# so only known quirks are overridden.
+FIELD_NAME_OVERRIDES: Final[dict[str, str]] = {
+    "Enabled": "enabled",
+    "Time_variate_thresholds_specification": "time_variate_thresholds_specification",
+}
+
+# object_type ids that live under the event management interface.
+_EVENT_MGMT_TYPES: Final[frozenset[str]] = frozenset(
+    {
+        "notable_event_group",
+        "notable_event_comment",
+        "notable_event_aggregation_policy",
+        "notable_event_email_template",
+        "correlation_search",
+        "event_management_state",
+    }
+)
+
+# Nesting relationships: (parent slug, field name) -> child schema slug.
+# Used to embed per-field subordinate references so the runtime validator can
+# recurse into nested payloads without a separate map.
+NESTING: Final[dict[tuple[str, str], str]] = {
+    ("service", "kpis"): "service_kpi",
+    ("service", "entity_rules"): "entity_rules",
+    ("base_service_template", "kpis"): "service_template_kpi",
+    ("base_service_template", "entity_rules"): "entity_rules",
+    ("entity_type", "data_drilldown"): "entity_type_data_drilldown",
+    ("entity_type", "dashboard_drilldowns"): "entity_type_dashboard_drilldown",
+    ("entity_type", "vital_metrics"): "entity_type_vital_metrics",
+    ("service_kpi", "entity_thresholds"): "kpi_threshold_settings",
+    ("service_kpi", "aggregate_thresholds"): "kpi_threshold_settings",
+    ("service_kpi", "time_variate_thresholds_specification"): (
+        "time_variate_thresholds_specification"
+    ),
+    ("service_kpi", "trending_ad"): "anomaly_detection_algorithm_settings",
+    ("service_kpi", "cohesive_ad"): "anomaly_detection_algorithm_settings",
+    ("service_template_kpi", "entity_thresholds"): "kpi_threshold_settings",
+    ("service_template_kpi", "aggregate_thresholds"): "kpi_threshold_settings",
+    ("kpi_threshold_settings", "thresholdLevels"): "kpi_threshold_levels",
+    ("deep_dive", "lane_settings_collection"): "deep_dive_lane_setting",
+}
+
+# Fields that are server-generated/read-only: setting them on create/update is
+# a warning, not an error. Keyed by the canonical (lower-cased) field name.
+READ_ONLY_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "object_type",
+        "create_by",
+        "create_source",
+        "create_time",
+        "mod_source",
+        "mod_time",
+        "mod_timestamp",
+        "_owner",
+        "_user",
+        "version",
+        "_version",
+        "acl",
+        "identifying_name",
+    }
+)
+
+# Minimal required fields per object type (conservative; see spec).
+REQUIRED_FIELDS: Final[dict[str, tuple[str, ...]]] = {
+    "entity": ("title",),
+    "service": ("title",),
+    "base_service_template": ("title",),
+    "entity_type": ("title",),
+    "kpi_threshold_template": ("title",),
+    "kpi_base_search": ("title",),
+    "glass_table": ("title",),
+    "deep_dive": ("title",),
+    "team": ("title",),
+    "correlation_search": ("title",),
+}
+
+
+def interface_for(object_type: str) -> str:
+    """Return the REST interface path prefix for a top-level object type."""
+    if object_type in _EVENT_MGMT_TYPES:
+        return EVENT_MGMT_INTERFACE
+    if object_type == "maintenance_calendar":
+        return MAINTENANCE_INTERFACE
+    return ITOA_INTERFACE

--- a/scripts/itsi_schema/parse_schema_md.py
+++ b/scripts/itsi_schema/parse_schema_md.py
@@ -1,0 +1,336 @@
+"""Parse the scraped ITSI 4.21 schema markdown into structured JSON.
+
+Usage:
+    python -m scripts.itsi_schema.parse_schema_md \
+        --source .research/itsi/schema.md \
+        --out mcp_itsi/knowledge/schema/data
+
+The output is one ``<slug>.json`` file per object type / subordinate structure,
+plus an ``index.json`` describing the corpus. These files are bundled with the
+package and consumed by ``mcp_itsi.knowledge.schema.registry``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+from scripts.itsi_schema import mapping
+
+_HEADING_RE = re.compile(r"^(#{1,3})\s+(.*?)\s*$")
+_TABLE_ROW_RE = re.compile(r"^\|(.+)\|\s*$")
+_BULLET_LINK_RE = re.compile(r"^\s*-\s*\[([^\]]+)\]")
+
+_TYPE_MAP = {
+    "string": "string",
+    "integer": "integer",
+    "int": "integer",
+    "number": "number",
+    "float": "number",
+    "boolean": "boolean",
+    "bool": "boolean",
+    "object": "object",
+    "objects": "array",
+    "dict": "object",
+    "array": "array",
+    "list": "array",
+    "boolean operator": "string",
+}
+
+
+@dataclass
+class Attribute:
+    name: str
+    label: str
+    type: str
+    type_raw: str
+    required: bool
+    read_only: bool
+    description: str
+    subordinate: str | None = None
+
+
+@dataclass
+class Schema:
+    slug: str
+    title: str
+    kind: str  # "object" | "subordinate"
+    description: str = ""
+    object_type: str | None = None
+    interface: str | None = None
+    endpoint: str | None = None
+    subordinate_objects: list[str] = field(default_factory=list)
+    attributes: list[Attribute] = field(default_factory=list)
+
+
+def _clean_field_name(cell: str) -> str:
+    """Turn a doc field cell like ``_\\_key_`` into ``_key``."""
+    text = cell.strip()
+    m = re.match(r"^_(.*)_$", text)
+    if m:
+        text = m.group(1)
+    text = text.replace("\\_", "_").replace("\\", "")
+    text = text.strip()
+    return mapping.FIELD_NAME_OVERRIDES.get(text, text)
+
+
+def _normalize_type(cell: str) -> tuple[str, str]:
+    raw = cell.strip()
+    key = raw.lower().strip(" .")
+    return _TYPE_MAP.get(key, "string"), raw
+
+
+def _clean_description(cell: str) -> str:
+    text = cell.replace("<br>", " ").replace("\\_", "_")
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def _split_row(line: str) -> list[str] | None:
+    m = _TABLE_ROW_RE.match(line)
+    if not m:
+        return None
+    return [c.strip() for c in m.group(1).split("|")]
+
+
+def _parse_attribute_table(lines: list[str], start: int) -> tuple[list[Attribute], int]:
+    """Parse a markdown table starting at/after ``start``; return rows + next idx."""
+    attrs: list[Attribute] = []
+    i = start
+    seen: set[str] = set()
+    in_table = False
+    while i < len(lines):
+        line = lines[i]
+        if _HEADING_RE.match(line):
+            break
+        cells = _split_row(line)
+        if cells is None:
+            if in_table:
+                break
+            i += 1
+            continue
+        # Header / separator rows.
+        joined = "".join(cells).replace("-", "").replace(":", "").strip()
+        if not joined or {c.lower() for c in cells} >= {"field", "type", "description"}:
+            in_table = True
+            i += 1
+            continue
+        in_table = True
+        if len(cells) < 3:
+            i += 1
+            continue
+        name = _clean_field_name(cells[0])
+        if not name or name.lower() in seen:
+            i += 1
+            continue
+        seen.add(name.lower())
+        type_norm, type_raw = _normalize_type(cells[1])
+        attrs.append(
+            Attribute(
+                name=name,
+                label=name,
+                type=type_norm,
+                type_raw=type_raw,
+                required=False,
+                read_only=name.lower() in mapping.READ_ONLY_FIELDS,
+                description=_clean_description("|".join(cells[2:])),
+            )
+        )
+        i += 1
+    return attrs, i
+
+
+def _parse_sections(lines: list[str]) -> dict[str, dict]:
+    """Split the doc body into raw section dicts keyed by section title."""
+    start = next(
+        (i for i, line in enumerate(lines) if line.strip() == "# ITSI REST API schema"),
+        0,
+    )
+    sections: dict[str, dict] = {}
+    current: dict | None = None
+    i = start
+    while i < len(lines):
+        line = lines[i]
+        m = _HEADING_RE.match(line)
+        if m and len(m.group(1)) == 2:
+            title = m.group(2).strip()
+            current = {"title": title, "description": "", "attributes": [], "subs": []}
+            sections[title] = current
+            i += 1
+            continue
+        if current is None:
+            i += 1
+            continue
+        if m and m.group(2).strip() == "Description":
+            desc, i = _collect_description(lines, i + 1)
+            current["description"] = desc
+            continue
+        if m and m.group(2).strip() == "Attributes":
+            attrs, i = _parse_attribute_table(lines, i + 1)
+            current["attributes"] = attrs
+            continue
+        if m and m.group(2).strip().startswith("Subordinate"):
+            subs, i = _collect_subordinates(lines, i + 1)
+            current["subs"] = subs
+            continue
+        i += 1
+    return sections
+
+
+def _collect_description(lines: list[str], start: int) -> tuple[str, int]:
+    out: list[str] = []
+    i = start
+    while i < len(lines):
+        if _HEADING_RE.match(lines[i]):
+            break
+        text = lines[i].strip()
+        if text:
+            out.append(text)
+        i += 1
+    return " ".join(out).strip(), i
+
+
+def _collect_subordinates(lines: list[str], start: int) -> tuple[list[str], int]:
+    titles: list[str] = []
+    i = start
+    while i < len(lines):
+        if _HEADING_RE.match(lines[i]):
+            break
+        m = _BULLET_LINK_RE.match(lines[i])
+        if m:
+            titles.append(m.group(1).strip())
+        i += 1
+    return titles, i
+
+
+def _resolve_slug(title: str) -> tuple[str, str] | None:
+    """Return ``(slug, kind)`` for a section title, or ``None`` to skip."""
+    if title in mapping.SKIP_SECTIONS:
+        return None
+    if title in mapping.TOP_LEVEL_OBJECTS:
+        return mapping.TOP_LEVEL_OBJECTS[title], "object"
+    if title in mapping.SUBORDINATE_OBJECTS:
+        return mapping.SUBORDINATE_OBJECTS[title], "subordinate"
+    return None
+
+
+def _title_to_slug(title: str) -> str | None:
+    if title in mapping.TOP_LEVEL_OBJECTS:
+        return mapping.TOP_LEVEL_OBJECTS[title]
+    if title in mapping.SUBORDINATE_OBJECTS:
+        return mapping.SUBORDINATE_OBJECTS[title]
+    return None
+
+
+def build_schemas(markdown: str, common_attrs: list[Attribute]) -> dict[str, Schema]:
+    lines = markdown.splitlines()
+    sections = _parse_sections(lines)
+    schemas: dict[str, Schema] = {}
+    for title, raw in sections.items():
+        resolved = _resolve_slug(title)
+        if resolved is None:
+            continue
+        slug, kind = resolved
+        schema = Schema(slug=slug, title=title, kind=kind, description=raw["description"])
+        if kind == "object":
+            schema.object_type = slug
+            schema.interface = mapping.interface_for(slug)
+            schema.endpoint = f"{schema.interface}/{slug}"
+        schema.subordinate_objects = [
+            s for t in raw["subs"] if (s := _title_to_slug(t)) is not None
+        ]
+        attrs: list[Attribute] = list(raw["attributes"])
+        _apply_required(slug, attrs)
+        _apply_nesting(slug, attrs)
+        _merge_common(attrs, common_attrs)
+        schema.attributes = attrs
+        schemas[slug] = schema
+    return schemas
+
+
+def _apply_required(slug: str, attrs: list[Attribute]) -> None:
+    required = set(mapping.REQUIRED_FIELDS.get(slug, ()))
+    for attr in attrs:
+        if attr.name in required or attr.name.lower() in required:
+            attr.required = True
+
+
+def _apply_nesting(slug: str, attrs: list[Attribute]) -> None:
+    for attr in attrs:
+        child = mapping.NESTING.get((slug, attr.name))
+        if child:
+            attr.subordinate = child
+
+
+def _merge_common(attrs: list[Attribute], common: list[Attribute]) -> None:
+    have = {a.name.lower() for a in attrs}
+    for c in common:
+        if c.name.lower() not in have:
+            attrs.append(c)
+
+
+def _extract_common_attrs(markdown: str) -> list[Attribute]:
+    lines = markdown.splitlines()
+    for i, line in enumerate(lines):
+        m = _HEADING_RE.match(line)
+        if m and m.group(2).strip() == "Common Attributes":
+            attrs, _ = _parse_attribute_table(lines, i + 1)
+            return attrs
+    return []
+
+
+def write_output(schemas: dict[str, Schema], out_dir: Path) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for slug, schema in sorted(schemas.items()):
+        payload = asdict(schema)
+        (out_dir / f"{slug}.json").write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+        )
+    index = {
+        "version": "4.21",
+        "source": (
+            "https://help.splunk.com/en/splunk-it-service-intelligence/"
+            "splunk-it-service-intelligence/leverage-rest-apis/4.21/"
+            "itsi-rest-api-schema/itsi-rest-api-schema"
+        ),
+        "object_types": sorted(
+            s.slug for s in schemas.values() if s.kind == "object"
+        ),
+        "subordinate_structures": sorted(
+            s.slug for s in schemas.values() if s.kind == "subordinate"
+        ),
+        "entries": {
+            slug: {
+                "title": s.title,
+                "kind": s.kind,
+                "object_type": s.object_type,
+                "endpoint": s.endpoint,
+                "attribute_count": len(s.attributes),
+                "subordinate_objects": s.subordinate_objects,
+            }
+            for slug, s in sorted(schemas.items())
+        },
+    }
+    (out_dir / "index.json").write_text(
+        json.dumps(index, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", default=".research/itsi/schema.md")
+    parser.add_argument("--out", default="mcp_itsi/knowledge/schema/data")
+    args = parser.parse_args()
+
+    markdown = Path(args.source).read_text(encoding="utf-8")
+    common = _extract_common_attrs(markdown)
+    schemas = build_schemas(markdown, common)
+    write_output(schemas, Path(args.out))
+    print(f"Wrote {len(schemas)} schemas to {args.out} (common attrs: {len(common)})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/itsi_schema/refresh.py
+++ b/scripts/itsi_schema/refresh.py
@@ -1,0 +1,83 @@
+"""Refresh bundled ITSI schemas from the live Splunk docs.
+
+Pipeline:
+1. Scrape the ITSI 4.21 REST API schema page with the Firecrawl CLI.
+2. Parse the markdown into structured ``data/*.json`` (parse_schema_md).
+3. Render the bundled ``content/api/schema.md`` (render_markdown).
+
+Requires the ``firecrawl`` CLI to be installed and authenticated
+(`firecrawl --status`). Run from the repo root:
+
+    python -m scripts.itsi_schema.refresh
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.itsi_schema import parse_schema_md, render_markdown
+
+SCHEMA_URL = (
+    "https://help.splunk.com/en/splunk-it-service-intelligence/"
+    "splunk-it-service-intelligence/leverage-rest-apis/4.21/"
+    "itsi-rest-api-schema/itsi-rest-api-schema"
+)
+
+
+def scrape(url: str, dest: Path, *, wait_ms: int = 4000) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    raw = dest.with_suffix(".raw.json")
+    cmd = [
+        "firecrawl", "scrape", url,
+        "--format", "markdown,links",
+        "--wait-for", str(wait_ms),
+        "--json", "-o", str(raw),
+    ]
+    print(f"$ {' '.join(cmd)}")
+    subprocess.run(cmd, check=True)
+    data = json.loads(raw.read_text(encoding="utf-8"))
+    markdown = data.get("markdown") or ""
+    if not markdown:
+        raise SystemExit("Firecrawl returned no markdown content.")
+    dest.write_text(markdown, encoding="utf-8")
+    print(f"Scraped {len(markdown)} chars -> {dest}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", default=SCHEMA_URL)
+    parser.add_argument("--source", default=".research/itsi/schema.md")
+    parser.add_argument("--data", default="mcp_itsi/knowledge/schema/data")
+    parser.add_argument("--doc", default="mcp_itsi/knowledge/content/api/schema.md")
+    parser.add_argument(
+        "--skip-scrape",
+        action="store_true",
+        help="Reuse the existing --source markdown instead of re-scraping.",
+    )
+    args = parser.parse_args()
+
+    source = Path(args.source)
+    if not args.skip_scrape:
+        scrape(args.url, source)
+    elif not source.exists():
+        print(f"--skip-scrape set but {source} is missing", file=sys.stderr)
+        raise SystemExit(1)
+
+    markdown = source.read_text(encoding="utf-8")
+    common = parse_schema_md._extract_common_attrs(markdown)
+    schemas = parse_schema_md.build_schemas(markdown, common)
+    parse_schema_md.write_output(schemas, Path(args.data))
+    print(f"Generated {len(schemas)} schemas -> {args.data}")
+
+    doc = render_markdown.render(Path(args.data))
+    Path(args.doc).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.doc).write_text(doc, encoding="utf-8")
+    print(f"Rendered doc -> {args.doc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/itsi_schema/render_markdown.py
+++ b/scripts/itsi_schema/render_markdown.py
@@ -1,0 +1,120 @@
+"""Render the parsed schema JSON into a single bundled markdown doc.
+
+Produces ``mcp_itsi/knowledge/content/api/schema.md`` from ``data/*.json`` so
+the doc tools (``itsi_read_doc('api/schema')``) and the
+``itsi://docs/api/schema`` resource serve the complete, regenerable schema.
+
+Usage:
+    python -m scripts.itsi_schema.render_markdown \
+        --data mcp_itsi/knowledge/schema/data \
+        --out mcp_itsi/knowledge/content/api/schema.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+_HEADER = """# ITSI REST API schema (4.21)
+
+> Source: <{source}>
+>
+> Auto-generated from the ITSI 4.21 REST API schema docs by
+> `scripts/itsi_schema`. Do not edit by hand — run the refresh script instead.
+> For machine-usable schemas and validation, use the `itsi_get_object_schema`,
+> `itsi_list_object_schemas` and `itsi_validate_object_payload` tools.
+
+ITSI stores its configuration in the splunkd KV store. **Do not** write to the
+KV store directly — always go through the REST endpoints. Common system fields
+(`object_type`, `create_time`, `mod_time`, `_owner`, `_user`, `version`, ...)
+are server-generated and read-only.
+"""
+
+
+def _load(data_dir: Path) -> tuple[dict, dict[str, dict]]:
+    index = json.loads((data_dir / "index.json").read_text(encoding="utf-8"))
+    schemas: dict[str, dict] = {}
+    for path in data_dir.glob("*.json"):
+        if path.name == "index.json":
+            continue
+        data = json.loads(path.read_text(encoding="utf-8"))
+        schemas[data["slug"]] = data
+    return index, schemas
+
+
+def _render_attributes(attrs: list[dict]) -> str:
+    rows = ["| Field | Type | Req | Description |", "| --- | --- | --- | --- |"]
+    for a in attrs:
+        flags = []
+        if a.get("required"):
+            flags.append("yes")
+        if a.get("read_only"):
+            flags.append("read-only")
+        sub = f" *(nested: `{a['subordinate']}`)*" if a.get("subordinate") else ""
+        desc = (a.get("description", "") or "").replace("|", "\\|")
+        rows.append(
+            f"| `{a['name']}` | {a.get('type', '')} | {', '.join(flags) or '-'} | {desc}{sub} |"
+        )
+    return "\n".join(rows)
+
+
+def _render_schema(slug: str, schema: dict) -> str:
+    lines = [f"## {schema['title']} (`{slug}`)", ""]
+    if schema.get("endpoint"):
+        lines.append(f"**Endpoint:** `{schema['endpoint']}`  ")
+    if schema.get("kind") == "subordinate":
+        lines.append("**Kind:** subordinate (nested) structure  ")
+    desc = schema.get("description", "")
+    if desc:
+        lines.append("")
+        lines.append(desc)
+    subs = schema.get("subordinate_objects") or []
+    if subs:
+        lines.append("")
+        lines.append("**Subordinate objects:** " + ", ".join(f"`{s}`" for s in subs))
+    lines.append("")
+    lines.append(_render_attributes(schema.get("attributes", [])))
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render(data_dir: Path) -> str:
+    index, schemas = _load(data_dir)
+    parts = [_HEADER.format(source=index.get("source", ""))]
+
+    object_types = index.get("object_types", [])
+    subordinate = index.get("subordinate_structures", [])
+
+    parts.append("\n## Object types\n")
+    parts.append(", ".join(f"`{t}`" for t in object_types))
+    parts.append("\n## Subordinate structures\n")
+    parts.append(", ".join(f"`{t}`" for t in subordinate))
+    parts.append("")
+
+    parts.append("---\n\n# Object type schemas\n")
+    for slug in object_types:
+        parts.append(_render_schema(slug, schemas[slug]))
+
+    parts.append("---\n\n# Subordinate structure schemas\n")
+    for slug in subordinate:
+        parts.append(_render_schema(slug, schemas[slug]))
+
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data", default="mcp_itsi/knowledge/schema/data")
+    parser.add_argument("--out", default="mcp_itsi/knowledge/content/api/schema.md")
+    args = parser.parse_args()
+
+    markdown = render(Path(args.data))
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(markdown, encoding="utf-8")
+    print(f"Wrote {len(markdown)} chars to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_itsi_schema.py
+++ b/tests/test_itsi_schema.py
@@ -1,0 +1,192 @@
+"""Tests for the ITSI schema knowledge layer and pre-flight validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_itsi.knowledge.schema import PayloadValidator, registry
+from mcp_itsi.knowledge.schema.examples import examples_for
+from mcp_itsi.tools import _itoa_ops as ops
+from mcp_itsi.tools._validation import (
+    PayloadValidationError,
+    drain_warnings,
+    preflight,
+    reset_warnings,
+)
+
+# --- Registry -------------------------------------------------------------
+
+
+def test_registry_loads_core_object_types():
+    slugs = {s.slug for s in registry.list_object_types()}
+    assert {"service", "kpi_base_search", "entity", "entity_type"} <= slugs
+
+
+def test_registry_get_by_object_type_and_slug():
+    assert registry.get("service") is registry.get("service")
+    assert registry.get("SERVICE").slug == "service"
+    assert registry.get("does_not_exist") is None
+
+
+def test_service_schema_marks_required_and_nested():
+    svc = registry.get("service")
+    assert "title" in svc.required_fields
+    kpis = svc.attribute("kpis")
+    assert kpis is not None and kpis.subordinate == "service_kpi"
+
+
+def test_json_schema_projection_has_types_and_required():
+    js = registry.get("service").to_json_schema()
+    assert js["type"] == "object"
+    assert js["properties"]["title"]["type"] == "string"
+    assert "title" in js["required"]
+
+
+# --- Validator ------------------------------------------------------------
+
+
+def test_valid_payload_passes():
+    result = PayloadValidator().validate("service", {"title": "Web", "enabled": 1})
+    assert result.ok
+    assert not result.errors
+
+
+def test_unknown_typo_field_is_error_with_suggestion():
+    result = PayloadValidator().validate("service", {"titel": "Web"})
+    assert not result.ok
+    messages = " ".join(e.message for e in result.errors)
+    assert "title" in messages
+
+
+def test_unknown_nontypo_field_is_warning_not_error():
+    result = PayloadValidator().validate(
+        "service", {"title": "Web", "totally_unrelated_field_xyz": 1}
+    )
+    assert result.ok
+    assert any("not in the documented" in w.message for w in result.warnings)
+
+
+def test_wrong_type_is_error():
+    result = PayloadValidator().validate("service", {"title": 123})
+    assert not result.ok
+    assert any(e.field == "title" for e in result.errors)
+
+
+def test_boolean_field_accepts_integer():
+    # ITSI uses 1/0 for documented "Boolean" fields like enabled.
+    assert PayloadValidator().validate("service", {"title": "x", "enabled": 1}).ok
+    assert not PayloadValidator().validate("service", {"title": "x", "enabled": "yes"}).ok
+
+
+def test_missing_required_is_error_unless_partial():
+    full = PayloadValidator().validate("service", {"description": "d"})
+    assert not full.ok
+    partial = PayloadValidator().validate("service", {"description": "d"}, is_partial=True)
+    assert partial.ok
+
+
+def test_read_only_field_is_warning():
+    result = PayloadValidator().validate("service", {"title": "x", "object_type": "service"})
+    assert result.ok
+    assert any(w.field == "object_type" for w in result.warnings)
+
+
+def test_nested_kpi_validation_recurses():
+    result = PayloadValidator().validate(
+        "service", {"title": "x", "kpis": [{"titel": "bad"}]}
+    )
+    assert not result.ok
+    assert any("Service KPI" in e.message for e in result.errors)
+
+
+def test_unknown_object_type_errors():
+    result = PayloadValidator().validate("nope", {"title": "x"})
+    assert not result.ok
+
+
+# --- Examples -------------------------------------------------------------
+
+
+@pytest.mark.parametrize("object_type", ["service", "kpi_base_search"])
+def test_curated_examples_validate_clean(object_type):
+    curated = examples_for(registry.get(object_type)).get("curated")
+    assert curated is not None
+    result = PayloadValidator().validate(object_type, curated)
+    assert result.ok, [e.message for e in result.errors]
+    assert not result.warnings
+
+
+def test_minimal_example_contains_required_fields():
+    minimal = examples_for(registry.get("service"))["minimal"]
+    assert "title" in minimal
+
+
+# --- Write-path pre-flight ------------------------------------------------
+
+
+def test_preflight_raises_on_hard_error():
+    reset_warnings()
+    with pytest.raises(PayloadValidationError):
+        preflight("service", {"titel": "x"}, is_partial=False)
+
+
+def test_preflight_records_warnings_without_raising():
+    reset_warnings()
+    preflight("service", {"title": "x", "object_type": "service"}, is_partial=False)
+    warnings = drain_warnings()
+    assert warnings
+    assert drain_warnings() == []  # buffer cleared after drain
+
+
+def test_preflight_skips_unknown_object_type():
+    reset_warnings()
+    preflight("unknown_type", {"anything": True}, is_partial=False)  # no raise
+
+
+async def test_create_object_blocks_before_network():
+    # ctx is None: if pre-flight did not block first, we'd hit an AttributeError
+    # trying to open a client. A PayloadValidationError proves it blocked early.
+    reset_warnings()
+    with pytest.raises(PayloadValidationError):
+        await ops.create_object(None, "service", {"titel": "x"})
+
+
+# --- Tools ----------------------------------------------------------------
+
+
+async def test_list_object_schemas_tool():
+    from mcp_itsi.tools.schema import ListObjectSchemas
+
+    result = await ListObjectSchemas().execute(None, None)
+    assert result["status"] == "success"
+    assert result["count"] >= 15
+    assert any(e["object_type"] == "service" for e in result["object_types"])
+
+
+async def test_get_object_schema_tool_offline():
+    from mcp_itsi.tools.schema import GetObjectSchema
+
+    result = await GetObjectSchema().execute(None, None, object_type="service")
+    assert result["status"] == "success"
+    assert result["object_type"] == "service"
+    assert "service_kpi" in result["subordinate_schemas"]
+    assert "json_schema" in result
+    assert "curated" in result["examples"]
+
+
+async def test_get_object_schema_unknown_type():
+    from mcp_itsi.tools.schema import GetObjectSchema
+
+    result = await GetObjectSchema().execute(None, None, object_type="nope")
+    assert result["status"] == "error"
+
+
+async def test_validate_payload_tool_reports_errors():
+    from mcp_itsi.tools.schema import ValidateObjectPayload
+
+    result = await ValidateObjectPayload().execute(
+        None, None, object_type="service", payload={"titel": "x"}
+    )
+    assert result["status"] == "success"
+    assert result["ok"] is False
+    assert result["errors"]

--- a/tests/test_mcp_itsi.py
+++ b/tests/test_mcp_itsi.py
@@ -300,6 +300,7 @@ async def test_build_server_registers_everything():
 
     resource_uris = {str(getattr(r, "uri", "")) for r in resources}
     assert "itsi://docs/api/reference" in resource_uris
+    assert "itsi://llms.txt" in resource_uris
 
     prompt_names = {getattr(p, "name", "") for p in prompts}
     assert "itsi_service_onboarding" in prompt_names


### PR DESCRIPTION
## Summary

Makes ITSI ITOA object CRUD reliable for LLM agents by bundling **structured schemas** (generated from the Splunk 4.21 ITSI REST API docs) and wiring them into discovery, dry-run validation, and pre-flight write checks. Also includes a CI fix so Docker images are released on merge.

### Schema-aware ITSI tooling
- **Schema knowledge layer** (`mcp_itsi/knowledge/schema`): models, registry, validator, and example generation, backed by **32 generated `data/*.json` specs** covering all documented ITOA object types and their nested/subordinate structures.
- **New tools:**
  - `itsi_list_object_schemas` — list all documented object types.
  - `itsi_get_object_schema` — full schema + JSON-Schema projection + skeleton/curated examples, with an optional **live example** pulled from the connected instance.
  - `itsi_validate_object_payload` — dry-run validation returning structured errors + warnings.
- **Pre-flight validation on create/update:** hard errors (typos, wrong types, missing required, nested errors) block **before** the POST and return structured `validation_errors`; non-fatal warnings (read-only / undocumented fields) surface **inline** on success via a request-scoped `ContextVar`.
- Dropped redundant per-tool `title` guards now that required fields are enforced by the schema validator (kept where `title` is not schema-required, e.g. `home_view`, `notable_event_aggregation_policy`).
- **Schema resources** (`itsi://schema/<type>`) + a dev-time generation pipeline (`scripts/itsi_schema`) and regenerated `content/api/schema.md`.
- `.gitignore`: keep the bundled schema data (so it ships in the wheel) while still ignoring other `data/` dirs.

### CI
- Make `docker.yml` reusable (`workflow_call`/`dispatch` with a version input) and fan out to it from release-please, matching the PyPI flow (the release-please-created tag never triggered the old `push: tags` listener).

## Test plan
- [x] Unit/integration suite: `tests/test_itsi_schema.py` — 24 passing (registry, validator, examples, write-path pre-flight).
- [x] `ruff check` clean on all touched tool files.
- [x] **Live-verified** against a real ITSI instance: connectivity (31 object types), schema listing, live-example enrichment (empty + populated), good/bad validation incl. nested typos, pre-flight blocking (no POST sent), and a real create -> inline-warning -> delete cycle.
- [ ] Reviewer: confirm bundled `mcp_itsi/knowledge/schema/data/**` is included in the built wheel.

## Notes
- mcp-builder eval set added at `packaging/mcp-itsi-server/evals/schema_tools_eval.xml`.
- Design doc: `docs/guides/itsi/2026-06-02-schema-tooling-design.md`.
