### PR TITLE
Fix Dashboard Studio cheatsheet loading in packaged installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,10 +80,14 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"docs/reference/dashboard_studio_cheatsheet.md" = "src/bundled_docs/dashboard_studio_cheatsheet.md"
+
 [tool.hatch.build.targets.sdist]
 include = [
 "/src",
 "/tests",
+"/docs/reference/dashboard_studio_cheatsheet.md",
 "/pyproject.toml",
 "/README.md"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-for-splunk"
-version = "0.6.3"
+version = "0.7.0"
 description = "MCP server for Splunk"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/bundled_docs/__init__.py
+++ b/src/bundled_docs/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled reference documents shipped inside the MCP server wheel."""

--- a/src/resources/dashboard_studio_content.py
+++ b/src/resources/dashboard_studio_content.py
@@ -1,0 +1,52 @@
+"""
+Load Dashboard Studio reference content for MCP tools and resources.
+
+The cheatsheet is authored at docs/reference/dashboard_studio_cheatsheet.md.
+That file is bundled into the wheel at build time for Docker and pip installs.
+"""
+
+from __future__ import annotations
+
+import logging
+from importlib import resources
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+CHEATSHEET_FILENAME = "dashboard_studio_cheatsheet.md"
+CHEATSHEET_SOURCE_PATH = f"docs/reference/{CHEATSHEET_FILENAME}"
+BUNDLED_DOCS_PACKAGE = "src.bundled_docs"
+
+
+class DashboardStudioContentError(Exception):
+    """Raised when Dashboard Studio reference content cannot be loaded."""
+
+
+def cheatsheet_edit_path() -> Path:
+    """Return the repo-relative path where the cheatsheet should be edited."""
+    return Path(__file__).resolve().parents[2] / "docs" / "reference" / CHEATSHEET_FILENAME
+
+
+def load_cheatsheet_markdown() -> str:
+    """
+    Load the Dashboard Studio cheatsheet markdown.
+
+    Resolution order:
+    1. docs/reference/dashboard_studio_cheatsheet.md (local repo / bind-mounted dev tree)
+    2. src/bundled_docs/dashboard_studio_cheatsheet.md (packaged wheel install)
+    """
+    dev_path = cheatsheet_edit_path()
+    if dev_path.exists():
+        logger.debug("Loading Dashboard Studio cheatsheet from %s", dev_path)
+        return dev_path.read_text(encoding="utf-8")
+
+    try:
+        bundled_path = resources.files(BUNDLED_DOCS_PACKAGE).joinpath(CHEATSHEET_FILENAME)
+        content = bundled_path.read_text(encoding="utf-8")
+        logger.debug("Loading Dashboard Studio cheatsheet from bundled package")
+        return content
+    except (FileNotFoundError, ModuleNotFoundError, TypeError, OSError) as exc:
+        raise DashboardStudioContentError(
+            "Dashboard Studio cheatsheet is unavailable. "
+            f"Edit {CHEATSHEET_SOURCE_PATH} in the repository and rebuild or reinstall the MCP server."
+        ) from exc

--- a/src/resources/dashboard_studio_docs.py
+++ b/src/resources/dashboard_studio_docs.py
@@ -13,8 +13,8 @@ from fastmcp import Context
 from src.core.base import BaseResource, ResourceMetadata
 from src.core.registry import resource_registry
 from src.resources.dashboard_studio_content import (
-    DashboardStudioContentError,
     CHEATSHEET_SOURCE_PATH,
+    DashboardStudioContentError,
     load_cheatsheet_markdown,
 )
 

--- a/src/resources/dashboard_studio_docs.py
+++ b/src/resources/dashboard_studio_docs.py
@@ -5,7 +5,6 @@ Provides curated Dashboard Studio (9.4) documentation for LLM-assisted dashboard
 """
 
 import logging
-from pathlib import Path
 
 import httpx
 from bs4 import BeautifulSoup
@@ -13,6 +12,11 @@ from fastmcp import Context
 
 from src.core.base import BaseResource, ResourceMetadata
 from src.core.registry import resource_registry
+from src.resources.dashboard_studio_content import (
+    DashboardStudioContentError,
+    CHEATSHEET_SOURCE_PATH,
+    load_cheatsheet_markdown,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +56,7 @@ DASHBOARD_STUDIO_TOPICS = {
     "framework": {
         "name": "Dashboard Framework Introduction",
         "description": "Introduction to Dashboard Framework concepts and architecture",
-        "url": "https://splunkui.splunk.com/Packages/dashboard-docs/Introduction",
+        "url": "https://help.splunk.com/en/splunk-enterprise/create-dashboards-and-reports/dashboard-studio/9.4/introduction-to-splunk-dashboard-studio/create-a-dashboard-in-dashboard-studio",
         "tags": ["framework", "introduction", "concepts"],
     },
 }
@@ -95,29 +99,22 @@ class DashboardStudioDocsResource(BaseResource):
         return await self._fetch_external_content(topic_info)
 
     async def _load_file_content(self, filename: str) -> str:
-        """Load content from a file in docs/reference."""
+        """Load bundled or repo-local Dashboard Studio reference content."""
+        if filename != "dashboard_studio_cheatsheet.md":
+            raise DashboardStudioContentError(
+                f"Unknown local Dashboard Studio document '{filename}'. "
+                f"Edit cheatsheet content in {CHEATSHEET_SOURCE_PATH}."
+            )
+
         try:
-            file_path = Path(__file__).parent.parent.parent / "docs" / "reference" / filename
-
-            if not file_path.exists():
-                return f"""# Dashboard Studio Documentation Not Found
-
-The documentation file was not found at: {file_path}
-
-Please ensure the file exists in the docs/reference directory.
-"""
-
-            content = file_path.read_text(encoding="utf-8")
-            return content
-
+            return load_cheatsheet_markdown()
+        except DashboardStudioContentError:
+            raise
         except Exception as e:  # pylint: disable=broad-except
             logger.error("Error loading Dashboard Studio documentation file %s: %s", filename, e)
-            return f"""# Error Loading Documentation
-
-Failed to load Dashboard Studio documentation: {str(e)}
-
-Please check the file path and permissions.
-"""
+            raise DashboardStudioContentError(
+                f"Failed to load Dashboard Studio cheatsheet from {CHEATSHEET_SOURCE_PATH}: {e}"
+            ) from e
 
     async def _fetch_external_content(self, topic_info: dict) -> str:
         """Fetch and format external documentation content."""
@@ -180,7 +177,16 @@ Please check the file path and permissions.
                     lines = [line.strip() for line in content_text.split("\n") if line.strip()]
                     formatted_content = "\n\n".join(lines)
                 else:
-                    formatted_content = "Content extraction failed - no main content found."
+                    raise DashboardStudioContentError(
+                        f"No readable documentation content found at {url}. "
+                        "Use dashboard-studio://cheatsheet for the local reference."
+                    )
+
+                if len(formatted_content.strip()) < 100:
+                    raise DashboardStudioContentError(
+                        f"Documentation at {url} returned insufficient content after parsing. "
+                        "Use dashboard-studio://cheatsheet for the local reference."
+                    )
 
                 return f"""# {name}
 
@@ -206,58 +212,19 @@ Please check the file path and permissions.
 **Note**: This content was fetched from Splunk's official documentation. For a comprehensive local reference, see: `dashboard-studio://cheatsheet`
 """
 
+        except DashboardStudioContentError:
+            raise
         except httpx.HTTPError as e:
             logger.error("Failed to fetch Dashboard Studio docs from %s: %s", url, e)
-            return f"""# {name}
-
-**Topic**: `{self.topic}`
-**Description**: {description}
-**Tags**: {tags}
-
-## Error Fetching Documentation
-
-Failed to retrieve documentation from: {url}
-
-**Error**: {str(e)}
-
-Please check:
-- Network connectivity
-- URL availability
-- Firewall settings
-
-For offline reference, use: `dashboard-studio://cheatsheet`
-
-## Related Topics
-
-{self._get_related_topics()}
-
----
-
-**Official URL**: {url}
-"""
+            raise DashboardStudioContentError(
+                f"Failed to retrieve documentation from {url}: {e}. "
+                "Use dashboard-studio://cheatsheet for the local reference."
+            ) from e
         except Exception as e:  # pylint: disable=broad-except
             logger.error("Error processing Dashboard Studio docs for %s: %s", self.topic, e)
-            return f"""# {name}
-
-**Topic**: `{self.topic}`
-**Description**: {description}
-
-## Error Processing Documentation
-
-An error occurred while processing the documentation.
-
-**Error**: {str(e)}
-
-For offline reference, use: `dashboard-studio://cheatsheet`
-
-## Related Topics
-
-{self._get_related_topics()}
-
----
-
-**Official URL**: {url}
-"""
+            raise DashboardStudioContentError(
+                f"Failed to process documentation for topic '{self.topic}': {e}"
+            ) from e
 
     def _get_related_topics(self) -> str:
         """Get formatted list of related topics."""

--- a/src/tools/docs/splunk_docs_tools.py
+++ b/src/tools/docs/splunk_docs_tools.py
@@ -13,6 +13,7 @@ from fastmcp import Context
 
 from src.core.base import BaseTool, ToolMetadata
 from src.core.utils import log_tool_execution
+from src.resources.dashboard_studio_content import DashboardStudioContentError
 from src.resources.dashboard_studio_docs import (
     DASHBOARD_STUDIO_TOPICS,
     DashboardStudioDiscoveryResource,
@@ -1702,6 +1703,10 @@ class GetStudioTopic(BaseTool):
                 }
             )
 
+        except DashboardStudioContentError as e:
+            error_msg = f"Failed to retrieve Dashboard Studio topic '{topic}': {e}"
+            self.logger.error(error_msg)
+            return self.format_error_response(error_msg)
         except Exception as e:
             error_msg = f"Failed to retrieve Dashboard Studio topic '{topic}': {str(e)}"
             self.logger.error(error_msg)

--- a/tests/test_resources_dashboard_studio.py
+++ b/tests/test_resources_dashboard_studio.py
@@ -5,6 +5,11 @@ Tests for Dashboard Studio documentation resources.
 import pytest
 
 from src.core.registry import resource_registry
+from src.resources.dashboard_studio_content import (
+    CHEATSHEET_SOURCE_PATH,
+    cheatsheet_edit_path,
+    load_cheatsheet_markdown,
+)
 from src.resources.dashboard_studio_docs import (
     DASHBOARD_STUDIO_TOPICS,
     DashboardStudioDiscoveryResource,
@@ -135,6 +140,20 @@ class TestDashboardStudioResources:
 
         # Verify cheatsheet has a file reference
         assert "file" in DASHBOARD_STUDIO_TOPICS["cheatsheet"]
+
+    def test_cheatsheet_source_path(self):
+        """Test cheatsheet source location points at docs/reference."""
+        assert CHEATSHEET_SOURCE_PATH == "docs/reference/dashboard_studio_cheatsheet.md"
+        assert cheatsheet_edit_path().name == "dashboard_studio_cheatsheet.md"
+        assert cheatsheet_edit_path().parent.name == "reference"
+
+    @pytest.mark.asyncio
+    async def test_load_cheatsheet_markdown(self):
+        """Test cheatsheet loader returns substantive content."""
+        content = load_cheatsheet_markdown()
+
+        assert "Dashboard Studio" in content
+        assert len(content) > 1000
 
     def test_dynamic_resource_creation(self):
         """Test creating resources for different topics."""

--- a/uv.lock
+++ b/uv.lock
@@ -1495,7 +1495,7 @@ cli = [
 
 [[package]]
 name = "mcp-itsi-server"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "packaging/mcp-itsi-server" }
 dependencies = [
     { name = "fastmcp" },
@@ -1512,7 +1512,7 @@ requires-dist = [
 
 [[package]]
 name = "mcp-server-for-splunk"
-version = "0.6.3"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

- Bundle `docs/reference/dashboard_studio_cheatsheet.md` into the wheel so `get_studio_topic("cheatsheet")` works in Docker and pip installs
- Add a dedicated loader that prefers the editable repo file in dev and falls back to bundled package content in production
- Point the `framework` topic at Splunk help docs instead of the JS-rendered splunkui page
- Return explicit `status: error` from `get_studio_topic` when topic content is missing or unparseable

## Context

`list_dashboard_studio_topics` and most external topics worked, but `cheatsheet` failed in packaged installs because only `src/` was shipped in the wheel. The cheatsheet lived under `docs/reference/` and was resolved via a source-tree path that does not exist in site-packages.

## Test plan

- [x] `pytest tests/test_resources_dashboard_studio.py` (12 passed)
- [x] Verified all 6 topics load locally via `get_studio_topic`
- [x] Verified wheel install loads bundled cheatsheet without `docs/reference/` on disk
- [ ] Rebuild/redeploy MCP server and confirm live `get_studio_topic("cheatsheet")` returns full content

## Breaking changes

None.