### PR TITLE
ci: use CURSOR_MODEL org variable for code review workflow

### DIFF
--- a/.github/workflows/cursor-code-review.yml
+++ b/.github/workflows/cursor-code-review.yml
@@ -64,9 +64,10 @@ jobs:
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           GH_TOKEN: ${{ github.token }}
-          MODEL: gpt-5.3-codex
+          MODEL: ${{ vars.CURSOR_MODEL || 'composer-2.5-fast' }}
         run: |
           set -euo pipefail
+          echo "Using Cursor model: $MODEL"
           agent --force --model "$MODEL" --output-format=text "You are operating in a GitHub Actions runner performing automated code review. The gh CLI is available and authenticated via GH_TOKEN. You may comment on pull requests.
 
           Context:


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `gpt-5.3-codex` model in the Cursor code review workflow with the organization/repository variable `CURSOR_MODEL`
- Falls back to `composer-2.5-fast` when the variable is unset
- Logs the selected model in CI output for easier debugging

## Motivation

Allows the org to change the review model centrally (Settings → Secrets and variables → Actions → Variables) without editing the workflow on each update.

## Configuration

Set `CURSOR_MODEL` at the org or repo level, e.g. `composer-2.5-fast`. If unset, the workflow uses `composer-2.5-fast` by default.

## Test plan

- [ ] Workflow YAML validates
- [ ] Open a PR and confirm the **Cursor Code Review** job logs `Using Cursor model: ...`
- [ ] Confirm review still completes when `CURSOR_MODEL` is set
- [ ] Confirm fallback works when `CURSOR_MODEL` is unset

## Checklist

- [x] CI workflow change only (no runtime code changes)
- [ ] Unit tests pass (unchanged application code)
- [ ] Manual testing completed on next PR trigger