### PR TITLE
fix: resolve Splunk client config from headers in availability check

### DIFF
--- a/src/core/base.py
+++ b/src/core/base.py
@@ -9,7 +9,11 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.server.dependencies import get_http_headers
 from splunklib import client
+
+from src.core.shared_context import http_headers_context
+from src.core.utils import extract_client_config_from_headers
 
 logger = logging.getLogger(__name__)
 
@@ -177,6 +181,75 @@ class BaseTool(ABC):
 
         return service
 
+    def _resolve_client_config_sync(self, ctx: Context) -> dict[str, Any] | None:
+        """
+        Resolve client configuration synchronously from available sources.
+
+        Mirrors the priority order of ``get_client_config_from_context`` using
+        sync-accessible sources only.
+        """
+        # Priority 1: HTTP request state (set by middleware per request)
+        try:
+            if (
+                hasattr(ctx, "request_context")
+                and hasattr(ctx.request_context, "request")
+                and hasattr(ctx.request_context.request, "state")
+                and hasattr(ctx.request_context.request.state, "client_config")
+            ):
+                client_config = ctx.request_context.request.state.client_config
+                if client_config:
+                    self.logger.info(
+                        "Using client config from request state (keys=%s)",
+                        list(client_config.keys()),
+                    )
+                    return client_config
+        except Exception as e:
+            self.logger.debug("Failed to get client config from request state: %s", e)
+
+        # Priority 2: HTTP headers (FastMCP runtime dependencies)
+        try:
+            headers = get_http_headers(include_all=True)
+            if headers:
+                client_config = extract_client_config_from_headers(headers)
+                if client_config:
+                    self.logger.info(
+                        "Using client config from HTTP headers (keys=%s)",
+                        list(client_config.keys()),
+                    )
+                    return client_config
+        except Exception as e:
+            self.logger.debug("Failed to get client config from HTTP headers: %s", e)
+
+        # Priority 3: ContextVar headers (set by middleware)
+        try:
+            headers = http_headers_context.get()
+            if headers:
+                client_config = extract_client_config_from_headers(headers)
+                if client_config:
+                    self.logger.info(
+                        "Using client config from http_headers_context (keys=%s)",
+                        list(client_config.keys()),
+                    )
+                    return client_config
+        except Exception as e:
+            self.logger.debug("Failed to get client config from http_headers_context: %s", e)
+
+        # Priority 4: Lifespan context (client environment)
+        try:
+            splunk_ctx = self._get_splunk_context(ctx)
+            if splunk_ctx:
+                if hasattr(splunk_ctx, "client_config") and splunk_ctx.client_config:
+                    self.logger.info("Using client config from lifespan context")
+                    return splunk_ctx.client_config
+                if isinstance(splunk_ctx, dict) and splunk_ctx.get("client_config"):
+                    self.logger.info("Using client config from lifespan context dict")
+                    return splunk_ctx["client_config"]
+        except Exception as e:
+            self.logger.debug("Failed to get client config from lifespan context: %s", e)
+
+        self.logger.debug("No client config found in any sync source")
+        return None
+
     def check_splunk_available(self, ctx: Context) -> tuple[bool, client.Service | None, str]:
         """
         Check if Splunk is available and return status.
@@ -184,39 +257,19 @@ class BaseTool(ABC):
         Returns:
             Tuple of (is_available, service, error_message)
         """
-        # Get splunk context from available sources
         splunk_ctx = self._get_splunk_context(ctx)
 
-        # First, prefer per-request client configuration (HTTP headers / client env)
-        try:
-            client_config = None
-            # From HTTP request state (preferred for HTTP transport)
-            if (
-                hasattr(ctx.request_context, "request")
-                and hasattr(ctx.request_context.request, "state")
-                and hasattr(ctx.request_context.request.state, "client_config")
-            ):
-                client_config = ctx.request_context.request.state.client_config
-            # Or from context client_config (handle both dict and object)
-            elif splunk_ctx:
-                if hasattr(splunk_ctx, "client_config"):
-                    client_config = splunk_ctx.client_config
-                elif isinstance(splunk_ctx, dict) and "client_config" in splunk_ctx:
-                    client_config = splunk_ctx["client_config"]
+        client_config = self._resolve_client_config_sync(ctx)
+        if client_config:
+            try:
+                from src.client.splunk_client import get_splunk_service
 
-            if client_config:
-                try:
-                    from src.client.splunk_client import get_splunk_service
-
-                    service = get_splunk_service(client_config)
-                    return True, service, ""
-                except Exception as e:
-                    # Fall back to server default if client-config connection fails
-                    logger.warning(
-                        f"Client-config Splunk connection failed in availability check: {e}"
-                    )
-        except Exception:  # nosec B110
-            pass  # Intentionally suppressed: header/env extraction is best-effort fallback
+                service = get_splunk_service(client_config)
+                return True, service, ""
+            except Exception as e:
+                logger.warning(
+                    "Client-config Splunk connection failed in availability check: %s", e
+                )
 
         # Fallback: use server default service established at startup
         # Handle both SplunkContext objects and dict formats

--- a/tests/test_check_splunk_available.py
+++ b/tests/test_check_splunk_available.py
@@ -1,0 +1,134 @@
+"""Tests for BaseTool.check_splunk_available header-based config resolution."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp import Context
+
+from src.core.base import BaseTool, SplunkContext
+
+
+class _TestTool(BaseTool):
+    """Minimal concrete tool for testing BaseTool helpers."""
+
+    async def execute(self, ctx: Context, *args, **kwargs):
+        return {"status": "success"}
+
+
+@pytest.fixture
+def tool():
+    return _TestTool("test", "test tool")
+
+
+@pytest.fixture
+def ctx():
+    mock_ctx = MagicMock(spec=Context)
+    mock_request = MagicMock()
+    mock_request.state.client_config = None
+    mock_ctx.request_context.request = mock_request
+    mock_ctx.request_context.lifespan_context = SplunkContext(
+        service=None,
+        is_connected=False,
+        client_config={},
+    )
+    return mock_ctx
+
+
+class TestCheckSplunkAvailable:
+    """Verify check_splunk_available resolves header-based client config."""
+
+    @patch("src.client.splunk_client.get_splunk_service")
+    @patch("src.core.base.get_http_headers")
+    def test_uses_http_headers_when_request_state_empty(
+        self, mock_get_http_headers, mock_get_splunk_service, tool, ctx
+    ):
+        """Header config should be used when request.state has no client_config."""
+        mock_get_http_headers.return_value = {
+            "X-Splunk-Host": "splunk.example.com",
+            "X-Splunk-Port": "8089",
+            "X-Splunk-Token": "test-token",
+        }
+        mock_service = MagicMock()
+        mock_get_splunk_service.return_value = mock_service
+
+        is_available, service, error = tool.check_splunk_available(ctx)
+
+        assert is_available is True
+        assert service is mock_service
+        assert error == ""
+        mock_get_splunk_service.assert_called_once_with(
+            {
+                "splunk_host": "splunk.example.com",
+                "splunk_port": 8089,
+                "splunk_token": "test-token",
+            }
+        )
+
+    @patch("src.client.splunk_client.get_splunk_service")
+    @patch("src.core.base.get_http_headers")
+    def test_prefers_request_state_over_headers(
+        self, mock_get_http_headers, mock_get_splunk_service, tool, ctx
+    ):
+        """Request state client_config takes priority over HTTP headers."""
+        ctx.request_context.request.state.client_config = {
+            "splunk_host": "state.example.com",
+            "splunk_port": 8089,
+        }
+        mock_get_http_headers.return_value = {
+            "X-Splunk-Host": "header.example.com",
+            "X-Splunk-Port": "8089",
+        }
+        mock_service = MagicMock()
+        mock_get_splunk_service.return_value = mock_service
+
+        is_available, service, error = tool.check_splunk_available(ctx)
+
+        assert is_available is True
+        assert service is mock_service
+        assert error == ""
+        mock_get_splunk_service.assert_called_once_with(
+            {
+                "splunk_host": "state.example.com",
+                "splunk_port": 8089,
+            }
+        )
+
+    @patch("src.client.splunk_client.get_splunk_service")
+    @patch("src.core.base.get_http_headers")
+    def test_falls_back_to_degraded_mode_when_no_client_config(
+        self, mock_get_http_headers, mock_get_splunk_service, tool, ctx
+    ):
+        """Without client config, degraded lifespan connection is reported unavailable."""
+        mock_get_http_headers.return_value = {}
+
+        is_available, service, error = tool.check_splunk_available(ctx)
+
+        assert is_available is False
+        assert service is None
+        assert "degraded mode" in error
+        mock_get_splunk_service.assert_not_called()
+
+    @patch("src.client.splunk_client.get_splunk_service")
+    @patch("src.core.base.get_http_headers")
+    def test_falls_back_to_lifespan_when_headers_fail(
+        self, mock_get_http_headers, mock_get_splunk_service, tool, ctx
+    ):
+        """When header connection fails, fall back to lifespan default service."""
+        mock_get_http_headers.return_value = {
+            "X-Splunk-Host": "bad.example.com",
+            "X-Splunk-Port": "8089",
+        }
+        mock_get_splunk_service.side_effect = Exception("connection refused")
+
+        lifespan_service = MagicMock()
+        ctx.request_context.lifespan_context = SplunkContext(
+            service=lifespan_service,
+            is_connected=True,
+            client_config={},
+        )
+
+        is_available, service, error = tool.check_splunk_available(ctx)
+
+        assert is_available is True
+        assert service is lifespan_service
+        assert error == ""


### PR DESCRIPTION
## Summary
- Add `_resolve_client_config_sync()` so `check_splunk_available()` resolves Splunk credentials from HTTP headers and `http_headers_context`, matching `get_splunk_service()` behavior.
- Fix header-only auth for tools like `me`, `list_apps`, and `run_oneshot_search` when the server startup connection is unavailable (degraded mode).
- Add unit tests covering header resolution, request-state priority, degraded mode, and lifespan fallback.

## Test plan
- [x] `uv run pytest tests/test_check_splunk_available.py tests/test_me_tool.py -q` (11 passed)
- [x] Live verify on `deslicer-i-0c23c33c7cefcac38.splunk.show` with `X-Splunk-*` headers only while `.env` points to unreachable `so1` (degraded mode): `get_splunk_health`, `me`, and `list_apps` all passed