### PR TITLE
fix(docker): copy cheatsheet before uv sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ COPY LICENSE ./
 # `uv sync` time so the workspace graph resolves and the wheel can build.
 COPY packaging/ ./packaging/
 COPY mcp_itsi/ ./mcp_itsi/
+COPY docs/reference/dashboard_studio_cheatsheet.md ./docs/reference/dashboard_studio_cheatsheet.md
 
 # Install Python dependencies, including the [itsi] extra so the plugin
 # entry point (mcp_splunk.plugins.itsi) is registered inside the container.


### PR DESCRIPTION
## Summary
- Copy `docs/reference/dashboard_studio_cheatsheet.md` before `RUN uv sync` in the Dockerfile
- Fixes Docker build failure where hatchling force-include requires the cheatsheet at wheel build time, but `docs/` was only copied after dependency install

## Test plan
- [x] Confirmed `docs/reference/dashboard_studio_cheatsheet.md` exists in the repo
- [ ] CI Docker build passes
- [ ] Optional: `docker build -t mcp-for-splunk .` completes without `FileNotFoundError`