### PR TITLE
feat: decode UTF-8 Splunk credentials from Base64 MCP headers

### DIFF
--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -93,12 +93,12 @@ def extract_client_config_from_headers(headers: dict) -> dict | None:
     return client_config if client_config else None
 
 
-def _decode_utf8_base64_header(value: str, header_name: str) -> str | None:
+def _decode_utf8_base64_header(value: str, _header_name: str) -> str | None:
     """Decode a UTF-8 credential header without logging the secret value."""
     try:
         return base64.b64decode(value, validate=True).decode("utf-8")
     except (ValueError, UnicodeDecodeError):
-        logger.warning("Invalid base64 credential header ignored: %s", header_name)
+        logger.warning("Invalid encoded Splunk header ignored")
         return None
 
 

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -64,7 +64,7 @@ def extract_client_config_from_headers(headers: dict) -> dict | None:
                 try:
                     client_config[config_key] = int(header_value)
                 except (ValueError, TypeError):
-                    logger.warning("Invalid non-numeric splunk_port header: %s", header_value)
+                    logger.warning("Invalid non-numeric Splunk port header ignored")
                     continue
             elif config_key == "splunk_verify_ssl":
                 client_config[config_key] = header_value.lower() == "true"

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -4,6 +4,7 @@ Common utilities for the MCP Splunk server core framework.
 Provides shared utility functions used across tools, resources, and prompts.
 """
 
+import base64
 import logging
 from typing import Any
 
@@ -70,6 +71,17 @@ def extract_client_config_from_headers(headers: dict) -> dict | None:
             else:
                 client_config[config_key] = header_value
 
+    base64_header_mapping = {  # nosec B105 - config key names, not passwords
+        "X-Splunk-Username-Base64": "splunk_username",
+        "X-Splunk-Password-Base64": "splunk_password",
+    }
+    for header_name, config_key in base64_header_mapping.items():
+        header_value = headers.get(header_name) or headers.get(header_name.lower())
+        if header_value:
+            decoded_value = _decode_utf8_base64_header(header_value, header_name)
+            if decoded_value is not None:
+                client_config[config_key] = decoded_value
+
     # Fall back to a standard ``Authorization: Bearer <token>`` header for the
     # Splunk bearer token. We only do this when MCP server-level auth is
     # disabled to avoid mistaking an MCP auth JWT for a Splunk credential.
@@ -79,6 +91,15 @@ def extract_client_config_from_headers(headers: dict) -> dict | None:
             client_config[_splunk_t] = splunk_from_auth_header
 
     return client_config if client_config else None
+
+
+def _decode_utf8_base64_header(value: str, header_name: str) -> str | None:
+    """Decode a UTF-8 credential header without logging the secret value."""
+    try:
+        return base64.b64decode(value, validate=True).decode("utf-8")
+    except (ValueError, UnicodeDecodeError):
+        logger.warning("Invalid base64 credential header ignored: %s", header_name)
+        return None
 
 
 def _mcp_auth_disabled() -> bool:

--- a/tests/test_token_auth.py
+++ b/tests/test_token_auth.py
@@ -7,6 +7,7 @@ extraction utility (`src/core/utils.py`), the enhanced extractor
 `src/core/client_identity.py`.
 """
 
+import base64
 import os
 from unittest.mock import patch
 
@@ -144,6 +145,21 @@ class TestHeaderExtractionForTokens:
             })
 
         assert cfg[_SPLUNK_TOK] == "preferred"
+
+    def test_base64_username_password_headers_are_decoded(self):
+        from src.core.utils import extract_client_config_from_headers
+
+        username = "admin€"
+        password = "€89#$:(^{])[ekj#ad"
+        cfg = extract_client_config_from_headers({
+            "X-Splunk-Host": "splunk.example.com",
+            "X-Splunk-Username-Base64": base64.b64encode(username.encode("utf-8")).decode("ascii"),
+            "X-Splunk-Password-Base64": base64.b64encode(password.encode("utf-8")).decode("ascii"),
+        })
+
+        assert cfg is not None
+        assert cfg["splunk_username"] == username
+        assert cfg["splunk_password"] == password
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Node/fetch requires HTTP header values to be Latin-1 (ByteString). When deslicer-ai sends Splunk basic-auth credentials containing characters outside that range (e.g. `€`), the client must use `X-Splunk-Username-Base64` / `X-Splunk-Password-Base64` instead of the plain headers.

This change adds optional decoding of those Base64 headers in `extract_client_config_from_headers`, so Unicode usernames and passwords work end-to-end with the matching deslicer-ai client change.

**Backward compatible:** plain `X-Splunk-Username` / `X-Splunk-Password` headers continue to work unchanged. Base64 headers are only read when present; invalid Base64 is ignored with a warning (no secret logged).

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor/Chore

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (README or docs/)
- [x] Lint and type checks pass (`uv run ruff check`, `uv run mypy`)

## Related issues

Pairs with deslicer-ai `buildSplunkMcpHeaders` base64 encoding for non-ByteString credentials.

**Rollout note:** deploy this MCP image before or with the DAI client update. ASCII/Latin-1 passwords are unaffected either way; Unicode passwords need both sides.

**Follow-up:** `mcp_itsi/config/headers.py` still reads only plain `X-Splunk-*` headers — ITSI toolset + Unicode basic auth needs a separate small change.

## Test plan

- [x] `uv run pytest tests/test_token_auth.py -q`
- [x] `uv run ruff check src/core/utils.py tests/test_token_auth.py`

Made with [Cursor](https://cursor.com)