### PR TITLE
fix: forward Splunk load balancer cookies

### DIFF
--- a/src/client/splunk_client.py
+++ b/src/client/splunk_client.py
@@ -103,6 +103,33 @@ def _has_basic_auth(splunk_config: dict[str, Any]) -> bool:
     return bool(splunk_config.get("username")) and bool(splunk_config.get("password"))
 
 
+def _enable_cookie_forwarding(service: client.Service) -> None:
+    """Forward cookies captured by splunklib on later REST calls.
+
+    Splunk's SDK stores Set-Cookie values in ``service.http._cookies`` but does
+    not add them to subsequent requests. Load-balanced Splunk management
+    endpoints rely on those cookies for target stickiness after login.
+    """
+
+    http = getattr(service, "http", None)
+    if http is None or not hasattr(http, "request"):
+        return
+
+    original_request = http.request
+
+    def request_with_cookies(url: str, message: dict[str, Any], **kwargs: Any) -> Any:
+        cookies = getattr(http, "_cookies", {}) or {}
+        if cookies:
+            headers = list(message.get("headers") or [])
+            has_cookie_header = any(key.lower() == "cookie" for key, _ in headers)
+            if not has_cookie_header:
+                cookie_header = "; ".join(f"{key}={value}" for key, value in cookies.items())
+                message = {**message, "headers": [*headers, ("Cookie", cookie_header)]}
+        return original_request(url, message, **kwargs)
+
+    http.request = request_with_cookies
+
+
 def get_splunk_service(client_config: dict[str, Any] | None = None) -> client.Service:
     """
     Create and return a Splunk service connection.
@@ -151,6 +178,7 @@ def get_splunk_service(client_config: dict[str, Any] | None = None) -> client.Se
 
     try:
         service = client.connect(**splunk_config)
+        _enable_cookie_forwarding(service)
         logger.info("Successfully connected to Splunk")
         return service
     except Exception as e:

--- a/tests/test_token_auth.py
+++ b/tests/test_token_auth.py
@@ -75,6 +75,37 @@ class TestModularClientTokenAuth:
         assert "password" not in kwargs
         assert "username" not in kwargs
 
+    @patch("src.client.splunk_client.client.connect")
+    def test_get_splunk_service_forwards_lb_cookies_after_basic_auth(self, mock_connect):
+        from src.client.splunk_client import get_splunk_service
+
+        captured_messages = []
+
+        class FakeHttp:
+            def __init__(self):
+                self._cookies = {"AWSALB": "route-a", "AWSALBTG": "target-a"}
+
+            def request(self, url, message, **kwargs):
+                captured_messages.append(message)
+                return {"status": 200, "headers": [], "body": b""}
+
+        class FakeService:
+            def __init__(self):
+                self.http = FakeHttp()
+
+        mock_connect.return_value = FakeService()
+
+        with patch.dict(os.environ, {}, clear=True):
+            service = get_splunk_service({
+                "splunk_host": "splunk.example.com",
+                "splunk_username": "admin",
+                "splunk_password": "password",
+            })
+
+        service.http.request("https://splunk.example.com:8089/services/server/info", {"headers": []})
+
+        assert ("Cookie", "AWSALB=route-a; AWSALBTG=target-a") in captured_messages[0]["headers"]
+
     def test_get_splunk_service_requires_some_credential(self):
         from src.client.splunk_client import get_splunk_service
 


### PR DESCRIPTION
## Summary

Splunk management APIs behind cookie-sticky load balancers (for example AWS ELB) can return intermittent `401` after a successful username/password login when follow-up REST calls do not send the `Set-Cookie` values captured during auth.

`splunklib` stores those cookies in `service.http._cookies` but does not attach them to later requests. This change wraps the Splunk service HTTP client so stored cookies are forwarded on subsequent REST calls, keeping the session pinned to the same backend.

Token-based auth is unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor/Chore

## Checklist

- [x] Tests added/updated (if applicable)
- [ ] Docs updated (README or docs/)
- [x] Lint and type checks pass (`uv run ruff check`, `uv run mypy`)

## Related issues

MSP show Splunk integration behind ELB stickiness.

Made with [Cursor](https://cursor.com)