### PR TITLE
fix: load .env before MCP client config extraction (#169)

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -17,6 +17,7 @@ from contextlib import asynccontextmanager
 from contextvars import ContextVar
 from importlib.metadata import entry_points
 
+from dotenv import load_dotenv
 from fastmcp import Context, FastMCP
 from fastmcp.server.dependencies import get_http_headers, get_http_request
 from fastmcp.server.middleware import Middleware, MiddlewareContext
@@ -40,6 +41,10 @@ if _sentry_enabled:
 project_root = os.path.dirname(os.path.dirname(__file__))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
+
+# Load .env before reading MCP_SPLUNK_* or MCP_LOG_LEVEL from the environment.
+# stdio launches often rely on a cwd .env file rather than client-supplied env vars.
+load_dotenv()
 
 # Create logs directory at project root if it doesn't exist
 log_dir = os.path.join(project_root, "logs")

--- a/tests/test_server_dotenv_loading.py
+++ b/tests/test_server_dotenv_loading.py
@@ -1,0 +1,70 @@
+"""Tests for .env loading before MCP client config extraction."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run_server_env_probe(cwd: Path, extra_env: dict[str, str] | None = None) -> dict[str, str]:
+    """Import server startup path in an isolated subprocess."""
+    env = os.environ.copy()
+    project_root = Path(__file__).resolve().parents[1]
+    env["PYTHONPATH"] = str(project_root)
+    for key in (
+        "MCP_SPLUNK_HOST",
+        "MCP_SPLUNK_TOKEN",
+        "MCP_LOG_LEVEL",
+        "SPLUNK_HOST",
+        "SPLUNK_USERNAME",
+        "SPLUNK_PASSWORD",
+        "SPLUNK_TOKEN",
+    ):
+        env.pop(key, None)
+    if extra_env:
+        env.update(extra_env)
+
+    script = """
+import json
+import os
+from src.server import LOG_LEVEL_NAME, extract_client_config_from_env
+
+print(json.dumps({
+    "log_level": LOG_LEVEL_NAME,
+    "config": extract_client_config_from_env(),
+    "mcp_log_level_env": os.getenv("MCP_LOG_LEVEL"),
+}))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    import json
+
+    return json.loads(result.stdout.strip())
+
+
+def test_load_dotenv_before_extract_client_config(tmp_path: Path):
+    """MCP_SPLUNK_* values from a cwd .env file must be visible at startup."""
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "MCP_SPLUNK_HOST=splunk.example.com",
+                "MCP_SPLUNK_TOKEN=test-bearer-token",
+                "MCP_LOG_LEVEL=WARNING",
+            ]
+        )
+    )
+
+    probe = _run_server_env_probe(tmp_path)
+
+    assert probe["config"] is not None
+    assert probe["config"]["splunk_host"] == "splunk.example.com"
+    assert probe["config"]["splunk_token"] == "test-bearer-token"
+    assert probe["log_level"] == "WARNING"
+    assert probe["mcp_log_level_env"] == "WARNING"


### PR DESCRIPTION
## Summary
- Call `load_dotenv()` at the top of `src/server.py` before `MCP_LOG_LEVEL` and `extract_client_config_from_env()` are read
- Add a subprocess-based regression test that verifies `MCP_SPLUNK_*` values from a cwd `.env` file are visible at startup

Fixes #169

## Test plan
- [x] `uv run pytest tests/test_server_dotenv_loading.py -q`
- [ ] Launch via stdio with only a cwd `.env` file (no client `env` block) and confirm Splunk tools connect