### PR TITLE
fix: add exponential backoff retry for Splunk connections (#189)

### DIFF
--- a/src/client/splunk_client.py
+++ b/src/client/splunk_client.py
@@ -6,6 +6,7 @@ Provides connection utilities for Splunk Enterprise/Cloud instances.
 
 import logging
 import os
+import time
 from typing import Any
 
 from dotenv import load_dotenv
@@ -130,6 +131,59 @@ def _enable_cookie_forwarding(service: client.Service) -> None:
     http.request = request_with_cookies
 
 
+def _get_connect_retry_settings() -> tuple[int, float]:
+    """Return retry count and base delay (seconds) from environment."""
+    retry_count = int(os.getenv("SPLUNK_CONNECT_RETRY_COUNT", "3"))
+    base_delay = float(os.getenv("SPLUNK_CONNECT_RETRY_BASE_DELAY", "2"))
+    return max(retry_count, 1), max(base_delay, 0.0)
+
+
+def _connect_with_retry(splunk_config: dict[str, Any], auth_mode: str) -> client.Service:
+    """Connect to Splunk with exponential backoff for transient failures."""
+    retry_count, base_delay = _get_connect_retry_settings()
+    last_exception: Exception | None = None
+
+    for attempt in range(retry_count):
+        try:
+            if attempt > 0:
+                delay = base_delay * (2 ** (attempt - 1))
+                logger.info(
+                    "Retrying Splunk connection in %.1fs (attempt %d/%d)",
+                    delay,
+                    attempt + 1,
+                    retry_count,
+                )
+                time.sleep(delay)
+
+            service = client.connect(**splunk_config)
+            _enable_cookie_forwarding(service)
+            if attempt > 0:
+                logger.info(
+                    "Successfully connected to Splunk on attempt %d/%d",
+                    attempt + 1,
+                    retry_count,
+                )
+            else:
+                logger.info("Successfully connected to Splunk")
+            return service
+        except Exception as e:
+            last_exception = e
+            logger.warning(
+                "Splunk connection attempt %d/%d failed (%s auth): %s",
+                attempt + 1,
+                retry_count,
+                auth_mode,
+                e,
+            )
+
+    logger.error(
+        "Failed to connect to Splunk after %d attempts: %s",
+        retry_count,
+        last_exception,
+    )
+    raise last_exception  # type: ignore[misc]
+
+
 def get_splunk_service(client_config: dict[str, Any] | None = None) -> client.Service:
     """
     Create and return a Splunk service connection.
@@ -176,14 +230,7 @@ def get_splunk_service(client_config: dict[str, Any] | None = None) -> client.Se
         auth_mode,
     )
 
-    try:
-        service = client.connect(**splunk_config)
-        _enable_cookie_forwarding(service)
-        logger.info("Successfully connected to Splunk")
-        return service
-    except Exception as e:
-        logger.error(f"Failed to connect to Splunk: {str(e)}")
-        raise
+    return _connect_with_retry(splunk_config, auth_mode)
 
 
 def get_splunk_service_safe(client_config: dict[str, Any] | None = None) -> client.Service | None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,11 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+# Keep Splunk connection retries fast in tests — real backoff delays cause CI timeouts
+# when server module init attempts a live connection in degraded mode.
+os.environ.setdefault("SPLUNK_CONNECT_RETRY_COUNT", "1")
+os.environ.setdefault("SPLUNK_CONNECT_RETRY_BASE_DELAY", "0")
+
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 

--- a/tests/test_client_splunk_retry.py
+++ b/tests/test_client_splunk_retry.py
@@ -1,0 +1,71 @@
+"""Tests for Splunk connection retry with exponential backoff."""
+
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+
+from src.client.splunk_client import get_splunk_service
+
+
+class TestSplunkConnectRetry:
+    @patch("src.client.splunk_client.time.sleep")
+    @patch("src.client.splunk_client.client.connect")
+    def test_retries_transient_failures(self, mock_connect, mock_sleep):
+        mock_service = Mock()
+        mock_connect.side_effect = [OSError("Network unreachable"), mock_service]
+
+        with patch.dict(
+            os.environ,
+            {
+                "SPLUNK_USERNAME": "admin",
+                "SPLUNK_PASSWORD": "password",
+                "SPLUNK_CONNECT_RETRY_COUNT": "3",
+                "SPLUNK_CONNECT_RETRY_BASE_DELAY": "2",
+            },
+            clear=True,
+        ):
+            service = get_splunk_service()
+
+        assert service is mock_service
+        assert mock_connect.call_count == 2
+        mock_sleep.assert_called_once_with(2.0)
+
+    @patch("src.client.splunk_client.time.sleep")
+    @patch("src.client.splunk_client.client.connect")
+    def test_raises_after_exhausting_retries(self, mock_connect, mock_sleep):
+        mock_connect.side_effect = OSError("Name or service not known")
+
+        with patch.dict(
+            os.environ,
+            {
+                "SPLUNK_USERNAME": "admin",
+                "SPLUNK_PASSWORD": "password",
+                "SPLUNK_CONNECT_RETRY_COUNT": "2",
+                "SPLUNK_CONNECT_RETRY_BASE_DELAY": "1",
+            },
+            clear=True,
+        ):
+            with pytest.raises(OSError, match="Name or service not known"):
+                get_splunk_service()
+
+        assert mock_connect.call_count == 2
+        mock_sleep.assert_called_once_with(1.0)
+
+    @patch("src.client.splunk_client.client.connect")
+    def test_success_on_first_attempt_skips_sleep(self, mock_connect):
+        mock_service = Mock()
+        mock_connect.return_value = mock_service
+
+        with patch.dict(
+            os.environ,
+            {
+                "SPLUNK_USERNAME": "admin",
+                "SPLUNK_PASSWORD": "password",
+            },
+            clear=True,
+        ):
+            service = get_splunk_service()
+
+        assert service is mock_service
+        mock_connect.assert_called_once()


### PR DESCRIPTION
## Summary
- Add `_connect_with_retry()` to `src/client/splunk_client.py` with exponential backoff for transient DNS/network failures
- Configurable via `SPLUNK_CONNECT_RETRY_COUNT` (default 3) and `SPLUNK_CONNECT_RETRY_BASE_DELAY` (default 2s)
- Add unit tests covering retry success, exhaustion, and first-attempt success

Partially addresses #189 — infrastructure-level DNS/network issues may still need ops fixes, but the server now tolerates transient failures instead of immediately entering degraded mode.

## Test plan
- [x] `uv run pytest tests/test_client_splunk_retry.py tests/test_token_auth.py -q`