### PR TITLE
fix: handle MCP client disconnects without Sentry noise (#188)

### DIFF
--- a/src/core/sentry/context.py
+++ b/src/core/sentry/context.py
@@ -9,6 +9,7 @@ from .config import (
     mcp_request_id,
     mcp_session_id,
 )
+from src.core.session_disconnect import is_session_disconnect_error
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +84,10 @@ def capture_mcp_error(
     Use this to manually capture exceptions with rich MCP metadata.
     """
     if not _sentry_initialized:
+        return
+
+    if is_session_disconnect_error(error):
+        logger.debug("Skipping Sentry capture for client disconnect: %s", error)
         return
 
     try:

--- a/src/core/sentry/context.py
+++ b/src/core/sentry/context.py
@@ -4,12 +4,13 @@ import logging
 from contextlib import contextmanager
 from typing import Any
 
+from src.core.session_disconnect import is_session_disconnect_error
+
 from .config import (
     _sentry_initialized,
     mcp_request_id,
     mcp_session_id,
 )
-from src.core.session_disconnect import is_session_disconnect_error
 
 logger = logging.getLogger(__name__)
 

--- a/src/core/sentry/mcp_middleware.py
+++ b/src/core/sentry/mcp_middleware.py
@@ -7,9 +7,10 @@ from typing import Any
 
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 
+from src.core.session_disconnect import is_session_disconnect_error
+
 from .config import _sentry_initialized
 from .context import add_breadcrumb, set_mcp_context
-from src.core.session_disconnect import is_session_disconnect_error
 
 logger = logging.getLogger(__name__)
 

--- a/src/core/sentry/mcp_middleware.py
+++ b/src/core/sentry/mcp_middleware.py
@@ -9,6 +9,7 @@ from fastmcp.server.middleware import Middleware, MiddlewareContext
 
 from .config import _sentry_initialized
 from .context import add_breadcrumb, set_mcp_context
+from src.core.session_disconnect import is_session_disconnect_error
 
 logger = logging.getLogger(__name__)
 
@@ -74,12 +75,15 @@ class SentryMCPMiddleware(Middleware):
                 except Exception as e:
                     duration_ms = (time.perf_counter() - start_time) * 1000
                     span.set_data("mcp.duration_ms", round(duration_ms, 2))
-                    span.set_data("mcp.status", "error")
-                    span.set_data("mcp.error.type", type(e).__name__)
-                    span.set_data("mcp.error.message", str(e)[:500])
-                    span.set_status("internal_error")
-
-                    sentry_sdk.capture_exception(e)
+                    if is_session_disconnect_error(e):
+                        span.set_data("mcp.status", "client_disconnect")
+                        span.set_status("cancelled")
+                    else:
+                        span.set_data("mcp.status", "error")
+                        span.set_data("mcp.error.type", type(e).__name__)
+                        span.set_data("mcp.error.message", str(e)[:500])
+                        span.set_status("internal_error")
+                        sentry_sdk.capture_exception(e)
                     raise
 
         except ImportError:

--- a/src/core/session_disconnect.py
+++ b/src/core/session_disconnect.py
@@ -1,0 +1,44 @@
+"""Detect client/session disconnect errors from MCP transport layers."""
+
+from __future__ import annotations
+
+_DISCONNECT_EXCEPTION_TYPES: tuple[type[BaseException], ...]
+
+
+def _load_disconnect_exception_types() -> tuple[type[BaseException], ...]:
+    types: list[type[BaseException]] = []
+
+    try:
+        from anyio import BrokenResourceError, ClosedResourceError, EndOfStream
+
+        types.extend([ClosedResourceError, BrokenResourceError, EndOfStream])
+    except ImportError:
+        pass
+
+    try:
+        from starlette.requests import ClientDisconnect
+
+        types.append(ClientDisconnect)
+    except ImportError:
+        pass
+
+    return tuple(types)
+
+
+_DISCONNECT_EXCEPTION_TYPES = _load_disconnect_exception_types()
+
+
+def is_session_disconnect_error(error: BaseException) -> bool:
+    """Return True when the client disconnected before the response completed."""
+    if isinstance(error, _DISCONNECT_EXCEPTION_TYPES):
+        return True
+
+    message = str(error).lower()
+    disconnect_markers = (
+        "closedresourceerror",
+        "brokenresourceerror",
+        "client disconnected",
+        "connection reset",
+        "end of stream",
+    )
+    return any(marker in message for marker in disconnect_markers)

--- a/src/core/session_disconnect_middleware.py
+++ b/src/core/session_disconnect_middleware.py
@@ -1,0 +1,33 @@
+"""Middleware for graceful handling of MCP client disconnects."""
+
+from __future__ import annotations
+
+import logging
+
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+
+from src.core.session_disconnect import is_session_disconnect_error
+
+logger = logging.getLogger(__name__)
+
+
+class SessionDisconnectMiddleware(Middleware):
+    """Log client disconnects at warning level instead of treating them as server errors."""
+
+    async def on_request(self, context: MiddlewareContext, call_next):
+        method = getattr(context, "method", "unknown")
+        session_id = getattr(context, "session_id", None)
+
+        try:
+            return await call_next(context)
+        except Exception as error:
+            if not is_session_disconnect_error(error):
+                raise
+
+            logger.warning(
+                "Client disconnected during MCP %s (session_id=%s): %s",
+                method,
+                session_id,
+                error,
+            )
+            raise

--- a/src/server.py
+++ b/src/server.py
@@ -29,6 +29,7 @@ from starlette.responses import JSONResponse
 from src.core.base import SplunkContext
 from src.core.loader import ComponentLoader
 from src.core.sentry import init_sentry
+from src.core.session_disconnect_middleware import SessionDisconnectMiddleware
 from src.core.shared_context import http_headers_context
 from src.core.utils import extract_client_config_from_headers
 from src.routes import setup_health_routes
@@ -802,6 +803,7 @@ class ClientConfigMiddleware(Middleware):
 
 # Add the middleware to the server
 mcp.add_middleware(ClientConfigMiddleware())
+mcp.add_middleware(SessionDisconnectMiddleware())
 
 # Add Sentry MCP middleware if enabled
 if _sentry_enabled:

--- a/tests/test_session_disconnect.py
+++ b/tests/test_session_disconnect.py
@@ -1,0 +1,48 @@
+"""Tests for client/session disconnect detection and middleware."""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from src.core.session_disconnect import is_session_disconnect_error
+from src.core.session_disconnect_middleware import SessionDisconnectMiddleware
+
+
+class TestSessionDisconnectDetection:
+    def test_detects_anyio_closed_resource_error(self):
+        from anyio import ClosedResourceError
+
+        assert is_session_disconnect_error(ClosedResourceError())
+
+    def test_detects_starlette_client_disconnect(self):
+        from starlette.requests import ClientDisconnect
+
+        assert is_session_disconnect_error(ClientDisconnect())
+
+    def test_ignores_unrelated_errors(self):
+        assert not is_session_disconnect_error(RuntimeError("something else"))
+
+
+class TestSessionDisconnectMiddleware:
+    @pytest.mark.asyncio
+    async def test_logs_and_reraises_disconnect_errors(self, caplog):
+        from anyio import ClosedResourceError
+
+        middleware = SessionDisconnectMiddleware()
+        context = Mock(method="tools/call", session_id="sess-1")
+        call_next = AsyncMock(side_effect=ClosedResourceError())
+
+        with caplog.at_level("WARNING"):
+            with pytest.raises(ClosedResourceError):
+                await middleware.on_request(context, call_next)
+
+        assert any("Client disconnected" in record.message for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_passes_through_other_errors(self):
+        middleware = SessionDisconnectMiddleware()
+        context = Mock(method="tools/call", session_id="sess-1")
+        call_next = AsyncMock(side_effect=ValueError("bad input"))
+
+        with pytest.raises(ValueError, match="bad input"):
+            await middleware.on_request(context, call_next)


### PR DESCRIPTION
## Summary
- Add `SessionDisconnectMiddleware` to log `ClosedResourceError`, `BrokenResourceError`, and `ClientDisconnect` at warning level
- Skip Sentry capture for client disconnect errors in `SentryMCPMiddleware` and `capture_mcp_error()`
- Add unit tests for disconnect detection and middleware behavior

Fixes #188

## Test plan
- [x] `uv run pytest tests/test_session_disconnect.py -q`
- [ ] Confirm Sentry no longer receives events for client timeout/disconnect scenarios