### PR TITLE
feat(observability): optional OpenTelemetry tracing support

### DIFF
--- a/docs/guides/monitoring.md
+++ b/docs/guides/monitoring.md
@@ -39,6 +39,12 @@ This guide outlines monitoring and observability practices for the MCP Server fo
 - Alert on sustained error rates, timeouts, or connection failures
 - Alert on high latency (e.g., P95 > 5s) and resource saturation
 
+## Distributed Tracing
+
+- Enable OpenTelemetry tracing to join end-to-end traces in any OTel-compatible backend
+- See the [OpenTelemetry Tracing guide](otel-tracing.md) for setup
+- Errors and performance can also be tracked with [Sentry](sentry-monitoring.md)
+
 ## References
 
 - Deployment: `docs/guides/deployment/`

--- a/docs/guides/otel-tracing.md
+++ b/docs/guides/otel-tracing.md
@@ -1,0 +1,86 @@
+# OpenTelemetry Tracing for MCP Server
+
+This guide explains how to enable OpenTelemetry (OTel) distributed tracing so the MCP Server for Splunk participates in end-to-end traces. When enabled, the server exports spans to any OpenTelemetry-compatible backend (Jaeger, Tempo, Grafana, Splunk Observability, etc.), continues an incoming W3C trace (`traceparent`), and emits child spans for outbound HTTP calls.
+
+> **🔧 OTel is Optional**: The MCP server runs normally without it. Tracing activates **only** when the `[otel]` extra is installed *and* `OTEL_EXPORTER_OTLP_ENDPOINT` is set. Otherwise there is zero overhead.
+
+## 🚀 Quick Start
+
+### 1. Install the OTel extra
+
+```bash
+pip install mcp-server-for-splunk[otel]
+```
+
+This pulls in the OTel SDK, the OTLP/HTTP exporter, and the Starlette, httpx, and logging instrumentations.
+
+### 2. Configure environment
+
+Add to your `.env` file:
+
+```bash
+# Required: enables tracing when set
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+
+# Recommended (defaults shown)
+OTEL_SERVICE_NAME=splunk-mcp
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+OTEL_TRACES_SAMPLER=parentbased_always_on
+DEPLOYMENT_ENVIRONMENT=development
+```
+
+### 3. Start the server
+
+```bash
+uv run python src/server.py
+```
+
+You'll see in the logs:
+
+```
+INFO - OpenTelemetry initialized (service=splunk-mcp, env=development, endpoint=http://otel-collector:4318)
+INFO - OpenTelemetry tracing and JSON logging enabled
+INFO - OpenTelemetry tool span middleware added
+INFO - Starlette OTel instrumentation enabled
+INFO - httpx OTel instrumentation enabled
+```
+
+## 🔧 What gets traced
+
+| Span | Source | Notes |
+|------|--------|-------|
+| HTTP server span | Starlette instrumentation | Extracts the W3C `traceparent` on `/mcp`, continuing the upstream trace |
+| `mcp.tool.{name}` | `OtelToolSpanMiddleware` | One span per tool call, carrying the `mcp.tool.name` attribute |
+| httpx client spans | httpx instrumentation | Child spans for outbound REST calls |
+
+> **Note on Splunk REST:** the Splunk SDK (`splunklib`) uses `urllib`, not `httpx`, so its calls are not captured by the httpx instrumentation. httpx child spans appear for other outbound HTTP traffic. Native `splunklib` span capture is tracked separately.
+
+## 📋 Configuration reference
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | _(unset)_ | OTLP/HTTP collector base URL. **Enables tracing when set.** |
+| `OTEL_SERVICE_NAME` | `splunk-mcp` | Stable service name reported to your tracing backend |
+| `OTEL_SERVICE_VERSION` | package version | `service.version` resource attribute |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/protobuf` | OTLP wire protocol |
+| `OTEL_TRACES_SAMPLER` | `parentbased_always_on` | Honors the upstream sampling decision |
+| `OTEL_TRACES_SAMPLER_ARG` | `1.0` | Ratio when using a `traceidratio` sampler |
+| `DEPLOYMENT_ENVIRONMENT` | `development` | `deployment.environment` resource attribute (commonly used to filter traces by environment) |
+
+The OTLP/HTTP exporter reads standard OTel environment variables (`OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, etc.) directly.
+
+## 🔗 Logs ↔ traces
+
+When tracing is enabled, log records are reformatted as single-line JSON carrying `otelTraceID`, `otelSpanID`, and `otelServiceName`, so logs and traces share the same identifiers in your backend:
+
+```json
+{"timestamp": "2026-06-23T17:07:46.645Z", "level": "INFO", "logger": "src.server", "message": "...", "otelTraceID": "9b...", "otelSpanID": "1a...", "otelServiceName": "splunk-mcp"}
+```
+
+## 🔒 Security
+
+Credential values are denied from spans and logs: `Authorization`, `X-Splunk-Token`, `X-Splunk-Password`, and generic `token` / `password` / `api_key` / `secret` patterns are masked as `***`. Tool arguments are never attached to spans.
+
+## 🔭 Distributed tracing conventions
+
+For consistent end-to-end traces across services, the defaults follow common OTel conventions: W3C context propagation, `parentbased_always_on` sampling (so a service honors the caller's sampling decision), a stable service name, and a `deployment.environment` resource attribute. Override any of these via the standard `OTEL_*` environment variables to match your own topology.

--- a/env.example
+++ b/env.example
@@ -84,3 +84,15 @@ SENTRY_PROFILES_SAMPLE_RATE=0.1
 SENTRY_DEBUG=false
 SENTRY_ENABLE_LOGS=true
 SENTRY_SEND_PII=true
+
+# OpenTelemetry distributed tracing (optional)
+# Install with: pip install mcp-server-for-splunk[otel]
+# Tracing activates ONLY when OTEL_EXPORTER_OTLP_ENDPOINT is set. When enabled,
+# this service exports OTLP spans to your backend, continues an incoming W3C
+# trace (traceparent), and emits JSON logs carrying trace IDs.
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+OTEL_SERVICE_NAME=splunk-mcp
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+OTEL_TRACES_SAMPLER=parentbased_always_on
+# deployment.environment is commonly used to filter traces by environment.
+DEPLOYMENT_ENVIRONMENT=development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,16 @@ docs = [
 sentry = [
 "sentry-sdk[mcp,starlette,httpx,asyncio]>=2.61.1",
 ]
+# Optional OpenTelemetry distributed tracing.
+# Enabled at runtime only when OTEL_EXPORTER_OTLP_ENDPOINT is set.
+otel = [
+"opentelemetry-api>=1.41.1",
+"opentelemetry-sdk>=1.41.1",
+"opentelemetry-exporter-otlp-proto-http>=1.41.1",
+"opentelemetry-instrumentation-starlette>=0.62b0",
+"opentelemetry-instrumentation-httpx>=0.62b0",
+"opentelemetry-instrumentation-logging>=0.62b0",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/src/core/otel/__init__.py
+++ b/src/core/otel/__init__.py
@@ -1,0 +1,31 @@
+"""OpenTelemetry distributed tracing for MCP Server for Splunk.
+
+Optional module - works without the OTel SDK installed. Install with:
+``pip install mcp-server-for-splunk[otel]`` and set
+``OTEL_EXPORTER_OTLP_ENDPOINT`` to activate. Exports OTLP spans to any
+OpenTelemetry-compatible backend; the default service name is ``splunk-mcp``.
+"""
+
+from .bootstrap import (
+    init_otel,
+    instrument_httpx,
+    instrument_starlette,
+)
+from .config import OtelSettings, is_otel_enabled
+from .logging import OtelJsonFormatter, redact_sensitive
+from .mcp_middleware import OtelToolSpanMiddleware
+
+__all__ = [
+    # Config
+    "OtelSettings",
+    "is_otel_enabled",
+    # Bootstrap
+    "init_otel",
+    "instrument_starlette",
+    "instrument_httpx",
+    # Logging
+    "OtelJsonFormatter",
+    "redact_sensitive",
+    # Middleware
+    "OtelToolSpanMiddleware",
+]

--- a/src/core/otel/bootstrap.py
+++ b/src/core/otel/bootstrap.py
@@ -1,0 +1,195 @@
+"""OpenTelemetry bootstrap: provider setup + instrumentation entry points.
+
+Public API (referenced from ``src/server.py``):
+
+* :func:`init_otel` — build a ``TracerProvider`` (resource + sampler + OTLP
+  ``BatchSpanProcessor``) from the environment and register it globally.
+* :func:`instrument_starlette` — wrap the ASGI app so incoming requests extract
+  the W3C ``traceparent`` and emit a server span.
+* :func:`instrument_httpx` — emit client child spans for outbound HTTP calls.
+
+Everything is import-safe and a no-op unless the ``[otel]`` extra is installed
+and ``OTEL_EXPORTER_OTLP_ENDPOINT`` is set.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from .config import OtelSettings, _otel_sdk_available
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from opentelemetry.sdk.trace import TracerProvider
+
+logger = logging.getLogger(__name__)
+
+
+class _BootstrapState:
+    """Holds the bootstrap provider + idempotency guard for this module."""
+
+    def __init__(self) -> None:
+        self.initialized = False
+        self.provider: Any | None = None
+
+    def reset(self) -> None:
+        self.initialized = False
+        self.provider = None
+
+
+_state = _BootstrapState()
+
+
+def _reset_for_tests() -> None:
+    """Reset module state so the bootstrap can run again (tests only)."""
+    _state.reset()
+
+
+def init_otel(
+    settings: OtelSettings | None = None,
+    *,
+    span_exporter: Any | None = None,
+) -> TracerProvider | None:
+    """Initialize the global tracer provider. Returns the provider or ``None``.
+
+    Returns ``None`` (and registers nothing) when the SDK is missing, no
+    endpoint is configured, or no span processor could be attached — so callers
+    can treat a non-``None`` result as "tracing is actually exporting".
+
+    Args:
+        settings: Pre-resolved settings; defaults to :meth:`OtelSettings.from_env`.
+        span_exporter: Optional exporter override (tests inject an in-memory one).
+    """
+    if _state.initialized:
+        return _state.provider
+
+    if not _otel_sdk_available:
+        logger.info("opentelemetry SDK not installed; tracing disabled")
+        return None
+
+    settings = settings or OtelSettings.from_env()
+    if not settings.enabled:
+        logger.info("OTEL_EXPORTER_OTLP_ENDPOINT not set; tracing disabled")
+        return None
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
+
+        resource = Resource.create(
+            {
+                "service.name": settings.service_name,
+                "service.version": settings.service_version,
+                "deployment.environment": settings.deployment_environment,
+            }
+        )
+
+        provider = TracerProvider(resource=resource, sampler=_build_sampler(settings.sampler))
+
+        if span_exporter is not None:
+            provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+        else:
+            exporter = _build_otlp_exporter()
+            if exporter is None:
+                logger.error(
+                    "OTLP exporter unavailable; OpenTelemetry not enabled "
+                    "(no span processor registered, nothing would be exported)"
+                )
+                return None
+            provider.add_span_processor(BatchSpanProcessor(exporter))
+
+        trace.set_tracer_provider(provider)
+        _instrument_logging()
+
+        _state.provider = provider
+        _state.initialized = True
+        logger.info(
+            "OpenTelemetry initialized (service=%s, env=%s, endpoint=%s)",
+            settings.service_name,
+            settings.deployment_environment,
+            settings.endpoint,
+        )
+        return provider
+
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Failed to initialize OpenTelemetry: %s", exc)
+        return None
+
+
+def _build_sampler(sampler_name: str) -> Any:
+    """Map the configured sampler name to an SDK sampler (default AlwaysOn root)."""
+    from opentelemetry.sdk.trace.sampling import (
+        ALWAYS_OFF,
+        ALWAYS_ON,
+        ParentBased,
+        TraceIdRatioBased,
+    )
+
+    name = (sampler_name or "").lower()
+    if name == "parentbased_always_on":
+        return ParentBased(ALWAYS_ON)
+    if name == "parentbased_always_off":
+        return ParentBased(ALWAYS_OFF)
+    if name == "always_on":
+        return ALWAYS_ON
+    if name == "always_off":
+        return ALWAYS_OFF
+    if name.startswith("parentbased_traceidratio") or name == "traceidratio":
+        import os
+
+        try:
+            ratio = float(os.getenv("OTEL_TRACES_SAMPLER_ARG", "1.0"))
+        except ValueError:
+            ratio = 1.0
+        base = TraceIdRatioBased(ratio)
+        return ParentBased(base) if name.startswith("parentbased") else base
+    return ParentBased(ALWAYS_ON)
+
+
+def _build_otlp_exporter() -> Any | None:
+    """Create the OTLP/HTTP span exporter (reads endpoint/headers from env)."""
+    try:
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+        return OTLPSpanExporter()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("OTLP exporter unavailable: %s", exc)
+        return None
+
+
+def _instrument_logging() -> None:
+    """Inject otelTraceID/otelSpanID onto log records (formatter renders them)."""
+    try:
+        from opentelemetry.instrumentation.logging import LoggingInstrumentor
+
+        LoggingInstrumentor().instrument(set_logging_format=False)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Logging instrumentation unavailable: %s", exc)
+
+
+def instrument_starlette(app: Any) -> None:
+    """Instrument a Starlette app to extract W3C context and emit server spans."""
+    if not _otel_sdk_available:
+        return
+    try:
+        from opentelemetry.instrumentation.starlette import StarletteInstrumentor
+
+        StarletteInstrumentor.instrument_app(app)
+        logger.info("Starlette OTel instrumentation enabled")
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Failed to instrument Starlette for OTel: %s", exc)
+
+
+def instrument_httpx() -> None:
+    """Instrument httpx so outbound REST calls become client child spans."""
+    if not _otel_sdk_available:
+        return
+    try:
+        from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+
+        HTTPXClientInstrumentor().instrument()
+        logger.info("httpx OTel instrumentation enabled")
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Failed to instrument httpx for OTel: %s", exc)

--- a/src/core/otel/config.py
+++ b/src/core/otel/config.py
@@ -1,0 +1,85 @@
+"""OpenTelemetry configuration resolved from environment variables.
+
+Vendor-neutral defaults: a stable service name (``splunk-mcp`` by default),
+W3C context propagation, a ``parentbased_always_on`` sampler, and a
+``deployment.environment`` resource attribute. The integration only activates
+when ``OTEL_EXPORTER_OTLP_ENDPOINT`` is set, keeping OTel fully optional.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# OTel API ships transitively; the SDK + exporters arrive via the [otel] extra.
+# Import a concrete SDK symbol so this acts as a real availability probe.
+try:
+    from opentelemetry.sdk.trace import TracerProvider as _SdkTracerProvider
+
+    _otel_sdk_available = _SdkTracerProvider is not None
+except ImportError:
+    _otel_sdk_available = False
+
+
+DEFAULT_SERVICE_NAME = "splunk-mcp"
+DEFAULT_PROTOCOL = "http/protobuf"
+DEFAULT_ENDPOINT = "http://otel-collector:4318"
+DEFAULT_SAMPLER = "parentbased_always_on"
+
+
+@dataclass(frozen=True)
+class OtelSettings:
+    """Immutable snapshot of the OTel environment configuration."""
+
+    endpoint: str | None
+    service_name: str
+    service_version: str
+    protocol: str
+    sampler: str
+    deployment_environment: str
+
+    @property
+    def enabled(self) -> bool:
+        """OTel is enabled only when an OTLP endpoint is configured."""
+        return bool(self.endpoint)
+
+    @classmethod
+    def from_env(cls) -> OtelSettings:
+        """Build settings from the process environment."""
+        endpoint = (os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT") or "").strip() or None
+        deployment_environment = (
+            os.getenv("DEPLOYMENT_ENVIRONMENT")
+            or os.getenv("DEPLOYMENT_ENV")
+            or os.getenv("SENTRY_ENVIRONMENT")
+            or "development"
+        ).strip()
+        return cls(
+            endpoint=endpoint,
+            service_name=(os.getenv("OTEL_SERVICE_NAME") or DEFAULT_SERVICE_NAME).strip(),
+            service_version=(
+                os.getenv("OTEL_SERVICE_VERSION") or _resolve_service_version()
+            ).strip(),
+            protocol=(os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL") or DEFAULT_PROTOCOL).strip(),
+            sampler=(os.getenv("OTEL_TRACES_SAMPLER") or DEFAULT_SAMPLER).strip(),
+            deployment_environment=deployment_environment,
+        )
+
+
+def _resolve_service_version() -> str:
+    """Best-effort package version for the ``service.version`` resource attr."""
+    try:
+        from importlib.metadata import version
+
+        return version("mcp-server-for-splunk")
+    except Exception:
+        return "0.0.0"
+
+
+def is_otel_enabled() -> bool:
+    """Return True when the SDK is installed and an OTLP endpoint is configured."""
+    if not _otel_sdk_available:
+        return False
+    return OtelSettings.from_env().enabled

--- a/src/core/otel/logging.py
+++ b/src/core/otel/logging.py
@@ -1,0 +1,143 @@
+"""Structured JSON logging that correlates logs with traces.
+
+The OTel logging instrumentation injects ``otelTraceID`` / ``otelSpanID`` /
+``otelServiceName`` onto every :class:`logging.LogRecord` while a span is
+active. This formatter renders records as JSON carrying those fields so logs can
+be correlated with traces, and applies a credential deny-list
+(Authorization / X-Splunk-Token / X-Splunk-Password / keys) to both the message
+and any structured ``extra`` fields.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import datetime, timezone
+
+# Header / field names whose values must never be logged in clear text.
+_SENSITIVE_KEYS = (
+    "authorization",
+    "x-splunk-token",
+    "x-splunk-password",
+    "splunk_password",
+    "splunk_token",
+    "password",
+    "token",
+    "api_key",
+    "apikey",
+    "secret",
+)
+
+# Matches `key: value`, `key=value`, and `"key": "value"` shapes, capturing the
+# separator so we can preserve formatting while masking the value.
+_SENSITIVE_PATTERN = re.compile(
+    r"(?i)(?P<key>" + "|".join(re.escape(k) for k in _SENSITIVE_KEYS) + r")"
+    r"(?P<sep>\"?\s*[:=]\s*\"?)"
+    r"(?:bearer\s+)?(?P<val>[^\s,;\"']+)"
+)
+
+# Standard LogRecord attributes we never want to duplicate as JSON "extra".
+_RESERVED_RECORD_ATTRS = frozenset(
+    {
+        "args",
+        "asctime",
+        "created",
+        "exc_info",
+        "exc_text",
+        "filename",
+        "funcName",
+        "levelname",
+        "levelno",
+        "lineno",
+        "module",
+        "msecs",
+        "message",
+        "msg",
+        "name",
+        "pathname",
+        "process",
+        "processName",
+        "relativeCreated",
+        "stack_info",
+        "taskName",
+        "thread",
+        "threadName",
+        "otelTraceID",
+        "otelSpanID",
+        "otelServiceName",
+        "otelTraceSampled",
+    }
+)
+
+
+def redact_sensitive(text: str) -> str:
+    """Mask values of deny-listed credential keys inside a free-form string."""
+    if not text:
+        return text
+
+    def _mask(match: re.Match[str]) -> str:
+        return f"{match.group('key')}{match.group('sep')}***"
+
+    return _SENSITIVE_PATTERN.sub(_mask, text)
+
+
+def is_sensitive_key(key: str) -> bool:
+    """True when a log/extra field name matches a deny-listed credential key."""
+    lowered = key.lower()
+    return any(sensitive in lowered for sensitive in _SENSITIVE_KEYS)
+
+
+class OtelJsonFormatter(logging.Formatter):
+    """Render log records as single-line JSON with trace correlation fields."""
+
+    def __init__(self, include_extra: bool = True) -> None:
+        super().__init__()
+        self._include_extra = include_extra
+
+    def format(self, record: logging.LogRecord) -> str:
+        message = redact_sensitive(record.getMessage())
+
+        payload: dict[str, object] = {
+            "timestamp": _iso_timestamp(record.created),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": message,
+            "otelTraceID": getattr(record, "otelTraceID", "0"),
+            "otelSpanID": getattr(record, "otelSpanID", "0"),
+            "otelServiceName": getattr(record, "otelServiceName", ""),
+        }
+
+        session = getattr(record, "session", None)
+        if session and session != "-":
+            payload["session"] = session
+
+        if record.exc_info:
+            payload["exception"] = redact_sensitive(self.formatException(record.exc_info))
+
+        if self._include_extra:
+            for key, value in record.__dict__.items():
+                if key in _RESERVED_RECORD_ATTRS or key in payload or key == "session":
+                    continue
+                if key.startswith("_"):
+                    continue
+                payload[key] = _coerce(key, value)
+
+        return json.dumps(payload, default=str, ensure_ascii=False)
+
+
+def _iso_timestamp(created: float) -> str:
+    """UTC ISO-8601 timestamp with millisecond precision and trailing ``Z``."""
+    dt = datetime.fromtimestamp(created, tz=timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
+
+
+def _coerce(key: str, value: object) -> object:
+    """Make an extra JSON-serializable; fully mask deny-listed keys, redact strings."""
+    if is_sensitive_key(key):
+        return "***"
+    if isinstance(value, str):
+        return redact_sensitive(value)
+    if isinstance(value, (int, float, bool)) or value is None:
+        return value
+    return redact_sensitive(str(value))

--- a/src/core/otel/mcp_middleware.py
+++ b/src/core/otel/mcp_middleware.py
@@ -1,0 +1,74 @@
+"""FastMCP middleware that emits a span per tool call.
+
+Creates a ``mcp.tool.{name}`` span (attribute ``mcp.tool.name``) as a child of
+the ambient HTTP server span produced by the Starlette instrumentation, so each
+tool's latency is visible in any OTel backend. Tool arguments are intentionally
+NOT attached to spans to honor the credential deny-list.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+
+logger = logging.getLogger(__name__)
+
+_TRACER_NAME = "mcp-for-splunk"
+
+
+class OtelToolSpanMiddleware(Middleware):
+    """Wrap ``tools/call`` invocations in an OpenTelemetry span."""
+
+    def __init__(self, tracer_provider: Any | None = None) -> None:
+        super().__init__()
+        self._tracer_provider = tracer_provider
+        logger.info("OtelToolSpanMiddleware initialized")
+
+    def _get_tracer(self) -> Any:
+        from opentelemetry import trace
+
+        if self._tracer_provider is not None:
+            return self._tracer_provider.get_tracer(_TRACER_NAME)
+        return trace.get_tracer(_TRACER_NAME)
+
+    async def on_request(self, context: MiddlewareContext, call_next):
+        """Create a tool span for ``tools/call``; pass through other methods."""
+        method = getattr(context, "method", None)
+        if method != "tools/call":
+            return await call_next(context)
+
+        tool_name = self._tool_name(context)
+        session_id = getattr(context, "session_id", None)
+
+        try:
+            from opentelemetry.trace import SpanKind, Status, StatusCode
+        except ImportError:
+            return await call_next(context)
+
+        tracer = self._get_tracer()
+        with tracer.start_as_current_span(
+            f"mcp.tool.{tool_name}", kind=SpanKind.INTERNAL
+        ) as span:
+            span.set_attribute("mcp.tool.name", tool_name)
+            if session_id:
+                span.set_attribute("mcp.session.id", str(session_id))
+
+            try:
+                result = await call_next(context)
+                span.set_status(Status(StatusCode.OK))
+                return result
+            except Exception as exc:
+                span.record_exception(exc)
+                span.set_status(Status(StatusCode.ERROR, str(exc)[:200]))
+                raise
+
+    @staticmethod
+    def _tool_name(context: MiddlewareContext) -> str:
+        params = getattr(context, "params", None)
+        if isinstance(params, dict):
+            name = params.get("name")
+            if name:
+                return str(name)
+        return "unknown"

--- a/src/core/otel/mcp_middleware.py
+++ b/src/core/otel/mcp_middleware.py
@@ -9,11 +9,17 @@ NOT attached to spans to honor the credential deny-list.
 from __future__ import annotations
 
 import logging
+import traceback
 from typing import Any
 
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 
+from .logging import redact_sensitive
+
 logger = logging.getLogger(__name__)
+
+_MAX_EXC_MESSAGE = 500
+_MAX_EXC_STACKTRACE = 8000
 
 _TRACER_NAME = "mcp-for-splunk"
 
@@ -48,8 +54,14 @@ class OtelToolSpanMiddleware(Middleware):
             return await call_next(context)
 
         tracer = self._get_tracer()
+        # Disable the SDK's automatic exception recording: it would attach the
+        # raw, unredacted message + stacktrace on context-manager exit. We record
+        # a credential-masked exception event ourselves instead.
         with tracer.start_as_current_span(
-            f"mcp.tool.{tool_name}", kind=SpanKind.INTERNAL
+            f"mcp.tool.{tool_name}",
+            kind=SpanKind.INTERNAL,
+            record_exception=False,
+            set_status_on_exception=False,
         ) as span:
             span.set_attribute("mcp.tool.name", tool_name)
             if session_id:
@@ -60,8 +72,10 @@ class OtelToolSpanMiddleware(Middleware):
                 span.set_status(Status(StatusCode.OK))
                 return result
             except Exception as exc:
-                span.record_exception(exc)
-                span.set_status(Status(StatusCode.ERROR, str(exc)[:200]))
+                _record_redacted_exception(span, exc)
+                span.set_status(
+                    Status(StatusCode.ERROR, redact_sensitive(str(exc))[:200])
+                )
                 raise
 
     @staticmethod
@@ -72,3 +86,22 @@ class OtelToolSpanMiddleware(Middleware):
             if name:
                 return str(name)
         return "unknown"
+
+
+def _record_redacted_exception(span: Any, exc: BaseException) -> None:
+    """Record an exception event on the span with credentials masked.
+
+    Mirrors the JSON-log credential deny-list so exception messages and stack
+    traces exported to the OTLP backend cannot leak tokens/passwords. We emit a
+    sanitized ``exception`` event instead of ``span.record_exception`` (which
+    would attach the raw message + traceback verbatim).
+    """
+    stacktrace = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    span.add_event(
+        "exception",
+        attributes={
+            "exception.type": type(exc).__qualname__,
+            "exception.message": redact_sensitive(str(exc))[:_MAX_EXC_MESSAGE],
+            "exception.stacktrace": redact_sensitive(stacktrace)[:_MAX_EXC_STACKTRACE],
+        },
+    )

--- a/src/server.py
+++ b/src/server.py
@@ -27,6 +27,14 @@ from starlette.responses import JSONResponse
 
 from src.core.base import SplunkContext
 from src.core.loader import ComponentLoader
+from src.core.otel import (
+    OtelJsonFormatter,
+    OtelToolSpanMiddleware,
+    init_otel,
+    instrument_httpx,
+    instrument_starlette,
+    is_otel_enabled,
+)
 from src.core.sentry import init_sentry
 from src.core.shared_context import http_headers_context
 from src.core.utils import extract_client_config_from_headers
@@ -106,6 +114,32 @@ def _record_factory(*args, **kwargs):
 
 
 logging.setLogRecordFactory(_record_factory)
+
+
+# ------------------------------
+# OpenTelemetry (optional distributed tracing)
+# ------------------------------
+# Activates only when the [otel] extra is installed and
+# OTEL_EXPORTER_OTLP_ENDPOINT is set. When enabled, log records gain trace IDs
+# and are re-formatted as JSON so logs can be correlated with traces.
+# _otel_enabled reflects a *successful* init_otel(), so downstream middleware
+# and instrumentation never run against a half-initialized provider.
+_otel_enabled = False
+if is_otel_enabled():
+    try:
+        if init_otel() is not None:
+            _otel_enabled = True
+            _json_formatter = OtelJsonFormatter()
+            for _handler in logging.getLogger().handlers:
+                _handler.setFormatter(_json_formatter)
+            logger.info("OpenTelemetry tracing and JSON logging enabled")
+        else:
+            logger.warning(
+                "OTEL_EXPORTER_OTLP_ENDPOINT is set but OpenTelemetry "
+                "initialization failed; tracing disabled"
+            )
+    except Exception as _otel_err:  # nosec B110 - tracing is best-effort
+        logger.warning("OpenTelemetry setup failed: %s", _otel_err)
 
 
 # ------------------------------
@@ -806,6 +840,14 @@ if _sentry_enabled:
     except Exception as e:
         logger.warning("Failed to add Sentry MCP middleware: %s", e)
 
+# Add OpenTelemetry per-tool span middleware if enabled
+if _otel_enabled:
+    try:
+        mcp.add_middleware(OtelToolSpanMiddleware())
+        logger.info("OpenTelemetry tool span middleware added")
+    except Exception as e:
+        logger.warning("Failed to add OpenTelemetry MCP middleware: %s", e)
+
 
 # Health check endpoint for Docker using custom route (recommended pattern)
 @mcp.custom_route("/health", methods=["GET"])
@@ -1161,6 +1203,15 @@ def create_root_app(server: FastMCP) -> Starlette:
     # Parent Starlette application that applies middleware to the initial HTTP handshake
     root_app = Starlette(lifespan=mcp_app.lifespan)
     root_app.add_middleware(HeaderCaptureMiddleware)
+
+    # Instrument the app for OpenTelemetry: extract the W3C traceparent on
+    # incoming requests (server spans) and emit httpx client child spans.
+    if _otel_enabled:
+        try:
+            instrument_starlette(root_app)
+            instrument_httpx()
+        except Exception as _otel_err:
+            logger.warning("Failed to apply OpenTelemetry instrumentation: %s", _otel_err)
 
     # Add Sentry HTTP middleware if enabled (must be added after HeaderCaptureMiddleware)
     if _sentry_enabled:

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -1,0 +1,259 @@
+"""Tests for the optional OpenTelemetry tracing integration.
+
+The integration is import-safe (works without the SDK) and only activates
+at runtime when ``OTEL_EXPORTER_OTLP_ENDPOINT`` is set. These tests cover the
+configuration parsing, the JSON log formatter (logs<->traces correlation +
+credential deny-list), the bootstrap lifecycle, and the per-tool span
+middleware that emits ``mcp.tool.{name}`` spans.
+"""
+
+import json
+import logging
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+class TestOtelSettings:
+    def test_disabled_when_endpoint_missing(self, monkeypatch):
+        from src.core.otel.config import OtelSettings, is_otel_enabled
+
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+        settings = OtelSettings.from_env()
+
+        assert settings.endpoint is None
+        assert settings.enabled is False
+        assert is_otel_enabled() is False
+
+    def test_enabled_when_endpoint_set(self, monkeypatch):
+        from src.core.otel.config import OtelSettings, _otel_sdk_available, is_otel_enabled
+
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector:4318")
+        settings = OtelSettings.from_env()
+
+        assert settings.endpoint == "http://otel-collector:4318"
+        assert settings.enabled is True
+        # is_otel_enabled() additionally requires the optional [otel] SDK extra,
+        # so it is only True when the SDK is actually installed.
+        assert is_otel_enabled() is _otel_sdk_available
+
+    def test_defaults_mirror_contract(self, monkeypatch):
+        from src.core.otel.config import OtelSettings
+
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector:4318")
+        monkeypatch.delenv("OTEL_SERVICE_NAME", raising=False)
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_PROTOCOL", raising=False)
+        monkeypatch.delenv("OTEL_TRACES_SAMPLER", raising=False)
+        settings = OtelSettings.from_env()
+
+        assert settings.service_name == "splunk-mcp"
+        assert settings.protocol == "http/protobuf"
+        assert settings.sampler == "parentbased_always_on"
+
+    def test_env_overrides_defaults(self, monkeypatch):
+        from src.core.otel.config import OtelSettings
+
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318")
+        monkeypatch.setenv("OTEL_SERVICE_NAME", "custom-mcp")
+        monkeypatch.setenv("DEPLOYMENT_ENVIRONMENT", "staging")
+        settings = OtelSettings.from_env()
+
+        assert settings.service_name == "custom-mcp"
+        assert settings.deployment_environment == "staging"
+
+
+# ---------------------------------------------------------------------------
+# JSON logging (logs <-> traces correlation + credential deny-list)
+# ---------------------------------------------------------------------------
+class TestOtelJsonFormatter:
+    def _record(self, msg: str) -> logging.LogRecord:
+        return logging.LogRecord(
+            name="test.logger",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg=msg,
+            args=(),
+            exc_info=None,
+        )
+
+    def test_emits_json_with_trace_ids(self):
+        from src.core.otel.logging import OtelJsonFormatter
+
+        formatter = OtelJsonFormatter()
+        record = self._record("hello world")
+        # Simulate fields injected by the OTel logging instrumentation.
+        record.otelTraceID = "abc123"
+        record.otelSpanID = "def456"
+        record.otelServiceName = "splunk-mcp"
+
+        payload = json.loads(formatter.format(record))
+
+        assert payload["message"] == "hello world"
+        assert payload["level"] == "INFO"
+        assert payload["otelTraceID"] == "abc123"
+        assert payload["otelSpanID"] == "def456"
+
+    def test_timestamp_is_iso8601_with_millis(self):
+        from src.core.otel.logging import OtelJsonFormatter
+
+        formatter = OtelJsonFormatter()
+        payload = json.loads(formatter.format(self._record("tick")))
+
+        ts = payload["timestamp"]
+        # Must be a real timestamp, not a literal strftime token like ".fZ".
+        assert "f" not in ts.replace("Z", "")
+        assert ts.endswith("Z")
+        assert ts[:4].isdigit()
+
+    def test_trace_ids_default_when_absent(self):
+        from src.core.otel.logging import OtelJsonFormatter
+
+        formatter = OtelJsonFormatter()
+        payload = json.loads(formatter.format(self._record("no span active")))
+
+        assert payload["otelTraceID"] == "0"
+        assert payload["otelSpanID"] == "0"
+
+    def test_redacts_sensitive_values(self):
+        from src.core.otel.logging import OtelJsonFormatter
+
+        formatter = OtelJsonFormatter()
+        record = self._record("connecting with X-Splunk-Token: super-secret-value")
+        payload = json.loads(formatter.format(record))
+
+        assert "super-secret-value" not in payload["message"]
+        assert "***" in payload["message"]
+
+    def test_redacts_sensitive_structured_extras(self):
+        from src.core.otel.logging import OtelJsonFormatter
+
+        formatter = OtelJsonFormatter()
+        record = self._record("login")
+        # Structured extras (e.g. logger.info(..., extra={...})) must not leak
+        # even when the bare value has no `key: value` shape to pattern-match.
+        record.splunk_token = "bare-secret-token"
+        record.api_key = "another-secret"
+        record.index = "main"
+
+        payload = json.loads(formatter.format(record))
+
+        assert payload["splunk_token"] == "***"
+        assert payload["api_key"] == "***"
+        assert payload["index"] == "main"
+
+
+class TestRedaction:
+    def test_redacts_authorization_bearer(self):
+        from src.core.otel.logging import redact_sensitive
+
+        out = redact_sensitive("Authorization: Bearer eyJhbGciOi.secrettoken")
+        assert "secrettoken" not in out
+        assert "***" in out
+
+    def test_passes_through_clean_text(self):
+        from src.core.otel.logging import redact_sensitive
+
+        assert redact_sensitive("searching index=main") == "searching index=main"
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap lifecycle
+# ---------------------------------------------------------------------------
+class TestInitOtel:
+    def test_returns_none_when_disabled(self, monkeypatch):
+        from src.core.otel import bootstrap
+
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+        bootstrap._reset_for_tests()
+
+        assert bootstrap.init_otel() is None
+
+    def test_initializes_and_is_idempotent(self, monkeypatch):
+        pytest.importorskip("opentelemetry.sdk")
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+
+        from src.core.otel import bootstrap
+
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318")
+        bootstrap._reset_for_tests()
+
+        exporter = InMemorySpanExporter()
+        provider = bootstrap.init_otel(span_exporter=exporter)
+        assert provider is not None
+
+        # Second call must not create a new provider.
+        provider2 = bootstrap.init_otel(span_exporter=exporter)
+        assert provider2 is provider
+
+
+# ---------------------------------------------------------------------------
+# Per-tool span middleware
+# ---------------------------------------------------------------------------
+class TestOtelToolSpanMiddleware:
+    @pytest.mark.asyncio
+    async def test_creates_tool_span_with_attribute(self, monkeypatch):
+        pytest.importorskip("opentelemetry.sdk")
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+
+        from src.core.otel.mcp_middleware import OtelToolSpanMiddleware
+
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+        middleware = OtelToolSpanMiddleware(tracer_provider=provider)
+
+        class FakeContext:
+            method = "tools/call"
+            params = {"name": "get_indexes", "arguments": {}}
+            session_id = "sess-1"
+
+        async def call_next(_ctx):
+            return {"ok": True}
+
+        result = await middleware.on_request(FakeContext(), call_next)
+
+        assert result == {"ok": True}
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].name == "mcp.tool.get_indexes"
+        assert spans[0].attributes.get("mcp.tool.name") == "get_indexes"
+
+    @pytest.mark.asyncio
+    async def test_non_tool_method_is_passthrough(self):
+        pytest.importorskip("opentelemetry.sdk")
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+
+        from src.core.otel.mcp_middleware import OtelToolSpanMiddleware
+
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        middleware = OtelToolSpanMiddleware(tracer_provider=provider)
+
+        class FakeContext:
+            method = "resources/read"
+            params = {"uri": "health://status"}
+            session_id = None
+
+        async def call_next(_ctx):
+            return "OK"
+
+        result = await middleware.on_request(FakeContext(), call_next)
+
+        assert result == "OK"
+        # No tool span should be created for non tool calls.
+        assert exporter.get_finished_spans() == ()

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -229,6 +229,49 @@ class TestOtelToolSpanMiddleware:
         assert spans[0].attributes.get("mcp.tool.name") == "get_indexes"
 
     @pytest.mark.asyncio
+    async def test_exception_event_is_redacted(self):
+        pytest.importorskip("opentelemetry.sdk")
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+
+        from src.core.otel.mcp_middleware import OtelToolSpanMiddleware
+
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        middleware = OtelToolSpanMiddleware(tracer_provider=provider)
+
+        class FakeContext:
+            method = "tools/call"
+            params = {"name": "do_thing", "arguments": {}}
+            session_id = None
+
+        async def call_next(_ctx):
+            raise ValueError("X-Splunk-Token: super-secret-value")
+
+        with pytest.raises(ValueError):
+            await middleware.on_request(FakeContext(), call_next)
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+
+        # Status description must not carry the raw secret.
+        assert "super-secret-value" not in (span.status.description or "")
+        assert "***" in (span.status.description or "")
+
+        # Exception event message + stacktrace must be redacted.
+        blob = json.dumps(
+            {event.name: dict(event.attributes) for event in span.events}
+        )
+        assert "exception" in blob
+        assert "super-secret-value" not in blob
+        assert "***" in blob
+
+    @pytest.mark.asyncio
     async def test_non_tool_method_is_passthrough(self):
         pytest.importorskip("opentelemetry.sdk")
         from opentelemetry.sdk.trace import TracerProvider

--- a/uv.lock
+++ b/uv.lock
@@ -77,6 +77,18 @@ wheels = [
 ]
 
 [[package]]
+name = "asgiref"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
+]
+
+[[package]]
 name = "ast-serialize"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -944,6 +956,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
 name = "griffe"
 version = "1.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1542,7 +1566,7 @@ requires-dist = [
 
 [[package]]
 name = "mcp-server-for-splunk"
-version = "0.7.0"
+version = "0.6.6"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -1568,6 +1592,14 @@ dev = [
 ]
 itsi = [
     { name = "mcp-itsi-server" },
+]
+otel = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-httpx" },
+    { name = "opentelemetry-instrumentation-logging" },
+    { name = "opentelemetry-instrumentation-starlette" },
+    { name = "opentelemetry-sdk" },
 ]
 security = [
     { name = "bandit" },
@@ -1613,6 +1645,12 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=2.1.0" },
     { name = "openai", specifier = ">=2.41.1" },
     { name = "openai-agents", specifier = ">=0.1.0" },
+    { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.41.1" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.41.1" },
+    { name = "opentelemetry-instrumentation-httpx", marker = "extra == 'otel'", specifier = ">=0.62b0" },
+    { name = "opentelemetry-instrumentation-logging", marker = "extra == 'otel'", specifier = ">=0.62b0" },
+    { name = "opentelemetry-instrumentation-starlette", marker = "extra == 'otel'", specifier = ">=0.62b0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.41.1" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.6.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
@@ -1628,7 +1666,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.49.0" },
     { name = "wsproto", specifier = ">=1.3.2" },
 ]
-provides-extras = ["dev", "itsi", "test", "security", "docs", "sentry"]
+provides-extras = ["dev", "itsi", "test", "security", "docs", "sentry", "otel"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1819,6 +1857,160 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/fa/f9e3bd3c4d692b3ce9a2880a167d1f79681a1bea11f00d5bf76adc03e6ea/opentelemetry_exporter_otlp_proto_common-1.41.1.tar.gz", hash = "sha256:0e253156ea9c36b0bd3d2440c5c9ba7dd1f3fb64ba7a08fc85fbac536b56e1fb", size = 20409, upload-time = "2026-04-24T13:15:40.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/48/bce76d3ea772b609757e9bc844e02ab408a6446609bf74fb562062ba6b71/opentelemetry_exporter_otlp_proto_common-1.41.1-py3-none-any.whl", hash = "sha256:10da74dad6a49344b9b7b21b6182e3060373a235fde1528616d5f01f92e66aa9", size = 18366, upload-time = "2026-04-24T13:15:18.917Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/5b/9d3c7f70cca10136ba82a81e738dee626c8e7fc61c6887ea9a58bf34c606/opentelemetry_exporter_otlp_proto_http-1.41.1.tar.gz", hash = "sha256:4747a9604c8550ab38c6fd6180e2fcb80de3267060bef2c306bad3cb443302bc", size = 24139, upload-time = "2026-04-24T13:15:42.977Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/4d/ef07ff2fc630849f2080ae0ae73a61f67257905b7ac79066640bfa0c5739/opentelemetry_exporter_otlp_proto_http-1.41.1-py3-none-any.whl", hash = "sha256:1a21e8f49c7a946d935551e90947d6c3eb39236723c6624401da0f33d68edcb4", size = 22673, upload-time = "2026-04-24T13:15:21.313Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/cb/0523b92c112a6cc70be43724343dc45225d3af134419844d7879a07755d4/opentelemetry_instrumentation-0.62b1.tar.gz", hash = "sha256:90e92a905ba4f84db06ac3aec96701df6c079b2d66e9379f8739f0a1bdcc7f45", size = 34043, upload-time = "2026-04-24T13:22:31.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/0f/45adbaea1f81b847cffdcee4f4b5f89297e42facf7fac78c7aaac4c38e75/opentelemetry_instrumentation-0.62b1-py3-none-any.whl", hash = "sha256:976fc6e640f2006599e97429c949e622c108d0c17c2059347d1e6c93c707f257", size = 34163, upload-time = "2026-04-24T13:21:31.722Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/43/b2f0703ff46718ff7b17d7fbf8e9d7f20e26a23c7c325092dd762d09cf9d/opentelemetry_instrumentation_asgi-0.62b1.tar.gz", hash = "sha256:7cf5f5d5c493bbb1edd2bd6d51fa879d964e94048904017258a32ffa47329310", size = 26781, upload-time = "2026-04-24T13:22:37.158Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/41/968c1fe12fb90abffca6620e65d4af91451c02ecca8f74a17a62cac490de/opentelemetry_instrumentation_asgi-0.62b1-py3-none-any.whl", hash = "sha256:b7f89be48528512619bd54fa2459f72afb1695ba71d7024d382ad96d467e7fa8", size = 17011, upload-time = "2026-04-24T13:21:38.006Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-httpx"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/cb/7a418e69c7dad281803529cb4f6de1b747d802cca44c38032668690b4836/opentelemetry_instrumentation_httpx-0.62b1.tar.gz", hash = "sha256:a1fac9bcc3a6ef5996a7990563f1af0798468b2c146de535fd598369383fba7e", size = 24181, upload-time = "2026-04-24T13:22:52.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/e0/eca824e9492ccec00e055bdd243aeda8eb7c5eda746d98af4d7a2d97ecf3/opentelemetry_instrumentation_httpx-0.62b1-py3-none-any.whl", hash = "sha256:88614015df451d61bc7e73f22524e6f223611f80b6caad2f6bdcbe05fa0df653", size = 17201, upload-time = "2026-04-24T13:21:58.072Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-logging"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/25/a30e0160cb3654bb63936be16d8ffe5f4a658d10bec0d5509cca3c74f103/opentelemetry_instrumentation_logging-0.62b1.tar.gz", hash = "sha256:997359d29ce06cb3768677387469431d0484b2450b5c35d7f02361431d3de338", size = 18969, upload-time = "2026-04-24T13:22:54.275Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/e4/216d1c7ff9c10815a8587ecbca0b570596921f001d1e2c2903c6f19e2e90/opentelemetry_instrumentation_logging-0.62b1-py3-none-any.whl", hash = "sha256:969330216d1ae02f4e10f1a030566ae758114caead020817192e6a02c6d1a0e1", size = 17488, upload-time = "2026-04-24T13:22:00.726Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-starlette"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/fd/d905b584833ece0129b344e5930e93a5d75235fec1af72ad68f9d39d91d3/opentelemetry_instrumentation_starlette-0.62b1.tar.gz", hash = "sha256:fb990e4540cba45142e159397f6143de27e71494b8d12bbddef5a2ab5d10ea2b", size = 14735, upload-time = "2026-04-24T13:23:04.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/a6ab143d01772dab7d9e284893b12a630883c84168ac6dbcc2c4d95dca5b/opentelemetry_instrumentation_starlette-0.62b1-py3-none-any.whl", hash = "sha256:cef8901660d5742d867327fada336e7465abbda31933377edc20d07fa0475920", size = 11947, upload-time = "2026-04-24T13:22:17.097Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/e8/633c6d8a9c8840338b105907e55c32d3da1983abab5e52f899f72a82c3d1/opentelemetry_proto-1.41.1.tar.gz", hash = "sha256:4b9d2eb631237ea43b80e16c073af438554e32bc7e9e3f8ca4a9582f900020e5", size = 45670, upload-time = "2026-04-24T13:15:49.768Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/1e/5cd77035e3e82070e2265a63a760f715aacd3cb16dddc7efee913f297fcc/opentelemetry_proto-1.41.1-py3-none-any.whl", hash = "sha256:0496713b804d127a4147e32849fbaf5683fac8ee98550e8e7679cd706c289720", size = 72076, upload-time = "2026-04-24T13:15:32.542Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/d0/54ee30dab82fb0acda23d144502771ff76ef8728459c83c3e89ef9fb1825/opentelemetry_sdk-1.41.1.tar.gz", hash = "sha256:724b615e1215b5aeacda0abb8a6a8922c9a1853068948bd0bd225a56d0c792e6", size = 230180, upload-time = "2026-04-24T13:15:50.991Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/e7/a1420b698aad018e1cf60fdbaaccbe49021fb415e2a0d81c242f4c518f54/opentelemetry_sdk-1.41.1-py3-none-any.whl", hash = "sha256:edee379c126c1bce952b0c812b48fe8ff35b30df0eecf17e98afa4d598b7d85d", size = 180213, upload-time = "2026-04-24T13:15:33.767Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/de/911ac9e309052aca1b20b2d5549d3db45d1011e1a610e552c6ccdd1b64f8/opentelemetry_semantic_conventions-0.62b1.tar.gz", hash = "sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802", size = 145750, upload-time = "2026-04-24T13:15:52.236Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/a6/83dc2ab6fa397ee66fba04fe2e74bdf7be3b3870005359ceb7689103c058/opentelemetry_semantic_conventions-0.62b1-py3-none-any.whl", hash = "sha256:cf506938103d331fbb78eded0d9788095f7fd59016f2bda813c3324e5a74a93c", size = 231620, upload-time = "2026-04-24T13:15:35.454Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/1b/aa71b63e18d30a8384036b9937f40f7618f8030a7aa213155fb54f6f2b47/opentelemetry_util_http-0.62b1.tar.gz", hash = "sha256:adf6facbb89aef8f8bc566e2f04624942ba08a7b678b3479a91051a8f4dc70a3", size = 11393, upload-time = "2026-04-24T13:23:12.994Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/85/a9d9d32161c1ced61346267db4c9702da54f81ec5dc88214bc65c23f4e9d/opentelemetry_util_http-0.62b1-py3-none-any.whl", hash = "sha256:c57e8a6c19fc422c288e6074e882f506f85030b69b7376182f74f9257b9261f0", size = 9295, upload-time = "2026-04-24T13:22:28.078Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1886,6 +2078,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]
@@ -3242,6 +3449,92 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/8b/59781d0fe7b0adfbea37f600857de4be68921e454aeecf1a11bda35cdccc/wrapt-2.2.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:055e6fcfaa28e58c6a8c247d48b92be9d56f818b7068aa4f22b15b3343a09931", size = 80556, upload-time = "2026-06-20T23:47:28.473Z" },
+    { url = "https://files.pythonhosted.org/packages/94/dc/66c61aca927230c9cf97a3cb005c803971a1076ff9f7d61085d035c20085/wrapt-2.2.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8374eb6b1a58809211e84ff835a182bb17ab2807a5bfef23204c8cff38178a00", size = 81648, upload-time = "2026-06-20T23:47:30.504Z" },
+    { url = "https://files.pythonhosted.org/packages/23/1b/545eee1c18f3af4cf140bb5822b6ef81ebe569df0a63ac109973103a30a5/wrapt-2.2.2-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:656593bb3f5529f03d27af4136c4d7b11990e470bcbc6fefa5ef218695bece55", size = 152956, upload-time = "2026-06-20T23:47:31.867Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a7/6f42a3d03e44dc612a5dcff324e7366075a7857f0be2d49a8cb8a68279b8/wrapt-2.2.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfb00cb7bb22099e2f64b7340fb96113639aa7260c0972af3797ace2297b936c", size = 154771, upload-time = "2026-06-20T23:47:33.352Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/55/4d76175aaa97523c38f1d28f79d18ab41a1b116814158a818bc0eba00571/wrapt-2.2.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e7f10ee0bd53673bfd52b67cbce83336fe6cad90d2377b03baf66491d2bbfb91", size = 149460, upload-time = "2026-06-20T23:47:34.712Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9b/12e23264d8f4735e8483262f95c5a6b03c3665fd2a84bdf99a45b6a2f4ec/wrapt-2.2.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4402f57c5f0d0579599858ffbdd9bf4e3f0972f51096f2bd6cc7dab6b76ee49e", size = 153648, upload-time = "2026-06-20T23:47:36.092Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a3/bcd5ec37289dcd85ecd4d15395a6a6063d60bc45ff94a9d77814e1e54d64/wrapt-2.2.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:3a4eb7964ff4643d333c84f880bcf554652b2a1050aebc54ae696327f61acfaf", size = 148502, upload-time = "2026-06-20T23:47:37.623Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/be/716d708f607fa70f8a6eb47dff8ee945d5278dfc89ffeeff33039d052e63/wrapt-2.2.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e542b7c5af91e2123a8aabf19894319d5ec4268d2a9ffd2f239386133fc47746", size = 152238, upload-time = "2026-06-20T23:47:39.118Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/c0/1a48e7e54501274f5d906f18372221b13183b0afbb5b8bb4c7ca0392c0b4/wrapt-2.2.2-cp310-cp310-win32.whl", hash = "sha256:6e7e45b43d3c774d244fe7264378f5a3f0f383bc55a54a9866434e524540110f", size = 77278, upload-time = "2026-06-20T23:47:40.476Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/82/9cd69a1af288fbdedf01a10e3c8a0b6890b08c7f3f96d36a213699dbcd94/wrapt-2.2.2-cp310-cp310-win_amd64.whl", hash = "sha256:955f1d6e72a352e478de8d8b503abe301c5e139a141b62eb0923bd694995025f", size = 80131, upload-time = "2026-06-20T23:47:41.785Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/73/8db7e27daef37ae70a53ea62bef7fe80cc51a8b5e9e9181a8be6eb9a999c/wrapt-2.2.2-cp310-cp310-win_arm64.whl", hash = "sha256:b89d8d73c82db2bb7e6090b3afd7973f980d24e905cc34394eab60b884b3bf67", size = 79615, upload-time = "2026-06-20T23:47:43.109Z" },
+    { url = "https://files.pythonhosted.org/packages/27/15/0c2d55168707465abfc41f33c0b23d792a5fa9b65c26983606940900a120/wrapt-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f1a2ff355ece6a111ca7a20dc86df6659c9205d3fcee674ca34f2a2854fd4e73", size = 80782, upload-time = "2026-06-20T23:47:44.367Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b5/5c0b093eb48f8a062ef6267d3cb36e9bb1b88440181f6545a383c60efdf8/wrapt-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55b9a899e6fff5444f229d30aa6e9ac92d2216d9d60f33c771b5d76a760d5f8e", size = 81678, upload-time = "2026-06-20T23:47:45.857Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f3/de70937472dd3e8a4e6811192f9c6075efdffd4a2cd9b4596bf160f89668/wrapt-2.2.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a2d78c363f97d8bd718ee40432c66395685e9e98528ccaa423c3355d1715a26d", size = 159671, upload-time = "2026-06-20T23:47:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/40aed2330e7f02ecf74386ffcfef9ccb7108c6a430f15b6a252b663b1bed/wrapt-2.2.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d619e1eed9bd4f6ed9f24cd61971aa086fa86505289628d464bcf8a2c2e3f328", size = 160785, upload-time = "2026-06-20T23:47:48.759Z" },
+    { url = "https://files.pythonhosted.org/packages/45/04/aa5309beed5344b00220ae6b3b24055852192656194c27947bee1736306a/wrapt-2.2.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:518b0c5e323511ec56a38894802ddd5e1222626484e68efe63f201854ad788e5", size = 153699, upload-time = "2026-06-20T23:47:50.177Z" },
+    { url = "https://files.pythonhosted.org/packages/01/df/2def7e99d1fe87eea413f95f671924cdddcb08823b1ffd212748dfa6d062/wrapt-2.2.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4bccea5cdecffa9dd70e343741f0e41e0a16619313d04b72f78bb525162ebcd0", size = 159695, upload-time = "2026-06-20T23:47:51.602Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f6/a906d01a2ce12157bad2404957b3e2140da354b8a70b2fa48bbf282871c0/wrapt-2.2.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:209112cafd963710a05d199aae431d79a28bc76eb8e6d1bbbb8ad24340722cae", size = 152813, upload-time = "2026-06-20T23:47:53.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/49/bc0086292d239575b4c08f4cf8a4079fa58abbad58ec23abf84833a283ed/wrapt-2.2.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e5a5290e4bf2f332fc29ce72ffb9a2fff678aaac047e2e9f5f7165cd7792e099", size = 158809, upload-time = "2026-06-20T23:47:54.391Z" },
+    { url = "https://files.pythonhosted.org/packages/55/83/8fbd034de1f3e907edaa18786d5dd8f6932874edee0826c7cecb5cab03a1/wrapt-2.2.2-cp311-cp311-win32.whl", hash = "sha256:5499236ad1dc116012e2a5dd943f3f31af12fce452128e2bbcbd55a7d3d4d14c", size = 77414, upload-time = "2026-06-20T23:47:55.882Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/9c/23695baa331c6de4e874c3d78b8e0bed92e1d2a274e665b29858f6841672/wrapt-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:8636809939152be6ae20a6cef0fed9fe60f411b47847d0426a826884b469e971", size = 80368, upload-time = "2026-06-20T23:47:57.237Z" },
+    { url = "https://files.pythonhosted.org/packages/08/49/40cefc342bf89b234a4490d741290fce781774b831aefb39c25471da96c9/wrapt-2.2.2-cp311-cp311-win_arm64.whl", hash = "sha256:5d0a142f7af07caeb5e5da87493162a7b8efa19ba919e550a746f7446e13fb30", size = 79489, upload-time = "2026-06-20T23:47:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds **optional OpenTelemetry (OTel) distributed tracing** to the MCP server, mirroring the existing optional Sentry integration. When enabled, the server continues an incoming W3C `traceparent`, emits a span per MCP tool call, instruments outbound `httpx` calls, and exports OTLP spans to any OpenTelemetry-compatible backend (Jaeger, Tempo, Grafana, Splunk Observability, etc.).

- **Optional `[otel]` extra** — `opentelemetry-api/sdk`, `exporter-otlp-proto-http`, and the `starlette` / `httpx` / `logging` instrumentations. Tracing has **zero overhead** unless the extra is installed **and** `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
- **`src/core/otel/`** (small, single-responsibility modules):
  - `config.py` — env-driven `OtelSettings` + `is_otel_enabled()`.
  - `bootstrap.py` — `init_otel()` (TracerProvider + resource + sampler + OTLP `BatchSpanProcessor`), `instrument_starlette(app)` (W3C `traceparent` extraction on `/mcp`), `instrument_httpx()` (client child spans).
  - `mcp_middleware.py` — `OtelToolSpanMiddleware` emitting a `mcp.tool.{name}` span per tool call with the `mcp.tool.name` attribute.
  - `logging.py` — JSON log formatter carrying `otelTraceID` / `otelSpanID` / `otelServiceName` with a credential **deny-list** (`Authorization`, `X-Splunk-Token`, `X-Splunk-Password`, tokens/keys → `***`) applied to **both** the message **and** structured `extra` fields.
- **Wiring in `src/server.py`** — provider init + JSON logging swap, tool-span middleware, and Starlette/httpx instrumentation, all gated on a **successful** `init_otel()` so nothing runs against a half-initialized provider.
- **Vendor-neutral defaults** via standard `OTEL_*` env — `OTEL_SERVICE_NAME=splunk-mcp` (default), `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`, `OTEL_TRACES_SAMPLER=parentbased_always_on`, `deployment.environment`. No backend-specific values are hardcoded.
- **Docs + env** — `docs/guides/otel-tracing.md`, monitoring index link, and an OTel block in `env.example`.

## Test plan

- [x] `uv run pytest tests/test_otel.py` — passes **with and without** the `[otel]` extra (SDK-dependent tests use `pytest.importorskip`).
- [x] `uv run pytest -q --maxfail=1` — full fast suite green (483 passed, 2 skipped), no regressions.
- [x] `ruff` + `mypy src/core/otel/` clean.
- [x] Smoke: with `OTEL_EXPORTER_OTLP_ENDPOINT` set, the app boots, instrumentation logs enable, JSON logs emit trace-id fields, and sensitive values are redacted in both messages and `extra` fields.

## Notes / follow-ups

- `splunklib` uses `urllib` (not `httpx`), so Splunk REST calls are **not** captured by the httpx instrumentation. httpx child spans cover other outbound HTTP traffic; native `splunklib` span capture is a separate follow-up. Documented in the guide.

Closes #203
