### PR TITLE
fix(auth): ignore DAI local-db bearer when MCP auth disabled

### DIFF
--- a/mcp_itsi/config/headers.py
+++ b/mcp_itsi/config/headers.py
@@ -14,6 +14,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 
 from mcp_itsi.config.settings import ITSIServerSettings
+from src.core.utils import _is_dai_session_bearer
 
 logger = logging.getLogger(__name__)
 
@@ -135,7 +136,9 @@ def extract_request_config(
     )
     splunk_token = bearer_from_headers or settings.default_splunk_token
     if not splunk_token and _mcp_auth_disabled():
-        splunk_token = _extract_bearer_from_authorization(headers)
+        bearer_from_auth = _extract_bearer_from_authorization(headers)
+        if bearer_from_auth and not _is_dai_session_bearer(bearer_from_auth):
+            splunk_token = bearer_from_auth
 
     session_from_headers = _ci_get(headers, "X-Splunk-Session-Token")
     splunk_session_token = (

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -85,9 +85,10 @@ def extract_client_config_from_headers(headers: dict) -> dict | None:
     # Fall back to a standard ``Authorization: Bearer <token>`` header for the
     # Splunk bearer token. We only do this when MCP server-level auth is
     # disabled to avoid mistaking an MCP auth JWT for a Splunk credential.
+    # Enterprise DAI session tokens (``local-db-*``) must never be mapped here.
     if _splunk_t not in client_config and _mcp_auth_disabled():
         splunk_from_auth_header = _extract_bearer_token(headers)
-        if splunk_from_auth_header:
+        if splunk_from_auth_header and not _is_dai_session_bearer(splunk_from_auth_header):
             client_config[_splunk_t] = splunk_from_auth_header
 
     return client_config if client_config else None
@@ -107,6 +108,11 @@ def _mcp_auth_disabled() -> bool:
     import os
 
     return (os.getenv("MCP_AUTH_DISABLED") or "false").strip().lower() == "true"
+
+
+def _is_dai_session_bearer(token: str) -> bool:
+    """Return True when the bearer value is a Deslicer AI enterprise session token."""
+    return token.startswith("local-db-")
 
 
 def _extract_bearer_token(headers: dict) -> str | None:

--- a/tests/test_mcp_itsi.py
+++ b/tests/test_mcp_itsi.py
@@ -103,6 +103,33 @@ def test_extract_request_config_authorization_bearer_when_mcp_auth_disabled(monk
     assert cfg.splunk_token == "hdr-token"
 
 
+def test_extract_request_config_ignores_local_db_authorization_bearer_when_mcp_auth_disabled(
+    monkeypatch,
+):
+    monkeypatch.setenv("MCP_AUTH_DISABLED", "true")
+    settings = ITSIServerSettings(default_splunk_host="so1")
+    cfg = extract_request_config(
+        {
+            "X-Splunk-Username": "admin",
+            "X-Splunk-Password": "password",
+            "Authorization": "Bearer local-db-session-token",
+        },
+        settings,
+    )
+    assert cfg.splunk_token is None
+    assert cfg.splunk_username == "admin"
+    assert cfg.has_credentials() is True
+
+
+def test_extract_request_config_rejects_local_db_authorization_only_when_mcp_auth_disabled(
+    monkeypatch,
+):
+    monkeypatch.setenv("MCP_AUTH_DISABLED", "true")
+    settings = ITSIServerSettings(default_splunk_host="so1")
+    with pytest.raises(ValueError, match="No Splunk credentials"):
+        extract_request_config({"Authorization": "Bearer local-db-session-token"}, settings)
+
+
 def test_extract_request_config_ignores_authorization_bearer_when_mcp_auth_enabled(monkeypatch):
     monkeypatch.delenv("MCP_AUTH_DISABLED", raising=False)
     settings = ITSIServerSettings(default_splunk_host="so1")

--- a/tests/test_token_auth.py
+++ b/tests/test_token_auth.py
@@ -165,6 +165,22 @@ class TestHeaderExtractionForTokens:
         assert cfg is not None
         assert _SPLUNK_TOK not in cfg
 
+    def test_authorization_local_db_bearer_ignored_when_mcp_auth_disabled(self):
+        from src.core.utils import extract_client_config_from_headers
+
+        with patch.dict(os.environ, {"MCP_AUTH_DISABLED": "true"}, clear=False):
+            cfg = extract_client_config_from_headers({
+                "X-Splunk-Host": "splunk.example.com",
+                "X-Splunk-Username": "admin",
+                "X-Splunk-Password": "password",
+                "Authorization": "Bearer local-db-session-token",
+            })
+
+        assert cfg is not None
+        assert _SPLUNK_TOK not in cfg
+        assert cfg["splunk_username"] == "admin"
+        assert cfg["splunk_password"] == "password"
+
     def test_explicit_splunk_token_header_wins_over_authorization(self):
         from src.core.utils import extract_client_config_from_headers
 


### PR DESCRIPTION
## Summary
- When `MCP_AUTH_DISABLED=true`, skip mapping `Authorization: Bearer local-db-*` to `splunk_token`
- Prefer explicit `X-Splunk-Username` / `X-Splunk-Password` or `X-Splunk-Token` headers
- Defense-in-depth alongside deslicer-ai PR that stops forwarding the DAI session bearer

## Test plan
- [x] `pytest tests/test_token_auth.py::TestHeaderExtractionForTokens`