### PR TITLE
fix: default ITSI Splunk TLS verification to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Remove OpenAI Agents `workflow_runner` execution path (Option C); workflow JSON discovery/authoring tools remain
 * Upgrade runtime to FastMCP `4.0.0b2` / MCP Python SDK v2 (protocol `2026-07-28`)
+* Default ITSI/Splunk TLS verification to **true** (`SPLUNK_VERIFY_SSL`); set `false` explicitly for lab/self-signed certs
 
 ### Features
 

--- a/docs/guides/itsi/getting-started.md
+++ b/docs/guides/itsi/getting-started.md
@@ -53,7 +53,8 @@ SPLUNK_HOST=<splunk-host>
 SPLUNK_PORT=8089
 SPLUNK_USERNAME=<user>
 SPLUNK_PASSWORD=<pass>
-SPLUNK_VERIFY_SSL=false           # set to true in production with a valid cert
+# Defaults to true; set false only for lab/self-signed certs
+SPLUNK_VERIFY_SSL=false
 
 # Optional ITSI namespace overrides (defaults shown)
 ITSI_APP=SA-ITOA

--- a/env.example
+++ b/env.example
@@ -6,6 +6,7 @@ SPLUNK_HOST=so1
 SPLUNK_PORT=8089
 SPLUNK_USERNAME=admin
 SPLUNK_PASSWORD=Chang3d!
+# Default is true; false is for local/lab self-signed certs
 SPLUNK_VERIFY_SSL=false
 
 # --- Splunk authentication (choose ONE of the following) -------------------

--- a/mcp_itsi/README.md
+++ b/mcp_itsi/README.md
@@ -118,7 +118,7 @@ Send the same `X-Splunk-*` headers the parent project accepts. Optional `X-ITSI-
 | `X-Splunk-Host` | splunkd host (or set `SPLUNK_HOST` in env). |
 | `X-Splunk-Port` | splunkd management port, default `8089`. |
 | `X-Splunk-Scheme` | `https` (default) or `http`. |
-| `X-Splunk-Verify-SSL` | `true` / `false`, default `false`. |
+| `X-Splunk-Verify-SSL` | `true` / `false`, default `true`. Set `false` for lab/self-signed certs. |
 | `X-Splunk-Username` + `X-Splunk-Password` | Basic auth pair. |
 | `X-Splunk-Token` | Splunk bearer / access token (preferred). |
 | `auth_token` / `X-Auth-Token` / `X-Splunk-Auth-Token` | Aliases for the bearer header (some clients send these names). |

--- a/mcp_itsi/README.md
+++ b/mcp_itsi/README.md
@@ -185,7 +185,7 @@ All variables have safe defaults; everything below is optional.
 | `SPLUNK_USERNAME` / `SPLUNK_PASSWORD` | — | Default basic-auth credentials. |
 | `SPLUNK_TOKEN` / `MCP_SPLUNK_TOKEN` | — | Default bearer token. |
 | `SPLUNK_SESSION_TOKEN` / `MCP_SPLUNK_SESSION_TOKEN` | — | Default splunkd session token. |
-| `SPLUNK_VERIFY_SSL` | `false` | Default TLS verification. |
+| `SPLUNK_VERIFY_SSL` | `true` | Default TLS verification. Set `false` for lab/self-signed certs. |
 
 ## Capabilities at a glance
 

--- a/mcp_itsi/config/headers.py
+++ b/mcp_itsi/config/headers.py
@@ -33,7 +33,7 @@ class ITSIRequestConfig:
     splunk_password: str | None = None
     splunk_token: str | None = None
     splunk_session_token: str | None = None
-    verify_ssl: bool = False
+    verify_ssl: bool = True
 
     itsi_app: str = "SA-ITOA"
     user_ns: str = "nobody"

--- a/mcp_itsi/config/settings.py
+++ b/mcp_itsi/config/settings.py
@@ -54,7 +54,7 @@ class ITSIServerSettings:
     default_splunk_password: str | None = None
     default_splunk_token: str | None = None
     default_splunk_session_token: str | None = None
-    default_splunk_verify_ssl: bool = False
+    default_splunk_verify_ssl: bool = True
 
     default_itsi_app: str = "SA-ITOA"
     default_itsi_user_ns: str = "nobody"
@@ -92,7 +92,7 @@ def load_settings() -> ITSIServerSettings:
         default_splunk_session_token=os.getenv("SPLUNK_SESSION_TOKEN")
         or os.getenv("MCP_SPLUNK_SESSION_TOKEN")
         or None,
-        default_splunk_verify_ssl=_bool(os.getenv("SPLUNK_VERIFY_SSL"), False),
+        default_splunk_verify_ssl=_bool(os.getenv("SPLUNK_VERIFY_SSL"), True),
         default_itsi_app=os.getenv("ITSI_APP", "SA-ITOA"),
         default_itsi_user_ns=os.getenv("ITSI_USER_NS", "nobody"),
         default_itsi_version=os.getenv("ITSI_API_VERSION", "vLatest"),

--- a/scripts/test_env_vars.py
+++ b/scripts/test_env_vars.py
@@ -18,7 +18,7 @@ def test_env_vars():
 
     optional_vars = {
         "SPLUNK_PORT": "Splunk management port (default: 8089)",
-        "SPLUNK_VERIFY_SSL": "Verify SSL certificates (default: false)",
+        "SPLUNK_VERIFY_SSL": "Verify SSL certificates (default: true)",
         "MCP_HOT_RELOAD": "Enable hot reload (development)",
         "MCP_SERVER_MODE": "Server mode (docker/local)",
         "MCP_STATELESS_HTTP": "Stateless HTTP for handshake-era clients (default: true)",

--- a/tests/test_mcp_itsi.py
+++ b/tests/test_mcp_itsi.py
@@ -45,6 +45,7 @@ def test_load_settings_returns_defaults(monkeypatch):
         "ITSI_API_VERSION",
         "MCP_STATELESS_HTTP",
         "MCP_JSON_RESPONSE",
+        "SPLUNK_VERIFY_SSL",
     ):
         monkeypatch.delenv(key, raising=False)
     s = load_settings()
@@ -52,6 +53,7 @@ def test_load_settings_returns_defaults(monkeypatch):
     assert s.transport == "http"
     assert s.default_itsi_app == "SA-ITOA"
     assert s.default_itsi_user_ns == "nobody"
+    assert s.default_splunk_verify_ssl is True
 
 
 def test_extract_request_config_uses_headers():


### PR DESCRIPTION
## Summary
- Default `SPLUNK_VERIFY_SSL` / ITSI `verify_ssl` to **true** (Code Scanning alert #537)
- Lab/self-signed deployments keep opting out via env, headers, docker-compose defaults, and CI
- Docs + unit test updated

Part of #233 P1. Kept separate from lockfile CVE PR #239 per the remediation plan.

## Test plan
- [x] `uv run pytest tests/test_mcp_itsi.py`
- [ ] CI green
- [ ] Confirm alert #537 closes after merge
