### PR TITLE
docs: add AGENTS.md and llms.txt for AI agents

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -105,6 +105,7 @@ tags = ["credential"]
 paths = [
     '''env\.example''',
     '''\.md$''',
+    '''llms\.txt$''',  # Agent header examples; placeholders only
     '''tests/''',
     '''conftest\.py$''',
     '''test.*\.py$''',

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,109 @@
+# AGENTS.md — coding agents in this repo
+
+Instructions for AI coding agents (Cursor, Codex, Copilot, Claude Code, etc.)
+working **in this repository**. For agents that only *call* the running MCP
+server, prefer [`llms.txt`](llms.txt) and
+[`mcp_itsi/llms.txt`](mcp_itsi/llms.txt).
+
+## Project overview
+
+- **Product**: MCP Server for Splunk — FastMCP 4 / MCP SDK v2 tools, resources,
+  and prompts over Splunk Enterprise/Cloud (+ optional ITSI plugin).
+- **Runtime pin**: `fastmcp==4.0.0b2` (see `pyproject.toml` / `uv.lock`).
+- **Layout**:
+  - `src/` — core server, tools, resources, middleware
+  - `mcp_itsi/` — ITSI plugin package (also packaged under `packaging/mcp-itsi-server`)
+  - `contrib/` — community tools/workflows
+  - `scripts/` — live probes and operator helpers
+  - `docs/` — human docs; follow `docs/readme-guide.md` when editing Markdown
+  - `tests/` — pytest suite
+
+## Setup
+
+```bash
+cp env.example .env   # fill Splunk host + token or user/password
+uv sync --extra dev
+```
+
+Useful entry points:
+
+```bash
+uv run mcp-server --local          # local HTTP defaults (sessionless)
+uv run python src/server.py --host 127.0.0.1 --port 8014
+```
+
+## Build / lint / test
+
+```bash
+uv run ruff check src/ tests/
+uv run mypy src/core/client_config_cache.py   # targeted; full mypy via CI lint job
+uv run pytest tests/ -q --ignore=tests/integration
+```
+
+Live Splunk (credentials via env, never commit secrets):
+
+```bash
+uv run python scripts/test_live_splunk_tools.py
+uv run python scripts/test_live_mcp_client.py          # in-memory FastMCP Client
+uv run python scripts/test_sessionless_http.py         # needs MCP_URL + SPLUNK_TOKEN
+```
+
+Always regenerate the lockfile when changing deps:
+
+```bash
+uv lock
+uv lock --check
+```
+
+Dependabot PRs that only edit `pyproject.toml` floors without `uv.lock` are incomplete.
+
+## Conventions
+
+- **Python**: 3.10+; keep modules focused; prefer composition over large god-files.
+- **File size**: stay under ~500 lines; split earlier around ~400.
+- **Imports**: top of module only (no inline imports unless a documented cycle).
+- **Markdown**: follow `.cursorrules` / `docs/readme-guide.md` (one H1, short
+  paragraphs, fenced code with language tags).
+- **HTTP client modes**: sessionless is the default
+  (`MCP_STATELESS_HTTP=true`). See
+  `docs/guides/configuration/http-client-modes.md`.
+- **Workflows**: OpenAI Agents `workflow_runner` was removed (Option C). Keep
+  JSON discovery/authoring tools only (`list_workflows`, `workflow_builder`,
+  `workflow_requirements`).
+- **Saved-search ACL**: read ownership from `entity.access` via
+  `src/tools/search/saved_search_acl.py` — not `content['eai:acl']`.
+- **ITSI packaging**: `mcp_itsi/` and `packaging/mcp-itsi-server/mcp_itsi/` may
+  be hardlinked — edit once, verify both paths if unsure.
+
+## Security rules for agents
+
+- Never commit `.env`, tokens, passwords, or live host credentials.
+- Prefer `X-Splunk-Token` / `SPLUNK_TOKEN` over passwords in examples.
+- Do not log raw `splunk_token`, `splunk_password`, or `splunk_session_token`.
+- Default TLS verification is **true**; lab stacks must set
+  `SPLUNK_VERIFY_SSL=false` explicitly.
+- Avoid adding `openai` / `openai-agents` back to the default install.
+
+## Git / PR habits
+
+- Do not push to `main` or force-push shared branches unless the user asks.
+- Do not amend commits you did not create in this session.
+- Squash-friendly commits: short why-focused subject.
+- After squash-merges, rebase follow-up branches onto `origin/main` (do not
+  merge the deleted feature-branch history).
+
+## Where to look first
+
+| Task | Start here |
+|------|------------|
+| Server / middleware / HTTP | `src/server.py`, `src/core/` |
+| Splunk tools | `src/tools/` |
+| Client config headers | `docs/guides/configuration/client_configuration.md` |
+| Sessionless vs session HTTP | `docs/guides/configuration/http-client-modes.md` |
+| ITSI tools / schemas | `mcp_itsi/`, `mcp_itsi/llms.txt` |
+| Contrib tools | `contrib/README.md` |
+
+## Optional nested agent docs
+
+- ITSI usage for LLM operators: `mcp_itsi/llms.txt`
+- Cursor markdown rules: `.cursorrules`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Dual-era client config cache: prefer `X-Session-ID`, fall back to `MCP-Session-Id`, then config fingerprint
 * Default Streamable HTTP to sessionless (`MCP_STATELESS_HTTP` / `MCP_JSON_RESPONSE` true)
 * Docs for sessionless vs session-scoped HTTP clients (`docs/guides/configuration/http-client-modes.md`)
+* Add root `llms.txt` (MCP usage for LLM agents) and `AGENTS.md` (coding-agent repo guide)
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ Both modes share the **same per-request `X-Splunk-*` headers** as the parent ser
 | **[Getting Started](docs/getting-started/)** | Complete setup guide with prerequisites | New users | 15 min |
 | **[Integration Guide](docs/guides/integration/)** | Connect AI clients | Developers | 30 min |
 | **[HTTP Client Modes](docs/guides/configuration/http-client-modes.md)** | Sessionless vs session-scoped HTTP clients | Developers | 10 min |
+| **[llms.txt](llms.txt)** | LLM-oriented guide for *using* the MCP server | Agents | 5 min |
+| **[AGENTS.md](AGENTS.md)** | Instructions for coding agents working in this repo | Contributors / agents | 5 min |
 | **[Deployment Guide](docs/guides/deployment/)** | Production deployment | DevOps | 45 min |
 | **[Workflows Guide](docs/guides/workflows/README.md)** | Discover, author, and validate workflow JSON | Developers | 10 min |
 | **[API Reference](docs/reference/tools.md)** | Tool documentation | Integrators | Reference |

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,8 @@ Practical guides for common tasks and scenarios.
 | **[Integration](guides/integration/)** | Connect AI clients to MCP server | 30 min | Developers |
 | **[Configuration](guides/configuration/)** | Configuration options and patterns | 20 min | Operators |
 | **[HTTP Client Modes](guides/configuration/http-client-modes.md)** | Sessionless vs session-scoped Streamable HTTP | 10 min | Developers / Operators |
+| **[llms.txt](../llms.txt)** | How LLM agents should connect and call Splunk tools | 5 min | Agents |
+| **[AGENTS.md](../AGENTS.md)** | Build/test/conventions for coding agents in-repo | 5 min | Contributors / agents |
 | **[Deployment](guides/deployment/)** | Production deployment strategies | 45 min | DevOps |
 | **[Security](guides/security.md)** | Security best practices | 30 min | Security teams |
 | **[Testing](guides/TESTING.md)** | Testing and validation | 15 min | Developers |

--- a/llms.txt
+++ b/llms.txt
@@ -19,7 +19,7 @@ X-Splunk-Host: splunk.example.com
 X-Splunk-Port: 8089
 X-Splunk-Scheme: https
 X-Splunk-Verify-SSL: true
-X-Splunk-Token: <splunk-access-token>
+X-Splunk-Token: <token>
 ```
 
 Omit `X-Session-ID` / `MCP-Session-ID` unless you want session-scoped caching.
@@ -32,7 +32,7 @@ Add a stable session key when using password auth or sticky IDE sessions:
 X-Session-ID: ide-session-abc123
 X-Splunk-Host: splunk.example.com
 X-Splunk-Username: analyst
-X-Splunk-Password: <password>
+X-Splunk-Password: <pass>
 X-Splunk-Scheme: https
 X-Splunk-Verify-SSL: true
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,82 @@
+# MCP Server for Splunk
+
+> Model Context Protocol server that lets LLM agents query and administer Splunk Enterprise/Cloud (search, indexes, saved searches, apps, KV store, docs resources) over Streamable HTTP or stdio. Optional ITSI plugin adds `itsi_*` tools.
+
+This file orients agents that **use** a running server. For agents that **edit this repo**, see `AGENTS.md`.
+
+## Connect (HTTP)
+
+Endpoint: `http(s)://HOST:PORT/mcp` (local default often `http://localhost:8003/mcp`).
+
+Prefer a real MCP client (FastMCP Client, Cursor, Claude Desktop, MCP Inspector). Send Splunk credentials as headers on each request.
+
+### Sessionless (default)
+
+Server: `MCP_STATELESS_HTTP=true`, `MCP_JSON_RESPONSE=true`.
+
+```http
+X-Splunk-Host: splunk.example.com
+X-Splunk-Port: 8089
+X-Splunk-Scheme: https
+X-Splunk-Verify-SSL: true
+X-Splunk-Token: <splunk-access-token>
+```
+
+Omit `X-Session-ID` / `MCP-Session-ID` unless you want session-scoped caching.
+
+### Session-scoped
+
+Add a stable session key when using password auth or sticky IDE sessions:
+
+```http
+X-Session-ID: ide-session-abc123
+X-Splunk-Host: splunk.example.com
+X-Splunk-Username: analyst
+X-Splunk-Password: <password>
+X-Splunk-Scheme: https
+X-Splunk-Verify-SSL: true
+```
+
+### Toolset filter (optional)
+
+```http
+X-MCP-Toolsets: splunk
+X-MCP-Toolsets: itsi
+X-MCP-Toolsets: splunk,itsi
+X-MCP-Toolsets: all
+```
+
+Default without header is usually `splunk` only (`MCP_DEFAULT_TOOLSETS`).
+
+## Golden path for Splunk work
+
+1. `get_splunk_health` — confirm connectivity.
+2. Discover: `list_indexes`, `list_sources`, `list_sourcetypes`, `get_metadata`.
+3. Search: `run_oneshot_search` for small results; `run_splunk_search` + `get_search_job_info` for longer jobs.
+4. Saved searches / alerts: `list_saved_searches` (supports app-scoped alerts), then `get_saved_search_details` / `execute_saved_search`.
+5. Docs resources: `discover_splunk_docs`, `get_splunk_cheat_sheet`, CIM/studio helpers — use when unsure about SPL or configs.
+6. Workflows: `list_workflows` / `workflow_builder` / `workflow_requirements` discover and validate JSON playbooks. There is **no** built-in OpenAI `workflow_runner`; orchestrate externally.
+
+## Important rules
+
+- Prefer bearer tokens (`X-Splunk-Token`) over passwords.
+- TLS verification defaults to **true**; set `X-Splunk-Verify-SSL: false` only for lab/self-signed.
+- Do not invent SPL indexes or saved-search names — list first.
+- Mutating tools (`create_*`, `delete_*`, `manage_apps`, `create_config`) need explicit user intent.
+- For ITSI objects, switch to the ITSI guide and always work schema-first.
+
+## Docs map
+
+- [HTTP client modes](docs/guides/configuration/http-client-modes.md): sessionless vs session-scoped
+- [Client configuration](docs/guides/configuration/client_configuration.md): full header/env matrix + toolsets
+- [Tools reference](docs/reference/tools.md): tool catalog
+- [Workflows](docs/guides/workflows/README.md): JSON workflow discovery (no OpenAI runner)
+- [ITSI llms.txt](mcp_itsi/llms.txt): ITSI schema-first CRUD
+- [ITSI getting started](docs/guides/itsi/getting-started.md): run plugin or standalone ITSI server
+- [AGENTS.md](AGENTS.md): repo contribution / coding-agent instructions
+
+## Optional
+
+- Live probes: `scripts/test_sessionless_http.py`, `scripts/test_live_mcp_client.py`
+- Session troubleshooting: `docs/SESSION_MANAGEMENT.md`
+- Contrib tools: `contrib/README.md`


### PR DESCRIPTION
## Summary
- Add root `llms.txt` for LLM agents that *use* the MCP server (connect headers, golden path, docs map)
- Add root `AGENTS.md` for coding agents that *edit* this repo (setup, test, conventions, security)
- Link both from README / docs hub

Complements existing `mcp_itsi/llms.txt`.

## Test plan
- [ ] Skim files for accuracy against current FastMCP 4 / sessionless defaults
- [ ] Confirm links resolve in GitHub UI