### PR TITLE
chore: add 7-day dependency cooldowns (#233 P2)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "America/New_York"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -50,6 +52,8 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "America/New_York"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "github-actions"
@@ -65,6 +69,8 @@ updates:
       day: "tuesday"
       time: "09:00"
       timezone: "America/New_York"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "docker"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,22 @@ Dependabot PRs that only edit `pyproject.toml` floors without `uv.lock` are inco
   `SPLUNK_VERIFY_SSL=false` explicitly.
 - Avoid adding `openai` / `openai-agents` back to the default install.
 
+### Dependency cooldowns
+
+Normal resolution waits ~7 days before adopting newly published versions
+(`exclude-newer` in `pyproject.toml`, Renovate `minimumReleaseAge`, Dependabot
+`cooldown`). For an emergency CVE lock bump:
+
+```bash
+uv lock --exclude-newer 2099-01-01 --upgrade-package <package>
+uv lock --check
+```
+
+If the package must stay exempt from the global cooldown, add it under
+`[tool.uv].exclude-newer-package` (see existing security/pin opt-outs).
+Renovate vulnerability alerts bypass `minimumReleaseAge` via a dedicated
+`packageRules` entry.
+
 ## Git / PR habits
 
 - Do not push to `main` or force-push shared branches unless the user asks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Drop `openai` / `openai-agents`; pull security upgrades via lockfile (cryptography, soupsieve, nltk, etc.)
 * Bump OpenTelemetry floors to 1.43+/0.64b+ and ruff to ≥0.15.20 (Phase 2 Dependabot sweep)
 * Upgrade `pydantic-settings` and `python-multipart` for remaining lockfile CVEs
+* Add 7-day dependency cooldowns (uv `exclude-newer`, Renovate `minimumReleaseAge`, Dependabot `cooldown`)
 
 ## [0.6.8](https://github.com/deslicer/mcp-for-splunk/compare/v0.6.7...v0.6.8) (2026-06-24)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,18 +119,6 @@ mcp-itsi-server = { workspace = true }
 # Opt out exact pins and recently cleared CVE/security bumps so `uv lock --check`
 # does not regress them while they are still inside the cooldown window.
 exclude-newer = "7 days"
-exclude-newer-package = {
-    fastmcp = false,
-    fastmcp-slim = false,
-    httpcore2 = false,
-    httpx2 = false,
-    "httpx2-jsfetch" = false,
-    nltk = false,
-    pydantic-settings = false,
-    ruff = false,
-    soupsieve = false,
-    starlette = false,
-}
 constraint-dependencies = ["fastmcp-slim==4.0.0b2"]
 dev-dependencies = [
 "pytest>=9.1.1",
@@ -146,6 +134,18 @@ dev-dependencies = [
 "safety>=3.8.1",
 "mcp-itsi-server",
 ]
+
+[tool.uv.exclude-newer-package]
+fastmcp = false
+fastmcp-slim = false
+httpcore2 = false
+httpx2 = false
+"httpx2-jsfetch" = false
+nltk = false
+pydantic-settings = false
+ruff = false
+soupsieve = false
+starlette = false
 
 [tool.pytest.ini_options]
 minversion = "7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,23 @@ members = ["packaging/mcp-itsi-server"]
 mcp-itsi-server = { workspace = true }
 
 [tool.uv]
+# Ignore package versions published in the last 7 days (supply-chain cooldown).
+# Emergency CVE path: uv lock --exclude-newer 2099-01-01 --upgrade-package <pkg>
+# Opt out exact pins and recently cleared CVE/security bumps so `uv lock --check`
+# does not regress them while they are still inside the cooldown window.
+exclude-newer = "7 days"
+exclude-newer-package = {
+    fastmcp = false,
+    fastmcp-slim = false,
+    httpcore2 = false,
+    httpx2 = false,
+    "httpx2-jsfetch" = false,
+    nltk = false,
+    pydantic-settings = false,
+    ruff = false,
+    soupsieve = false,
+    starlette = false,
+}
 constraint-dependencies = ["fastmcp-slim==4.0.0b2"]
 dev-dependencies = [
 "pytest>=9.1.1",

--- a/renovate.json
+++ b/renovate.json
@@ -26,15 +26,10 @@
     "enabled": true,
     "labels": ["security", "priority-high"],
     "groupName": "Security Updates",
-    "schedule": ["at any time"]
+    "schedule": ["at any time"],
+    "minimumReleaseAge": null
   },
   "packageRules": [
-    {
-      "description": "Security updates bypass minimum release age",
-      "matchDatasources": ["pypi", "github-actions", "docker"],
-      "vulnerabilityAlerts": true,
-      "minimumReleaseAge": null
-    },
     {
       "description": "Group all Python development dependencies",
       "matchPackagePatterns": ["^pytest", "^black", "^ruff", "^mypy", "^pre-commit"],

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,8 @@
   ],
   "labels": ["dependencies", "renovate"],
   "enabledManagers": ["pip_requirements", "pip-compile", "poetry", "uv", "github-actions", "dockerfile"],
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
   "platformAutomerge": false,
   "automerge": false,
   "automergeType": "pr",
@@ -27,6 +29,12 @@
     "schedule": ["at any time"]
   },
   "packageRules": [
+    {
+      "description": "Security updates bypass minimum release age",
+      "matchDatasources": ["pypi", "github-actions", "docker"],
+      "vulnerabilityAlerts": true,
+      "minimumReleaseAge": null
+    },
     {
       "description": "Group all Python development dependencies",
       "matchPackagePatterns": ["^pytest", "^black", "^ruff", "^mypy", "^pre-commit"],

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,22 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+nltk = false
+pydantic-settings = false
+ruff = false
+starlette = false
+fastmcp = false
+httpx2-jsfetch = false
+soupsieve = false
+httpcore2 = false
+httpx2 = false
+fastmcp-slim = false
+
 [manifest]
 members = [
     "mcp-itsi-server",


### PR DESCRIPTION
## Summary
- Add uv `exclude-newer = "7 days"` with opt-outs for exact FastMCP pins and recent CVE/security bumps
- Set Renovate `minimumReleaseAge` / `internalChecksFilter` (security alerts bypass age)
- Add Dependabot `cooldown.default-days: 7` for pip, Actions, and Docker
- Document emergency lock bump path in `AGENTS.md`

Part of #233 P2 (PR-D). Follow-up: Actions SHA pinning (PR-E).

## Test plan
- [x] `uv lock --check`
- [ ] CI green
- [ ] Confirm Semgrep cooldown alerts (#533–#536, #567, #466–#468) clear after merge + rescan
