### PR TITLE
feat: advertise HTTP session mode for client discovery

### DIFF
--- a/docs/SESSION_MANAGEMENT.md
+++ b/docs/SESSION_MANAGEMENT.md
@@ -10,6 +10,10 @@ Streamable HTTP supports two client styles with this server:
 For copy-paste client configs, see
 **[HTTP Client Connection Modes](guides/configuration/http-client-modes.md)**.
 
+HTTP clients should `GET /health` and read `http.session_mode` (or
+`X-MCP-Session-Mode`) before `initialize`. `sessionless` means omit session
+ids. Missing fields mean an older server — send a stable `X-Session-ID`.
+
 ## Prefer a real MCP client
 
 Use FastMCP Client, Cursor, Claude Desktop, or MCP Inspector. They perform the

--- a/docs/guides/configuration/client_configuration.md
+++ b/docs/guides/configuration/client_configuration.md
@@ -254,9 +254,18 @@ Discover what your server supports via `/health`:
 ```json
 {
   "available_toolsets": ["itsi", "splunk"],
-  "loaded_plugins": [{"name": "itsi"}]
+  "loaded_plugins": [{"name": "itsi"}],
+  "server": {"version": "0.6.9", "session_mode": "sessionless"},
+  "http": {
+    "stateless": true,
+    "json_response": true,
+    "session_mode": "sessionless",
+    "client_api": 1
+  }
 }
 ```
+
+`http.session_mode` (and `X-MCP-Session-Mode`) tell HTTP clients whether to omit session ids. See [HTTP Client Connection Modes](http-client-modes.md#discover-session-mode-deslicer-ai-and-other-clients).
 
 ### Cursor IDE / Claude Desktop
 

--- a/docs/guides/configuration/http-client-modes.md
+++ b/docs/guides/configuration/http-client-modes.md
@@ -15,6 +15,53 @@ stable session key for config caching and sticky routing.
 Use a real MCP client library (FastMCP Client, Cursor, Claude Desktop, MCP
 Inspector). Prefer bearer tokens (`X-Splunk-Token`) over passwords for HTTP.
 
+## Discover session mode (Deslicer AI and other clients)
+
+Do **not** infer sessionless from package version alone. Published **0.6.8** is
+handshake-era; unreleased main also reported 0.6.8 after FastMCP 4.
+
+Probe `GET /health` on the same origin as `/mcp` (strip a trailing `/mcp`).
+Read the explicit flag, then fall back to session-scoped if anything is missing.
+
+```http
+GET /health HTTP/1.1
+```
+
+```json
+{
+  "status": "healthy",
+  "server": {
+    "name": "MCP Server for Splunk",
+    "version": "0.6.9",
+    "session_mode": "sessionless"
+  },
+  "http": {
+    "stateless": true,
+    "json_response": true,
+    "session_mode": "sessionless",
+    "client_api": 1
+  }
+}
+```
+
+Response headers (also present on `/mcp`):
+
+```http
+X-MCP-Server-Version: 0.6.9
+X-MCP-Session-Mode: sessionless
+```
+
+Client rule:
+
+1. If `http.session_mode` or `X-MCP-Session-Mode` is `sessionless`, omit session ids.
+2. If the value is `session` (operator set `MCP_STATELESS_HTTP=false`), send a stable `X-Session-ID`.
+3. If `/health` has no `http` block (older images), send a session id.
+4. If `/health` is unreachable, try sessionless first; on `Missing session ID`, retry with a session id.
+
+The MCP resource `info://server` carries the same `version` and `session_mode`
+after the client has already connected. Use `/health` to choose the mode
+**before** `initialize`.
+
 ## Sessionless mode (default)
 
 Local and Docker runs enable sessionless HTTP by default. The server does not

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -152,6 +152,13 @@ values:
 ```json
 {
   "available_toolsets": ["itsi", "splunk"],
-  "loaded_plugins": [{"name": "itsi"}]
+  "loaded_plugins": [{"name": "itsi"}],
+  "http": {
+    "session_mode": "sessionless",
+    "stateless": true,
+    "client_api": 1
+  }
 }
 ```
+
+`http.session_mode` is the client signal for sessionless vs session-scoped HTTP. See [HTTP Client Connection Modes](configuration/http-client-modes.md).

--- a/llms.txt
+++ b/llms.txt
@@ -10,6 +10,8 @@ Endpoint: `http(s)://HOST:PORT/mcp` (local default often `http://localhost:8003/
 
 Prefer a real MCP client (FastMCP Client, Cursor, Claude Desktop, MCP Inspector). Send Splunk credentials as headers on each request.
 
+Before connecting, `GET /health` (same origin as `/mcp`, strip `/mcp`). Use `http.session_mode` or the `X-MCP-Session-Mode` header. `sessionless` means omit session ids. `session` or a missing `http` block means send a stable `X-Session-ID`. Do not infer this from package version alone (published 0.6.8 is handshake-era).
+
 ### Sessionless (default)
 
 Server: `MCP_STATELESS_HTTP=true`, `MCP_JSON_RESPONSE=true`.

--- a/src/core/http_session_mode.py
+++ b/src/core/http_session_mode.py
@@ -1,0 +1,115 @@
+"""Advertise MCP HTTP session mode to clients.
+
+Deslicer AI (and other HTTP clients) probe ``GET /health`` before connecting.
+Package version alone is not enough: published 0.6.8 is handshake-era, while
+unreleased main also reports 0.6.8 after FastMCP 4. Clients must read the
+explicit ``session_mode`` flag (and matching response headers).
+"""
+
+from __future__ import annotations
+
+import os
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as package_version
+from pathlib import Path
+
+try:  # Python 3.11+
+    import tomllib  # type: ignore[attr-defined]
+except ImportError:  # Python 3.10 fallback
+    import tomli as tomllib  # type: ignore[no-redef]
+
+SESSION_MODE_SESSIONLESS = "sessionless"
+SESSION_MODE_SESSION = "session"
+CLIENT_API_VERSION = 1
+PACKAGE_DISTRIBUTION_NAME = "mcp-server-for-splunk"
+HEADER_SERVER_VERSION = "X-MCP-Server-Version"
+HEADER_SESSION_MODE = "X-MCP-Session-Mode"
+
+
+def env_flag_is_true(name: str, default: bool = True) -> bool:
+    """Return True when the named env var is the string ``true`` (case-insensitive)."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() == "true"
+
+
+def resolve_package_version() -> str:
+    """Return the installed package version, then pyproject.toml, then unknown."""
+    try:
+        return package_version(PACKAGE_DISTRIBUTION_NAME)
+    except PackageNotFoundError:
+        pass
+    from_toml = _version_from_pyproject()
+    return from_toml or "unknown"
+
+
+def _version_from_pyproject() -> str | None:
+    project_root = Path(__file__).resolve().parents[2]
+    pyproject_path = project_root / "pyproject.toml"
+    try:
+        with pyproject_path.open("rb") as handle:
+            data = tomllib.load(handle)
+        version = data.get("project", {}).get("version")
+        if isinstance(version, str) and version.strip():
+            return version.strip()
+    except Exception:
+        return None
+    return None
+
+
+class HttpSessionModeAdvertiser:
+    """Build the client-discovery payload and response headers for one process."""
+
+    def __init__(
+        self,
+        *,
+        version: str,
+        stateless_http: bool,
+        json_response: bool,
+    ) -> None:
+        self.version = version
+        self.stateless_http = stateless_http
+        self.json_response = json_response
+
+    @classmethod
+    def from_env(cls) -> HttpSessionModeAdvertiser:
+        """Snapshot version and HTTP flags from the current process environment."""
+        return cls(
+            version=resolve_package_version(),
+            stateless_http=env_flag_is_true("MCP_STATELESS_HTTP", True),
+            json_response=env_flag_is_true("MCP_JSON_RESPONSE", True),
+        )
+
+    @property
+    def session_mode(self) -> str:
+        """Return ``sessionless`` when Streamable HTTP does not require sticky ids."""
+        if self.stateless_http:
+            return SESSION_MODE_SESSIONLESS
+        return SESSION_MODE_SESSION
+
+    def as_health_http_block(self) -> dict[str, object]:
+        """Return the ``http`` object nested under ``GET /health``."""
+        return {
+            "stateless": self.stateless_http,
+            "json_response": self.json_response,
+            "session_mode": self.session_mode,
+            "client_api": CLIENT_API_VERSION,
+        }
+
+    def as_response_headers(self) -> dict[str, str]:
+        """Return headers clients can read without parsing the JSON body."""
+        return {
+            HEADER_SERVER_VERSION: self.version,
+            HEADER_SESSION_MODE: self.session_mode,
+        }
+
+    def as_server_info_fields(self) -> dict[str, object]:
+        """Return fields merged into the ``info://server`` resource."""
+        return {
+            "version": self.version,
+            "session_mode": self.session_mode,
+            "stateless_http": self.stateless_http,
+            "json_response": self.json_response,
+            "client_api": CLIENT_API_VERSION,
+        }

--- a/src/core/http_session_mode_middleware.py
+++ b/src/core/http_session_mode_middleware.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
@@ -21,7 +23,7 @@ class HttpSessionModeHeaderMiddleware(BaseHTTPMiddleware):
         self._advertiser = advertiser or HttpSessionModeAdvertiser.from_env()
 
     async def dispatch(self, request: Request, call_next) -> Response:
-        response = await call_next(request)
+        response = cast(Response, await call_next(request))
         for header_name, header_value in self._advertiser.as_response_headers().items():
             response.headers[header_name] = header_value
         return response

--- a/src/core/http_session_mode_middleware.py
+++ b/src/core/http_session_mode_middleware.py
@@ -1,0 +1,27 @@
+"""Attach session-mode discovery headers to every HTTP response."""
+
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from src.core.http_session_mode import HttpSessionModeAdvertiser
+
+
+class HttpSessionModeHeaderMiddleware(BaseHTTPMiddleware):
+    """Add ``X-MCP-Server-Version`` and ``X-MCP-Session-Mode`` on responses."""
+
+    def __init__(
+        self,
+        app,
+        advertiser: HttpSessionModeAdvertiser | None = None,
+    ) -> None:
+        super().__init__(app)
+        self._advertiser = advertiser or HttpSessionModeAdvertiser.from_env()
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        response = await call_next(request)
+        for header_name, header_value in self._advertiser.as_response_headers().items():
+            response.headers[header_name] = header_value
+        return response

--- a/src/routes/health.py
+++ b/src/routes/health.py
@@ -6,16 +6,13 @@ component loading, and Splunk connectivity.
 """
 
 import logging
-import os
 import time
 
-try:  # Python 3.11+
-    import tomllib  # type: ignore[attr-defined]
-except Exception:  # Python 3.10 fallback
-    import tomli as tomllib  # type: ignore[no-redef]
 from fastmcp import FastMCP
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse
+
+from src.core.http_session_mode import HttpSessionModeAdvertiser, resolve_package_version
 
 from .templates import load_css, load_template, render_template
 
@@ -23,16 +20,8 @@ logger = logging.getLogger(__name__)
 
 
 def get_version() -> str:
-    """Get version from pyproject.toml"""
-    try:
-        project_root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-        pyproject_path = os.path.join(project_root, "pyproject.toml")
-        with open(pyproject_path, "rb") as f:
-            pyproject_data = tomllib.load(f)
-            return pyproject_data.get("project", {}).get("version", "unknown")
-    except Exception as e:
-        logger.debug(f"Could not read version from pyproject.toml: {e}")
-        return "unknown"  # fallback
+    """Return the MCP server package version for health pages and JSON."""
+    return resolve_package_version()
 
 
 def get_component_counts(mcp_server: FastMCP) -> tuple[int, int, int]:
@@ -253,19 +242,28 @@ def setup_health_routes(mcp: FastMCP):
                 {"splunk"} | {p["name"] for p in loaded_plugins if "name" in p}
             )
 
+            advertiser = HttpSessionModeAdvertiser.from_env()
+            http_block = advertiser.as_health_http_block()
+            server_info_data["session_mode"] = advertiser.session_mode
+
             return JSONResponse(
                 {
                     "status": "healthy",
                     "server": server_info_data,
+                    "http": http_block,
                     "splunk_connection": splunk_status,
                     "splunk_info": splunk_info,
                     "loaded_plugins": loaded_plugins,
                     "available_toolsets": available_toolsets,
                     "timestamp": time.time(),
-                }
+                },
+                headers=advertiser.as_response_headers(),
             )
         except Exception as e:
             logger.error(f"Error in health_api: {e}")
+            advertiser = HttpSessionModeAdvertiser.from_env()
             return JSONResponse(
-                {"status": "error", "error": str(e), "timestamp": time.time()}, status_code=500
+                {"status": "error", "error": str(e), "timestamp": time.time()},
+                status_code=500,
+                headers=advertiser.as_response_headers(),
             )

--- a/src/routes/health.py
+++ b/src/routes/health.py
@@ -85,15 +85,22 @@ def get_splunk_status(mcp_server: FastMCP) -> tuple[str, str, str]:
     return splunk_status, splunk_server_name, splunk_version
 
 
-def setup_health_routes(mcp: FastMCP):
-    """Setup health routes for the MCP server"""
+def setup_health_routes(
+    mcp: FastMCP,
+    advertiser: HttpSessionModeAdvertiser | None = None,
+) -> None:
+    """Setup health routes for the MCP server.
+
+    ``advertiser`` should be the process snapshot used for Streamable HTTP
+    so ``/health`` cannot drift from runtime ``MCP_STATELESS_HTTP``.
+    """
+    http_mode = advertiser or HttpSessionModeAdvertiser.from_env()
 
     @mcp.custom_route("/", methods=["GET"])
     async def health_page(request: Request) -> HTMLResponse:
         """Server health page at root URL with real server data"""
         try:
-            # Get real version from pyproject.toml
-            version = get_version()
+            version = http_mode.version
 
             # Get component counts from stored results
             tools_count, resources_count, prompts_count = get_component_counts(mcp)
@@ -174,8 +181,7 @@ def setup_health_routes(mcp: FastMCP):
     async def health_api(request: Request) -> JSONResponse:
         """API endpoint for health checks with real data"""
         try:
-            # Get real version from pyproject.toml
-            version = get_version()
+            version = http_mode.version
 
             # Get component counts from stored results
             tools_count, resources_count, prompts_count = get_component_counts(mcp)
@@ -242,9 +248,8 @@ def setup_health_routes(mcp: FastMCP):
                 {"splunk"} | {p["name"] for p in loaded_plugins if "name" in p}
             )
 
-            advertiser = HttpSessionModeAdvertiser.from_env()
-            http_block = advertiser.as_health_http_block()
-            server_info_data["session_mode"] = advertiser.session_mode
+            http_block = http_mode.as_health_http_block()
+            server_info_data["session_mode"] = http_mode.session_mode
 
             return JSONResponse(
                 {
@@ -257,13 +262,12 @@ def setup_health_routes(mcp: FastMCP):
                     "available_toolsets": available_toolsets,
                     "timestamp": time.time(),
                 },
-                headers=advertiser.as_response_headers(),
+                headers=http_mode.as_response_headers(),
             )
         except Exception as e:
             logger.error(f"Error in health_api: {e}")
-            advertiser = HttpSessionModeAdvertiser.from_env()
             return JSONResponse(
                 {"status": "error", "error": str(e), "timestamp": time.time()},
                 status_code=500,
-                headers=advertiser.as_response_headers(),
+                headers=http_mode.as_response_headers(),
             )

--- a/src/server.py
+++ b/src/server.py
@@ -613,7 +613,7 @@ mcp = FastMCP(
 )
 
 # Import and setup health routes
-setup_health_routes(mcp)
+setup_health_routes(mcp, advertiser=HTTP_SESSION_MODE)
 
 # NOTE: Plugins are loaded once after the Starlette app is created so plugins can
 # register both MCP-level and HTTP-level integrations in a single call.
@@ -936,7 +936,6 @@ def health_check_resource() -> str:
 @mcp.resource("info://server")
 def server_info() -> str:
     """Server information and capabilities"""
-    advertiser = HttpSessionModeAdvertiser.from_env()
     payload = {
         "name": "MCP Server for Splunk",
         "transport": "http",
@@ -944,7 +943,7 @@ def server_info() -> str:
         "description": "Modular MCP Server providing Splunk integration",
         "status": "running",
     }
-    payload.update(advertiser.as_server_info_fields())
+    payload.update(HTTP_SESSION_MODE.as_server_info_fields())
     return json.dumps(payload)
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -32,6 +32,8 @@ from src.core.client_config_cache import (
     ClientConfigCacheKeyResolver,
     normalize_header_token,
 )
+from src.core.http_session_mode import HttpSessionModeAdvertiser
+from src.core.http_session_mode_middleware import HttpSessionModeHeaderMiddleware
 from src.core.loader import ComponentLoader
 from src.core.otel import (
     OtelJsonFormatter,
@@ -601,8 +603,14 @@ else:
 STATELESS_HTTP = os.getenv("MCP_STATELESS_HTTP", "true").strip().lower() == "true"
 JSON_RESPONSE = os.getenv("MCP_JSON_RESPONSE", "true").strip().lower() == "true"
 HOST_ORIGIN_PROTECTION = os.getenv("FASTMCP_HTTP_HOST_ORIGIN_PROTECTION", "auto")
+HTTP_SESSION_MODE = HttpSessionModeAdvertiser.from_env()
 
-mcp = FastMCP(name="MCP Server for Splunk", auth=auth_verifier, lifespan=splunk_lifespan)
+mcp = FastMCP(
+    name="MCP Server for Splunk",
+    version=HTTP_SESSION_MODE.version,
+    auth=auth_verifier,
+    lifespan=splunk_lifespan,
+)
 
 # Import and setup health routes
 setup_health_routes(mcp)
@@ -842,13 +850,6 @@ if _otel_enabled:
         logger.warning("Failed to add OpenTelemetry MCP middleware: %s", e)
 
 
-# Health check endpoint for Docker using custom route (recommended pattern)
-@mcp.custom_route("/health", methods=["GET"])
-async def health_check(request) -> JSONResponse:
-    """Health check endpoint for Docker and load balancers"""
-    return JSONResponse({"status": "OK", "service": "MCP for Splunk"})
-
-
 # Sentry test endpoint for verifying integration
 @mcp.custom_route("/sentry-test", methods=["GET"])
 async def sentry_test_endpoint(request) -> JSONResponse:
@@ -935,14 +936,16 @@ def health_check_resource() -> str:
 @mcp.resource("info://server")
 def server_info() -> str:
     """Server information and capabilities"""
-    return json.dumps({
+    advertiser = HttpSessionModeAdvertiser.from_env()
+    payload = {
         "name": "MCP Server for Splunk",
-        "version": "2.0.0",
         "transport": "http",
         "capabilities": ["tools", "resources", "prompts"],
         "description": "Modular MCP Server providing Splunk integration",
         "status": "running",
-    })
+    }
+    payload.update(advertiser.as_server_info_fields())
+    return json.dumps(payload)
 
 
 # Hot reload endpoint for development
@@ -1204,6 +1207,7 @@ def create_root_app(server: FastMCP) -> Starlette:
     # Parent Starlette application that applies middleware to the initial HTTP handshake
     root_app = Starlette(lifespan=mcp_app.lifespan)
     root_app.add_middleware(HeaderCaptureMiddleware)
+    root_app.add_middleware(HttpSessionModeHeaderMiddleware, advertiser=HTTP_SESSION_MODE)
 
     # Instrument the app for OpenTelemetry: extract the W3C traceparent on
     # incoming requests (server spans) and emit httpx client child spans.

--- a/tests/test_health_routes.py
+++ b/tests/test_health_routes.py
@@ -54,3 +54,35 @@ def test_health_api_handles_missing_loaded_plugins_attribute():
     body = resp.json()
     assert body.get("loaded_plugins") == []
     assert body.get("available_toolsets") == ["splunk"]
+
+
+def test_health_api_advertises_sessionless_http_by_default():
+    mcp = FastMCP(name="HealthTestSessionMode")
+    client = TestClient(_build_app(mcp))
+    resp = client.get("/health")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    http_block = body.get("http") or {}
+    assert http_block.get("session_mode") == "sessionless"
+    assert http_block.get("stateless") is True
+    assert http_block.get("json_response") is True
+    assert http_block.get("client_api") == 1
+    assert body.get("server", {}).get("version")
+    assert body["server"]["version"] != "unknown"
+    assert body["server"].get("session_mode") == "sessionless"
+    assert resp.headers.get("X-MCP-Session-Mode") == "sessionless"
+    assert resp.headers.get("X-MCP-Server-Version") == body["server"]["version"]
+
+
+def test_health_api_advertises_session_mode_when_stateless_disabled(monkeypatch):
+    monkeypatch.setenv("MCP_STATELESS_HTTP", "false")
+    mcp = FastMCP(name="HealthTestStateful")
+    client = TestClient(_build_app(mcp))
+    resp = client.get("/health")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["http"]["session_mode"] == "session"
+    assert body["http"]["stateless"] is False
+    assert resp.headers.get("X-MCP-Session-Mode") == "session"

--- a/tests/test_health_routes.py
+++ b/tests/test_health_routes.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from fastmcp import FastMCP
 from starlette.testclient import TestClient
 
+from src.core.http_session_mode import HttpSessionModeAdvertiser
 from src.routes.health import setup_health_routes
 
 
@@ -86,3 +87,23 @@ def test_health_api_advertises_session_mode_when_stateless_disabled(monkeypatch)
     assert body["http"]["session_mode"] == "session"
     assert body["http"]["stateless"] is False
     assert resp.headers.get("X-MCP-Session-Mode") == "session"
+
+
+def test_health_api_uses_injected_advertiser_not_live_env(monkeypatch):
+    monkeypatch.setenv("MCP_STATELESS_HTTP", "true")
+    mcp = FastMCP(name="HealthTestInjectedAdvertiser")
+    advertiser = HttpSessionModeAdvertiser(
+        version="9.9.9-test",
+        stateless_http=False,
+        json_response=True,
+    )
+    setup_health_routes(mcp, advertiser=advertiser)
+    client = TestClient(mcp.http_app())
+    resp = client.get("/health")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["http"]["session_mode"] == "session"
+    assert body["server"]["version"] == "9.9.9-test"
+    assert resp.headers.get("X-MCP-Session-Mode") == "session"
+    assert resp.headers.get("X-MCP-Server-Version") == "9.9.9-test"

--- a/tests/test_http_session_mode.py
+++ b/tests/test_http_session_mode.py
@@ -1,0 +1,64 @@
+"""Client-discovery payload for sessionless vs session-scoped HTTP."""
+
+from __future__ import annotations
+
+from src.core.http_session_mode import (
+    CLIENT_API_VERSION,
+    HEADER_SERVER_VERSION,
+    HEADER_SESSION_MODE,
+    SESSION_MODE_SESSION,
+    SESSION_MODE_SESSIONLESS,
+    HttpSessionModeAdvertiser,
+    env_flag_is_true,
+)
+
+
+def test_env_flag_is_true_defaults_and_parses_true_false(monkeypatch) -> None:
+    monkeypatch.delenv("MCP_STATELESS_HTTP", raising=False)
+    assert env_flag_is_true("MCP_STATELESS_HTTP", True) is True
+    monkeypatch.setenv("MCP_STATELESS_HTTP", "false")
+    assert env_flag_is_true("MCP_STATELESS_HTTP", True) is False
+    monkeypatch.setenv("MCP_STATELESS_HTTP", "TRUE")
+    assert env_flag_is_true("MCP_STATELESS_HTTP", True) is True
+
+
+def test_advertiser_defaults_to_sessionless() -> None:
+    advertiser = HttpSessionModeAdvertiser(
+        version="0.6.9",
+        stateless_http=True,
+        json_response=True,
+    )
+    assert advertiser.session_mode == SESSION_MODE_SESSIONLESS
+    assert advertiser.as_health_http_block() == {
+        "stateless": True,
+        "json_response": True,
+        "session_mode": SESSION_MODE_SESSIONLESS,
+        "client_api": CLIENT_API_VERSION,
+    }
+    headers = advertiser.as_response_headers()
+    assert headers[HEADER_SERVER_VERSION] == "0.6.9"
+    assert headers[HEADER_SESSION_MODE] == SESSION_MODE_SESSIONLESS
+
+
+def test_advertiser_session_mode_when_stateless_disabled() -> None:
+    advertiser = HttpSessionModeAdvertiser(
+        version="0.6.9",
+        stateless_http=False,
+        json_response=False,
+    )
+    assert advertiser.session_mode == SESSION_MODE_SESSION
+    block = advertiser.as_health_http_block()
+    assert block["stateless"] is False
+    assert block["session_mode"] == SESSION_MODE_SESSION
+    assert advertiser.as_response_headers()[HEADER_SESSION_MODE] == SESSION_MODE_SESSION
+
+
+def test_from_env_reads_stateless_flag(monkeypatch) -> None:
+    monkeypatch.setenv("MCP_STATELESS_HTTP", "false")
+    monkeypatch.setenv("MCP_JSON_RESPONSE", "false")
+    advertiser = HttpSessionModeAdvertiser.from_env()
+    assert advertiser.stateless_http is False
+    assert advertiser.json_response is False
+    assert advertiser.session_mode == SESSION_MODE_SESSION
+    assert advertiser.version
+    assert advertiser.version != "unknown"

--- a/tests/test_http_session_mode_middleware.py
+++ b/tests/test_http_session_mode_middleware.py
@@ -1,0 +1,32 @@
+"""Response headers advertise session mode on every HTTP response."""
+
+from __future__ import annotations
+
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from src.core.http_session_mode import HttpSessionModeAdvertiser
+from src.core.http_session_mode_middleware import HttpSessionModeHeaderMiddleware
+
+
+async def _ok(_request):
+    return JSONResponse({"ok": True})
+
+
+def test_middleware_sets_discovery_headers_on_json_response():
+    advertiser = HttpSessionModeAdvertiser(
+        version="0.6.9-test",
+        stateless_http=True,
+        json_response=True,
+    )
+    app = Starlette(routes=[Route("/mcp", _ok, methods=["POST"])])
+    app.add_middleware(HttpSessionModeHeaderMiddleware, advertiser=advertiser)
+    client = TestClient(app)
+
+    resp = client.post("/mcp", json={})
+
+    assert resp.status_code == 200
+    assert resp.headers["X-MCP-Server-Version"] == "0.6.9-test"
+    assert resp.headers["X-MCP-Session-Mode"] == "sessionless"

--- a/tests/test_mcp_server_comprehensive.py
+++ b/tests/test_mcp_server_comprehensive.py
@@ -72,7 +72,9 @@ class TestMCPServerCore:
         info = json.loads(content_text)
 
         assert info["name"] == "MCP Server for Splunk"
-        assert info["version"] == "2.0.0"
+        assert info["version"]
+        assert info["version"] != "2.0.0"
+        assert info["session_mode"] in {"sessionless", "session"}
         assert info["transport"] == "http"
         assert "tools" in info["capabilities"]
         assert "resources" in info["capabilities"]
@@ -895,6 +897,7 @@ class TestServerConfiguration:
 
         assert info["name"] == "MCP Server for Splunk"
         assert info["transport"] == "http"
+        assert info["session_mode"] in {"sessionless", "session"}
         assert "tools" in info["capabilities"]
         assert "resources" in info["capabilities"]
         assert "prompts" in info["capabilities"]


### PR DESCRIPTION
## Summary
- Advertise an explicit `http.session_mode` on `GET /health` plus `X-MCP-Server-Version` / `X-MCP-Session-Mode` headers (also on `/mcp`) so Deslicer AI can choose sessionless vs session-id without inferring from the package version.
- Align `info://server` and FastMCP `serverInfo.version` with the real package version (drop the hardcoded `2.0.0`).
- Document the client discovery rule: sessionless when the flag is present; fall back to a stable `X-Session-ID` on older images.

## Test plan
- [ ] `uv run pytest tests/test_http_session_mode.py tests/test_http_session_mode_middleware.py tests/test_health_routes.py -q`
- [ ] Confirm `GET /health` returns `http.session_mode` and the two discovery headers
- [ ] Confirm `MCP_STATELESS_HTTP=false` advertises `session`
- [ ] Confirm `info://server` reports a real version and `session_mode`