### PR TITLE
Add create, update, and delete Splunk alert tools

### DIFF
--- a/scripts/test_alert_tools_mcp_client.py
+++ b/scripts/test_alert_tools_mcp_client.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""
+Exercise alert tools through a real FastMCP Client (not tool.execute).
+
+Credentials via env (never hard-coded):
+  SPLUNK_HOST, SPLUNK_PORT, SPLUNK_SCHEME, SPLUNK_VERIFY_SSL
+  and either SPLUNK_TOKEN or SPLUNK_USERNAME + SPLUNK_PASSWORD
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+import uuid
+from typing import Any
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+
+def _require_creds() -> None:
+    if not os.environ.get("SPLUNK_HOST", "").strip():
+        raise SystemExit("SPLUNK_HOST is required")
+    token = os.environ.get("SPLUNK_TOKEN", "").strip()
+    user = os.environ.get("SPLUNK_USERNAME", "").strip()
+    password = os.environ.get("SPLUNK_PASSWORD", "")
+    if not token and not (user and password):
+        raise SystemExit("Provide SPLUNK_TOKEN or SPLUNK_USERNAME+SPLUNK_PASSWORD")
+
+
+def _extract(result: Any) -> Any:
+    if getattr(result, "data", None) is not None:
+        return result.data
+    if getattr(result, "structured_content", None) is not None:
+        return result.structured_content
+    texts = [
+        getattr(c, "text", None)
+        for c in (getattr(result, "content", None) or [])
+        if getattr(c, "text", None)
+    ]
+    if not texts:
+        return None
+    try:
+        return json.loads(texts[0])
+    except Exception:
+        return texts[0]
+
+
+async def _call(client: Any, name: str, args: dict[str, Any] | None = None) -> Any:
+    started = time.perf_counter()
+    raw = await client.call_tool(name, args or {})
+    elapsed_ms = int((time.perf_counter() - started) * 1000)
+    payload = _extract(raw)
+    is_error = bool(getattr(raw, "is_error", False) or getattr(raw, "isError", False))
+    status = "FAIL" if is_error else "PASS"
+    if isinstance(payload, dict) and payload.get("status") == "error" and not is_error:
+        status = "FAIL"
+    print(f"[{status}] {name} ({elapsed_ms}ms)")
+    if status == "FAIL":
+        print(f"      {payload}")
+    return payload, status
+
+
+def _ok(payload: Any) -> bool:
+    return isinstance(payload, dict) and payload.get("status") == "success"
+
+
+async def main() -> int:
+    _require_creds()
+    os.environ.setdefault("MCP_AUTH_DISABLED", "true")
+    os.environ.setdefault("SPLUNK_CONNECT_RETRY_COUNT", "1")
+    os.environ.setdefault("SPLUNK_CONNECT_RETRY_BASE_DELAY", "0")
+
+    temp_name = f"mcp_cli_alert_{uuid.uuid4().hex[:8]}"
+    outcomes: list[tuple[str, str]] = []
+
+    from fastmcp import Client
+
+    from src.server import mcp
+
+    async with Client(mcp) as client:
+        print("MCP client connected (in-memory transport → live Splunk via server env)")
+        tools = await client.list_tools()
+        tool_names = {t.name for t in tools}
+        required = {
+            "list_alert_actions",
+            "create_alert",
+            "update_alert",
+            "delete_alert",
+            "get_saved_search_details",
+            "list_triggered_alerts",
+        }
+        missing = sorted(required - tool_names)
+        if missing:
+            print(f"Missing tools on server: {missing}")
+            return 1
+        print(f"Alert tools present: {sorted(required)}")
+
+        payload, status = await _call(client, "list_alert_actions")
+        outcomes.append(("list_alert_actions", status))
+        if not _ok(payload):
+            return 1
+        action_entries = payload.get("alert_actions") or []
+        action_names = [a.get("name") for a in action_entries]
+        print(f"      installed actions ({payload.get('count')}): {action_names[:12]}")
+        custom = [a for a in action_entries if a.get("is_custom")]
+        if custom:
+            sample = custom[0]
+            print(
+                f"      custom sample: {sample.get('name')} "
+                f"params={sample.get('param_keys')}"
+            )
+
+        create_actions: list[dict[str, Any]] = []
+        if "email" in action_names:
+            create_actions.append(
+                {
+                    "name": "email",
+                    "params": {
+                        "to": "mcp-test@splunk.com",
+                        "subject": "MCP alert",
+                    },
+                }
+            )
+        if "rss" in action_names:
+            create_actions.append({"name": "rss", "params": {}})
+        payload, status = await _call(
+            client,
+            "create_alert",
+            {
+                "name": temp_name,
+                "search": "index=_internal | head 1",
+                "description": "MCP client alert probe",
+                "cron_schedule": "0 0 1 1 *",
+                "earliest_time": "-15m",
+                "latest_time": "now",
+                "app": "search",
+                "sharing": "user",
+                "alert_type": "number of events",
+                "alert_comparator": "greater than",
+                "alert_threshold": "999999",
+                "alert_track": True,
+                "actions": create_actions,
+            },
+        )
+        outcomes.append(("create_alert", status))
+        created = _ok(payload)
+        if created:
+            print(f"      created {temp_name} actions={create_actions}")
+
+        try:
+            if created:
+                details, status = await _call(
+                    client,
+                    "get_saved_search_details",
+                    {"name": temp_name, "app": "search"},
+                )
+                outcomes.append(("get_saved_search_details", status))
+                if _ok(details):
+                    alert = (details.get("details") or {}).get("alert") or {}
+                    print(f"      alert config: {alert}")
+
+                payload, status = await _call(
+                    client,
+                    "update_alert",
+                    {
+                        "name": temp_name,
+                        "app": "search",
+                        "actions_mode": "patch",
+                        "description": "MCP client alert probe (patched)",
+                        "alert_threshold": "888888",
+                    },
+                )
+                outcomes.append(("update_alert(patch scalars)", status))
+
+                if any(item["name"] == "email" for item in create_actions):
+                    payload, status = await _call(
+                        client,
+                        "update_alert",
+                        {
+                            "name": temp_name,
+                            "app": "search",
+                            "actions_mode": "patch",
+                            "actions": [
+                                {
+                                    "name": "email",
+                                    "params": {"subject": "MCP alert patched"},
+                                }
+                            ],
+                        },
+                    )
+                    outcomes.append(("update_alert(patch email.subject)", status))
+
+                if "deslicer_investigate" in action_names:
+                    payload, status = await _call(
+                        client,
+                        "update_alert",
+                        {
+                            "name": temp_name,
+                            "app": "search",
+                            "actions_mode": "patch",
+                            "actions": [{"name": "deslicer_investigate", "params": {}}],
+                        },
+                    )
+                    outcomes.append(("update_alert(patch custom action)", status))
+
+                payload, status = await _call(
+                    client,
+                    "update_alert",
+                    {
+                        "name": temp_name,
+                        "app": "search",
+                        "actions_mode": "override",
+                        "actions": [{"name": "rss", "params": {}}],
+                    },
+                )
+                outcomes.append(("update_alert(override rss only)", status))
+
+            payload, status = await _call(
+                client, "list_triggered_alerts", {"count": 5, "earliest_time": "-1h"}
+            )
+            outcomes.append(("list_triggered_alerts", status))
+        finally:
+            if created:
+                payload, status = await _call(
+                    client,
+                    "delete_alert",
+                    {"name": temp_name, "app": "search", "confirm": True},
+                )
+                outcomes.append(("delete_alert", status))
+            else:
+                outcomes.append(("delete_alert", "SKIP"))
+
+    print("\n=== Alert MCP client summary ===")
+    failed = 0
+    for name, status in outcomes:
+        print(f"  {status:4}  {name}")
+        if status != "PASS" and status != "SKIP":
+            failed += 1
+    print(f"Failed: {failed}/{len(outcomes)}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -41,6 +41,10 @@ __all__ = [
     "ToolDescriptionEnhancer",
     # Alerts tools
     "ListTriggeredAlerts",
+    "ListAlertActions",
+    "CreateAlert",
+    "UpdateAlert",
+    "DeleteAlert",
     # KV Store tools
     "ListKvstoreCollections",
     "GetKvstoreData",

--- a/src/tools/alerts/__init__.py
+++ b/src/tools/alerts/__init__.py
@@ -2,9 +2,20 @@
 Alerts management tools for Splunk MCP Server.
 
 This module provides tools for managing and querying Splunk alerts including
-listing triggered alerts, alert status monitoring, and alert configuration.
+listing triggered alerts, discovering alert actions, and creating, updating,
+and deleting alerts.
 """
 
 from .alerts import ListTriggeredAlerts
+from .create_alert import CreateAlert
+from .delete_alert import DeleteAlert
+from .list_alert_actions import ListAlertActions
+from .update_alert import UpdateAlert
 
-__all__ = ["ListTriggeredAlerts"]
+__all__ = [
+    "ListTriggeredAlerts",
+    "ListAlertActions",
+    "CreateAlert",
+    "UpdateAlert",
+    "DeleteAlert",
+]

--- a/src/tools/alerts/alert_action_catalog.py
+++ b/src/tools/alerts/alert_action_catalog.py
@@ -1,0 +1,73 @@
+"""Discover installed Splunk alert actions via REST."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+SKIP_CONTENT_KEYS = frozenset(
+    {
+        "eai:acl",
+        "eai:appName",
+        "eai:userName",
+        "disabled",
+        "label",
+        "description",
+        "is_custom",
+        "icon_path",
+        "payload_format",
+        "command",
+        "python.version",
+        "filename",
+        "track_alert",
+        "ttl",
+        "maxtime",
+        "maxresults",
+    }
+)
+
+
+class AlertActionCatalog:
+    """List alert actions installed on a connected Splunk instance."""
+
+    def list_actions(self, service: Any) -> list[dict[str, Any]]:
+        response = service.get("alerts/alert_actions", output_mode="json", count=0)
+        payload = json.loads(response.body.read())
+        actions: list[dict[str, Any]] = []
+        for entry in payload.get("entry", []):
+            content = entry.get("content") or {}
+            acl = entry.get("acl") or {}
+            actions.append(
+                {
+                    "name": entry.get("name", ""),
+                    "label": content.get("label") or entry.get("name", ""),
+                    "description": content.get("description", ""),
+                    "is_custom": self._is_true(content.get("is_custom")),
+                    "app": acl.get("app", ""),
+                    "param_keys": self._param_keys(content),
+                }
+            )
+        return actions
+
+    def names(self, service: Any) -> set[str]:
+        return {action["name"] for action in self.list_actions(service) if action.get("name")}
+
+    def unknown_actions(self, service: Any, requested: list[str]) -> list[str]:
+        available = self.names(service)
+        return [name for name in requested if name not in available]
+
+    def _param_keys(self, content: dict[str, Any]) -> list[str]:
+        keys: list[str] = []
+        for key in content:
+            if key in SKIP_CONTENT_KEYS:
+                continue
+            if key.startswith("param.") or key.startswith("action."):
+                keys.append(key)
+        return sorted(keys)
+
+    def _is_true(self, value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.lower() in ("1", "true", "yes", "on")
+        return False

--- a/src/tools/alerts/alert_action_settings.py
+++ b/src/tools/alerts/alert_action_settings.py
@@ -1,0 +1,154 @@
+"""Map structured alert-action payloads to Splunk saved-search fields."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+FLAT_BUILTIN_ACTIONS = frozenset(
+    {
+        "email",
+        "rss",
+        "script",
+        "populate_lookup",
+        "summary_index",
+    }
+)
+
+
+class AlertActionSettings:
+    """Convert MCP action lists into Splunk `action.*` saved-search fields."""
+
+    def parse_actions(self, raw: Any) -> list[dict[str, Any]]:
+        payload = self._load_payload(raw)
+        parsed: list[dict[str, Any]] = []
+        for index, item in enumerate(payload):
+            parsed.append(self._parse_action_item(item, index))
+        return parsed
+
+    def splunk_fields(
+        self,
+        actions: list[dict[str, Any]],
+        *,
+        include_actions_csv: bool = True,
+    ) -> dict[str, str]:
+        fields: dict[str, str] = {}
+        enabled_names: list[str] = []
+        for item in actions:
+            name = item["name"]
+            enabled = bool(item.get("enabled", True))
+            fields[f"action.{name}"] = "1" if enabled else "0"
+            if enabled:
+                enabled_names.append(name)
+            fields.update(self._param_fields(name, item.get("params") or {}))
+        if include_actions_csv:
+            fields["actions"] = ",".join(enabled_names)
+        return fields
+
+    def enabled_names_from_content(self, content: dict[str, Any] | None) -> list[str]:
+        source = content or {}
+        names: list[str] = []
+        seen: set[str] = set()
+        csv_value = source.get("actions") or ""
+        if isinstance(csv_value, str):
+            for name in csv_value.split(","):
+                cleaned = name.strip()
+                if cleaned and cleaned not in seen:
+                    names.append(cleaned)
+                    seen.add(cleaned)
+        for key, value in source.items():
+            if not self._is_action_toggle_key(key) or not self._is_true(value):
+                continue
+            name = key.split(".", 1)[1]
+            if name not in seen:
+                names.append(name)
+                seen.add(name)
+        return names
+
+    def patch_fields(
+        self,
+        current_content: dict[str, Any] | None,
+        actions: list[dict[str, Any]],
+    ) -> dict[str, str]:
+        enabled = list(self.enabled_names_from_content(current_content))
+        fields: dict[str, str] = {}
+        for item in actions:
+            name = item["name"]
+            is_enabled = bool(item.get("enabled", True))
+            fields[f"action.{name}"] = "1" if is_enabled else "0"
+            enabled = self._adjust_enabled_names(enabled, name, is_enabled)
+            fields.update(self._param_fields(name, item.get("params") or {}))
+        fields["actions"] = ",".join(enabled)
+        return fields
+
+    def override_fields(
+        self,
+        current_content: dict[str, Any] | None,
+        actions: list[dict[str, Any]],
+    ) -> dict[str, str]:
+        fields = self.splunk_fields(actions, include_actions_csv=True)
+        new_enabled = {item["name"] for item in actions if item.get("enabled", True)}
+        for name in self.enabled_names_from_content(current_content):
+            if name not in new_enabled:
+                fields[f"action.{name}"] = "0"
+        return fields
+
+    def param_field_name(self, action_name: str, key: str) -> str:
+        if "." in key:
+            return f"action.{action_name}.{key}"
+        if action_name in FLAT_BUILTIN_ACTIONS:
+            return f"action.{action_name}.{key}"
+        return f"action.{action_name}.param.{key}"
+
+    def _load_payload(self, raw: Any) -> list[Any]:
+        if raw is None:
+            return []
+        if isinstance(raw, str):
+            raw = json.loads(raw) if raw.strip() else []
+        if not isinstance(raw, list):
+            raise ValueError("actions must be a list of {name, params, enabled}")
+        return raw
+
+    def _parse_action_item(self, item: Any, index: int) -> dict[str, Any]:
+        if not isinstance(item, dict):
+            raise ValueError(f"actions[{index}] must be an object with a name")
+        name = str(item.get("name") or "").strip()
+        if not name:
+            raise ValueError(f"actions[{index}].name is required")
+        params = item.get("params") or {}
+        if isinstance(params, str):
+            params = json.loads(params) if params.strip() else {}
+        if not isinstance(params, dict):
+            raise ValueError(f"actions[{index}].params must be an object")
+        return {
+            "name": name,
+            "params": dict(params),
+            "enabled": bool(item.get("enabled", True)),
+        }
+
+    def _param_fields(self, action_name: str, params: dict[str, Any]) -> dict[str, str]:
+        return {
+            self.param_field_name(action_name, str(key)): "" if value is None else str(value)
+            for key, value in params.items()
+        }
+
+    def _adjust_enabled_names(
+        self, enabled: list[str], name: str, is_enabled: bool
+    ) -> list[str]:
+        if is_enabled:
+            if name not in enabled:
+                enabled.append(name)
+            return enabled
+        return [existing for existing in enabled if existing != name]
+
+    def _is_action_toggle_key(self, key: str) -> bool:
+        return key.startswith("action.") and key.count(".") == 1
+
+    def _is_true(self, value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.lower() in ("1", "true", "yes", "on")
+        if isinstance(value, int | float):
+            return bool(value)
+        return False

--- a/src/tools/alerts/alert_saved_search.py
+++ b/src/tools/alerts/alert_saved_search.py
@@ -1,0 +1,74 @@
+"""Shared saved-search helpers used by alert create/update/delete tools."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from src.core.utils import sanitize_search_query
+from src.tools.search.saved_search_tools import (
+    DEFAULT_SAVED_SEARCH_APP,
+    _apply_saved_search_namespace,
+    _find_saved_search,
+    _namespace_for_saved_search_create,
+)
+
+SharingLevel = Literal["user", "app", "global"]
+
+
+def default_alert_app() -> str:
+    return DEFAULT_SAVED_SEARCH_APP
+
+
+def find_alert_saved_search(
+    service: Any,
+    name: str,
+    app: str | None = None,
+    owner: str | None = None,
+) -> Any | None:
+    return _find_saved_search(service, name, app, owner)
+
+
+def namespace_for_create(*, app: str, owner: str, sharing: SharingLevel) -> Any:
+    return _namespace_for_saved_search_create(app=app, owner=owner, sharing=sharing)
+
+
+def apply_saved_search_namespace(service: Any, saved_search: Any) -> Any:
+    return _apply_saved_search_namespace(service, saved_search)
+
+
+def create_alert_config(
+    *,
+    search: str,
+    description: str,
+    earliest_time: str,
+    latest_time: str,
+    cron_schedule: str,
+    is_visible: bool,
+    alert_type: str,
+    alert_comparator: str,
+    alert_threshold: str,
+    alert_condition: str,
+    alert_track: bool,
+    alert_severity: int,
+    alert_digest_mode: bool,
+) -> dict[str, str]:
+    config = {
+        "search": sanitize_search_query(search),
+        "description": description,
+        "is_visible": "1" if is_visible else "0",
+        "is_scheduled": "1",
+        "cron_schedule": cron_schedule,
+        "alert_type": alert_type,
+        "alert_comparator": alert_comparator,
+        "alert_threshold": str(alert_threshold),
+        "alert.track": "1" if alert_track else "0",
+        "alert.severity": str(alert_severity),
+        "alert.digest_mode": "1" if alert_digest_mode else "0",
+    }
+    if earliest_time:
+        config["dispatch.earliest_time"] = earliest_time
+    if latest_time:
+        config["dispatch.latest_time"] = latest_time
+    if alert_condition:
+        config["alert_condition"] = alert_condition
+    return config

--- a/src/tools/alerts/alert_tool_context.py
+++ b/src/tools/alerts/alert_tool_context.py
@@ -40,8 +40,10 @@ class AlertContextMixin:
         try:
             missing = catalog.unknown_actions(service, requested)
         except Exception as exc:
-            await ctx.warning(f"Skipping alert-action catalog validation: {exc}")
-            return None
+            return (
+                f"Could not validate alert actions ({exc}). "
+                "Retry list_alert_actions, or omit actions for a track-only alert."
+            )
         if not missing:
             return None
         available = ", ".join(sorted(catalog.names(service)))

--- a/src/tools/alerts/alert_tool_context.py
+++ b/src/tools/alerts/alert_tool_context.py
@@ -1,0 +1,51 @@
+"""FastMCP Context helpers for alert tools.
+
+FastMCP 4 sends client notifications via ``ctx.info`` / ``ctx.error`` /
+``ctx.warning`` / ``ctx.report_progress``. This mixin keeps those calls on
+every failure path while still returning the repo's structured error dicts
+(the tool loader already converts uncaught exceptions into the same shape).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import Context
+
+from src.tools.alerts.alert_action_catalog import AlertActionCatalog
+
+
+class AlertContextMixin:
+    """Mixin for BaseTool subclasses that talk to the MCP client Context."""
+
+    async def fail(self, ctx: Context, message: str, **extra: Any) -> dict[str, Any]:
+        await ctx.error(message)
+        return self.format_error_response(message, **extra)  # type: ignore[attr-defined]
+
+    async def notify_progress(
+        self, ctx: Context, progress: float, total: float, message: str
+    ) -> None:
+        await ctx.report_progress(progress=progress, total=total, message=message)
+
+    async def unknown_actions_message(
+        self,
+        ctx: Context,
+        service: Any,
+        parsed_actions: list[dict[str, Any]] | None,
+    ) -> str | None:
+        requested = [item["name"] for item in (parsed_actions or [])]
+        if not requested:
+            return None
+        catalog = AlertActionCatalog()
+        try:
+            missing = catalog.unknown_actions(service, requested)
+        except Exception as exc:
+            await ctx.warning(f"Skipping alert-action catalog validation: {exc}")
+            return None
+        if not missing:
+            return None
+        available = ", ".join(sorted(catalog.names(service)))
+        return (
+            f"Unknown alert action(s): {', '.join(missing)}. "
+            f"Call list_alert_actions. Available: {available}"
+        )

--- a/src/tools/alerts/create_alert.py
+++ b/src/tools/alerts/create_alert.py
@@ -1,5 +1,6 @@
 """Create a Splunk alert (scheduled saved search with trigger and actions)."""
 
+from dataclasses import dataclass
 from typing import Any, Literal
 
 from fastmcp import Context
@@ -17,6 +18,15 @@ from src.tools.alerts.alert_tool_context import AlertContextMixin
 from src.tools.search.saved_search_acl import get_saved_search_acl
 
 SharingLevel = Literal["user", "app", "global"]
+
+
+@dataclass(frozen=True)
+class CreatedAlertNamespace:
+    """Result of creating a saved search in a Splunk namespace."""
+
+    app: str
+    owner: str
+    error: str | None = None
 
 
 class CreateAlert(AlertContextMixin, BaseTool):
@@ -148,13 +158,6 @@ class CreateAlert(AlertContextMixin, BaseTool):
         **kwargs: Any,
     ) -> dict[str, Any]:
         name = kwargs["name"]
-        try:
-            if service.saved_searches[name]:
-                return await self.fail(
-                    ctx, f"Alert '{name}' already exists", name=name, created=False
-                )
-        except KeyError:
-            pass
         mapper = AlertActionSettings()
         config = create_alert_config(
             search=kwargs["search"],
@@ -175,9 +178,12 @@ class CreateAlert(AlertContextMixin, BaseTool):
         config.update(action_fields)
         await ctx.info(f"Creating alert '{name}'")
         await self.notify_progress(ctx, 50, 100, f"Submitting alert '{name}'")
-        target_app, create_owner = self._create_in_namespace(
+        created = self._create_in_namespace(
             service, name, config, kwargs["app"], kwargs["sharing"]
         )
+        if created.error:
+            return await self.fail(ctx, created.error, name=name, created=False)
+        target_app, create_owner = created.app, created.owner
         saved_search = find_alert_saved_search(
             service, name, app=target_app, owner=create_owner if kwargs["sharing"] == "user" else None
         )
@@ -217,7 +223,7 @@ class CreateAlert(AlertContextMixin, BaseTool):
         config: dict[str, str],
         app: str | None,
         sharing: SharingLevel,
-    ) -> tuple[str, str]:
+    ) -> CreatedAlertNamespace:
         original_namespace = getattr(service, "namespace", None)
         create_owner = getattr(service, "username", None) or "admin"
         target_app = (app or default_alert_app()).strip()
@@ -225,7 +231,17 @@ class CreateAlert(AlertContextMixin, BaseTool):
             service.namespace = namespace_for_create(
                 app=target_app, owner=create_owner, sharing=sharing
             )
-            service.saved_searches.create(name, **config)
+            try:
+                service.saved_searches[name]
+            except KeyError:
+                # Splunklib raises KeyError when this name is unused in the
+                # create namespace. Continue with create.
+                service.saved_searches.create(name, **config)
+                return CreatedAlertNamespace(app=target_app, owner=create_owner)
+            return CreatedAlertNamespace(
+                app=target_app,
+                owner=create_owner,
+                error=f"Alert '{name}' already exists",
+            )
         finally:
             service.namespace = original_namespace
-        return target_app, create_owner

--- a/src/tools/alerts/create_alert.py
+++ b/src/tools/alerts/create_alert.py
@@ -1,0 +1,231 @@
+"""Create a Splunk alert (scheduled saved search with trigger and actions)."""
+
+from typing import Any, Literal
+
+from fastmcp import Context
+
+from src.core.base import BaseTool, ToolMetadata
+from src.core.utils import log_tool_execution
+from src.tools.alerts.alert_action_settings import AlertActionSettings
+from src.tools.alerts.alert_saved_search import (
+    create_alert_config,
+    default_alert_app,
+    find_alert_saved_search,
+    namespace_for_create,
+)
+from src.tools.alerts.alert_tool_context import AlertContextMixin
+from src.tools.search.saved_search_acl import get_saved_search_acl
+
+SharingLevel = Literal["user", "app", "global"]
+
+
+class CreateAlert(AlertContextMixin, BaseTool):
+    """Create a scheduled Splunk alert with optional built-in or custom actions."""
+
+    METADATA = ToolMetadata(
+        name="create_alert",
+        description=(
+            "Create a Splunk alert (a scheduled saved search with trigger conditions). "
+            "Actions can be any installed alert action, including custom ones, and more than "
+            "one action is allowed. Call list_alert_actions first for custom action names and "
+            "param keys.\n\n"
+            "Args:\n"
+            "    name (str): Unique alert name (required)\n"
+            "    search (str): SPL query (required)\n"
+            "    cron_schedule (str): Cron schedule, e.g. '*/5 * * * *' (required)\n"
+            "    description (str, optional): Description\n"
+            "    earliest_time (str, optional): Dispatch earliest time, e.g. '-15m'\n"
+            "    latest_time (str, optional): Dispatch latest time, e.g. 'now'\n"
+            "    app (str, optional): App context (default: search)\n"
+            "    sharing (str, optional): user|app|global (default: user)\n"
+            "    alert_type (str, optional): always|number of events|number of hosts|"
+            "number of sources|custom (default: number of events)\n"
+            "    alert_comparator (str, optional): greater than|less than|equal to|"
+            "not equal to (default: greater than)\n"
+            "    alert_threshold (str, optional): Threshold value (default: 0)\n"
+            "    alert_condition (str, optional): Required when alert_type is custom\n"
+            "    alert_track (bool, optional): Show in Triggered Alerts (default: true)\n"
+            "    alert_severity (int, optional): 1-5 (default: 3)\n"
+            "    actions (list, optional): [{name, params, enabled}]. Empty means track-only. "
+            "Custom action params use keys from list_alert_actions.\n\n"
+            "Outputs: created name, trigger, schedule, and applied action fields.\n"
+            "Security: visibility and execution follow the chosen sharing level and user ACL."
+        ),
+        category="alerts",
+        tags=["alerts", "create", "saved_searches", "alert-actions"],
+        requires_connection=True,
+    )
+
+    async def execute(
+        self,
+        ctx: Context,
+        name: str,
+        search: str,
+        cron_schedule: str,
+        description: str = "",
+        earliest_time: str = "-15m",
+        latest_time: str = "now",
+        app: str | None = None,
+        sharing: SharingLevel = "user",
+        is_visible: bool = True,
+        alert_type: str = "number of events",
+        alert_comparator: str = "greater than",
+        alert_threshold: str = "0",
+        alert_condition: str = "",
+        alert_track: bool = True,
+        alert_severity: int = 3,
+        alert_digest_mode: bool = True,
+        actions: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        log_tool_execution("create_alert", name=name, search=search[:50] + "...")
+        is_available, service, error_msg = self.check_splunk_available(ctx)
+        if not is_available:
+            return await self.fail(ctx, error_msg, name=name, created=False)
+
+        try:
+            await self.notify_progress(ctx, 0, 100, f"Validating alert '{name}'")
+            parsed_actions = AlertActionSettings().parse_actions(actions)
+            validation_error = self._validate(
+                name, search, cron_schedule, alert_type, alert_condition, alert_severity
+            )
+            if validation_error:
+                return await self.fail(ctx, validation_error, name=name, created=False)
+            unknown = await self.unknown_actions_message(ctx, service, parsed_actions)
+            if unknown:
+                return await self.fail(ctx, unknown, name=name, created=False)
+            return await self._create(
+                ctx,
+                service,
+                name=name,
+                search=search,
+                cron_schedule=cron_schedule,
+                description=description,
+                earliest_time=earliest_time,
+                latest_time=latest_time,
+                app=app,
+                sharing=sharing,
+                is_visible=is_visible,
+                alert_type=alert_type,
+                alert_comparator=alert_comparator,
+                alert_threshold=alert_threshold,
+                alert_condition=alert_condition,
+                alert_track=alert_track,
+                alert_severity=alert_severity,
+                alert_digest_mode=alert_digest_mode,
+                parsed_actions=parsed_actions,
+            )
+        except Exception as exc:
+            self.logger.error("Failed to create alert '%s': %s", name, exc)
+            return await self.fail(
+                ctx, f"Failed to create alert '{name}': {exc}", name=name, created=False
+            )
+
+    def _validate(
+        self,
+        name: str,
+        search: str,
+        cron_schedule: str,
+        alert_type: str,
+        alert_condition: str,
+        alert_severity: int,
+    ) -> str | None:
+        if not name.strip():
+            return "Alert name cannot be empty"
+        if not search.strip():
+            return "Search query cannot be empty"
+        if not cron_schedule.strip():
+            return "cron_schedule is required"
+        if alert_type.strip().lower() == "custom" and not alert_condition.strip():
+            return "alert_condition is required when alert_type is custom"
+        if alert_severity < 1 or alert_severity > 5:
+            return "alert_severity must be between 1 and 5"
+        return None
+
+    async def _create(
+        self,
+        ctx: Context,
+        service: Any,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        name = kwargs["name"]
+        try:
+            if service.saved_searches[name]:
+                return await self.fail(
+                    ctx, f"Alert '{name}' already exists", name=name, created=False
+                )
+        except KeyError:
+            pass
+        mapper = AlertActionSettings()
+        config = create_alert_config(
+            search=kwargs["search"],
+            description=kwargs["description"],
+            earliest_time=kwargs["earliest_time"],
+            latest_time=kwargs["latest_time"],
+            cron_schedule=kwargs["cron_schedule"],
+            is_visible=kwargs["is_visible"],
+            alert_type=kwargs["alert_type"],
+            alert_comparator=kwargs["alert_comparator"],
+            alert_threshold=str(kwargs["alert_threshold"]),
+            alert_condition=kwargs["alert_condition"],
+            alert_track=kwargs["alert_track"],
+            alert_severity=kwargs["alert_severity"],
+            alert_digest_mode=kwargs["alert_digest_mode"],
+        )
+        action_fields = mapper.splunk_fields(kwargs["parsed_actions"])
+        config.update(action_fields)
+        await ctx.info(f"Creating alert '{name}'")
+        await self.notify_progress(ctx, 50, 100, f"Submitting alert '{name}'")
+        target_app, create_owner = self._create_in_namespace(
+            service, name, config, kwargs["app"], kwargs["sharing"]
+        )
+        saved_search = find_alert_saved_search(
+            service, name, app=target_app, owner=create_owner if kwargs["sharing"] == "user" else None
+        )
+        if not saved_search:
+            return await self.fail(
+                ctx,
+                f"Alert '{name}' was submitted but is not accessible after creation",
+                name=name,
+                created=False,
+            )
+        await self.notify_progress(ctx, 100, 100, f"Created alert '{name}'")
+        acl = get_saved_search_acl(saved_search)
+        return self.format_success_response(
+            {
+                "name": name,
+                "created": True,
+                "app": acl.get("app") or target_app,
+                "owner": acl.get("owner") or create_owner,
+                "sharing": kwargs["sharing"],
+                "configuration": {
+                    "search": config["search"],
+                    "cron_schedule": kwargs["cron_schedule"],
+                    "alert_type": kwargs["alert_type"],
+                    "alert_comparator": kwargs["alert_comparator"],
+                    "alert_threshold": str(kwargs["alert_threshold"]),
+                    "alert_track": kwargs["alert_track"],
+                    "actions": kwargs["parsed_actions"],
+                    "applied_action_fields": action_fields,
+                },
+            }
+        )
+
+    def _create_in_namespace(
+        self,
+        service: Any,
+        name: str,
+        config: dict[str, str],
+        app: str | None,
+        sharing: SharingLevel,
+    ) -> tuple[str, str]:
+        original_namespace = getattr(service, "namespace", None)
+        create_owner = getattr(service, "username", None) or "admin"
+        target_app = (app or default_alert_app()).strip()
+        try:
+            service.namespace = namespace_for_create(
+                app=target_app, owner=create_owner, sharing=sharing
+            )
+            service.saved_searches.create(name, **config)
+        finally:
+            service.namespace = original_namespace
+        return target_app, create_owner

--- a/src/tools/alerts/delete_alert.py
+++ b/src/tools/alerts/delete_alert.py
@@ -1,0 +1,87 @@
+"""Delete a Splunk alert (the underlying saved search)."""
+
+import time
+from typing import Any
+
+from fastmcp import Context
+
+from src.core.base import BaseTool, ToolMetadata
+from src.core.utils import log_tool_execution
+from src.tools.alerts.alert_saved_search import (
+    apply_saved_search_namespace,
+    find_alert_saved_search,
+)
+from src.tools.alerts.alert_tool_context import AlertContextMixin
+from src.tools.search.saved_search_acl import get_saved_search_acl
+
+
+class DeleteAlert(AlertContextMixin, BaseTool):
+    """Delete a Splunk alert after explicit confirmation."""
+
+    METADATA = ToolMetadata(
+        name="delete_alert",
+        description=(
+            "Delete a Splunk alert. Alerts are saved searches, so this removes that saved search. "
+            "Requires confirm=true. Use app and owner when the name exists in more than one "
+            "namespace.\n\n"
+            "Args:\n"
+            "    name (str): Alert name (required)\n"
+            "    confirm (bool): Must be true to delete (default: false)\n"
+            "    app (str, optional): App context for lookup\n"
+            "    owner (str, optional): Owner context for lookup\n"
+        ),
+        category="alerts",
+        tags=["alerts", "delete", "saved_searches"],
+        requires_connection=True,
+    )
+
+    async def execute(
+        self,
+        ctx: Context,
+        name: str,
+        confirm: bool = False,
+        app: str | None = None,
+        owner: str | None = None,
+    ) -> dict[str, Any]:
+        log_tool_execution("delete_alert", name=name, confirm=confirm)
+        is_available, service, error_msg = self.check_splunk_available(ctx)
+        if not is_available:
+            return await self.fail(ctx, error_msg, name=name, deleted=False)
+
+        try:
+            if not confirm:
+                return await self.fail(
+                    ctx,
+                    "Deletion requires explicit confirmation. Set confirm=true to proceed.",
+                    name=name,
+                    deleted=False,
+                )
+            saved_search = find_alert_saved_search(service, name, app, owner)
+            if not saved_search:
+                return await self.fail(
+                    ctx, f"Alert '{name}' not found", name=name, deleted=False
+                )
+            acl = get_saved_search_acl(saved_search)
+            await ctx.info(f"Deleting alert '{name}'")
+            await self.notify_progress(ctx, 50, 100, f"Deleting alert '{name}'")
+            original_namespace = apply_saved_search_namespace(service, saved_search)
+            try:
+                saved_search = service.saved_searches[saved_search.name]
+                saved_search.delete()
+            finally:
+                service.namespace = original_namespace
+            await self.notify_progress(ctx, 100, 100, f"Deleted alert '{name}'")
+            return self.format_success_response(
+                {
+                    "name": name,
+                    "deleted": True,
+                    "app": acl.get("app", ""),
+                    "owner": acl.get("owner", ""),
+                    "deleted_at": time.time(),
+                }
+            )
+        except Exception as exc:
+            self.logger.error("Failed to delete alert '%s': %s", name, exc)
+            return await self.fail(
+                ctx, f"Failed to delete alert '{name}': {exc}", name=name, deleted=False
+            )

--- a/src/tools/alerts/list_alert_actions.py
+++ b/src/tools/alerts/list_alert_actions.py
@@ -1,0 +1,48 @@
+"""List alert actions installed on the connected Splunk instance."""
+
+from typing import Any
+
+from fastmcp import Context
+
+from src.core.base import BaseTool, ToolMetadata
+from src.core.utils import log_tool_execution
+from src.tools.alerts.alert_action_catalog import AlertActionCatalog
+from src.tools.alerts.alert_tool_context import AlertContextMixin
+
+
+class ListAlertActions(AlertContextMixin, BaseTool):
+    """Discover built-in and custom Splunk alert actions and their param keys."""
+
+    METADATA = ToolMetadata(
+        name="list_alert_actions",
+        description=(
+            "List alert actions installed on the connected Splunk instance, including custom "
+            "actions. Returns name, label, description, is_custom, app, and param_keys. Call this "
+            "before create_alert or update_alert when using a custom action so you pass the correct "
+            "action name and param keys.\n\n"
+            "Outputs: 'alert_actions' array and 'count'.\n"
+            "Security: results are constrained by the authenticated user's permissions."
+        ),
+        category="alerts",
+        tags=["alerts", "alert-actions", "discovery", "custom"],
+        requires_connection=True,
+    )
+
+    async def execute(self, ctx: Context) -> dict[str, Any]:
+        log_tool_execution("list_alert_actions")
+        is_available, service, error_msg = self.check_splunk_available(ctx)
+        if not is_available:
+            return await self.fail(ctx, error_msg)
+
+        try:
+            await ctx.info("Retrieving installed Splunk alert actions")
+            await self.notify_progress(ctx, 0, 100, "Listing alert actions")
+            actions = AlertActionCatalog().list_actions(service)
+            await ctx.info(f"Found {len(actions)} alert actions")
+            await self.notify_progress(ctx, 100, 100, f"Found {len(actions)} alert actions")
+            return self.format_success_response(
+                {"alert_actions": actions, "count": len(actions)}
+            )
+        except Exception as exc:
+            self.logger.error("Failed to list alert actions: %s", exc)
+            return await self.fail(ctx, f"Failed to list alert actions: {exc}")

--- a/src/tools/alerts/update_alert.py
+++ b/src/tools/alerts/update_alert.py
@@ -1,0 +1,210 @@
+"""Update an existing Splunk alert, including patch or override of actions."""
+
+from typing import Any, Literal
+
+from fastmcp import Context
+
+from src.core.base import BaseTool, ToolMetadata
+from src.core.utils import log_tool_execution, sanitize_search_query
+from src.tools.alerts.alert_action_settings import AlertActionSettings
+from src.tools.alerts.alert_saved_search import (
+    apply_saved_search_namespace,
+    find_alert_saved_search,
+)
+from src.tools.alerts.alert_tool_context import AlertContextMixin
+from src.tools.search.saved_search_acl import get_saved_search_acl
+
+ActionsMode = Literal["patch", "override"]
+
+
+class UpdateAlert(AlertContextMixin, BaseTool):
+    """Partially update an alert, with patch or override for actions."""
+
+    METADATA = ToolMetadata(
+        name="update_alert",
+        description=(
+            "Update an existing Splunk alert (a scheduled saved search with trigger conditions "
+            "and optional actions). Omit any field you do not want to change. Search, schedule, "
+            "trigger, and tracking fields are always patched.\n\n"
+            "actions_mode (only applies when actions is sent):\n"
+            "    patch (default): Change only the listed actions and params. Other actions and "
+            "unspecified params on those actions stay as they are. Use this to change one setting "
+            "(for example only email.to). Set enabled=false on an action to turn that action off "
+            "without touching the others.\n"
+            "    override: The actions list becomes the full set. Listed actions are enabled with "
+            "the given params; any action currently on the alert but missing from the list is "
+            "disabled. Use this when you want the alert to have exactly these actions.\n\n"
+            "Call list_alert_actions first for custom actions and their param names.\n\n"
+            "Args:\n"
+            "    name (str): Alert name (required)\n"
+            "    app (str, optional): App context for lookup\n"
+            "    owner (str, optional): Owner context for lookup\n"
+            "    search (str, optional): New SPL query\n"
+            "    description (str, optional): New description\n"
+            "    cron_schedule (str, optional): New cron schedule\n"
+            "    earliest_time (str, optional): New dispatch earliest time\n"
+            "    latest_time (str, optional): New dispatch latest time\n"
+            "    alert_type (str, optional): Trigger type\n"
+            "    alert_comparator (str, optional): Comparator\n"
+            "    alert_threshold (str, optional): Threshold\n"
+            "    alert_condition (str, optional): Custom trigger search\n"
+            "    alert_track (bool, optional): Show in Triggered Alerts\n"
+            "    alert_severity (int, optional): 1-5\n"
+            "    actions_mode (str, optional): patch|override (default: patch)\n"
+            "    actions (list, optional): [{name, params, enabled}]\n"
+        ),
+        category="alerts",
+        tags=["alerts", "update", "saved_searches", "alert-actions"],
+        requires_connection=True,
+    )
+
+    async def execute(
+        self,
+        ctx: Context,
+        name: str,
+        app: str | None = None,
+        owner: str | None = None,
+        search: str | None = None,
+        description: str | None = None,
+        cron_schedule: str | None = None,
+        earliest_time: str | None = None,
+        latest_time: str | None = None,
+        is_visible: bool | None = None,
+        alert_type: str | None = None,
+        alert_comparator: str | None = None,
+        alert_threshold: str | None = None,
+        alert_condition: str | None = None,
+        alert_track: bool | None = None,
+        alert_severity: int | None = None,
+        alert_digest_mode: bool | None = None,
+        actions_mode: ActionsMode = "patch",
+        actions: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        log_tool_execution("update_alert", name=name, actions_mode=actions_mode)
+        is_available, service, error_msg = self.check_splunk_available(ctx)
+        if not is_available:
+            return await self.fail(ctx, error_msg, name=name, updated=False)
+
+        try:
+            if not name.strip():
+                return await self.fail(
+                    ctx, "Alert name cannot be empty", name=name, updated=False
+                )
+            if actions_mode not in ("patch", "override"):
+                return await self.fail(
+                    ctx,
+                    "actions_mode must be 'patch' or 'override'",
+                    name=name,
+                    updated=False,
+                )
+            mapper = AlertActionSettings()
+            parsed_actions = mapper.parse_actions(actions) if actions is not None else None
+            unknown = await self.unknown_actions_message(ctx, service, parsed_actions)
+            if unknown:
+                return await self.fail(ctx, unknown, name=name, updated=False)
+            return await self._update(
+                ctx,
+                service,
+                mapper,
+                name=name,
+                app=app,
+                owner=owner,
+                search=search,
+                description=description,
+                cron_schedule=cron_schedule,
+                earliest_time=earliest_time,
+                latest_time=latest_time,
+                is_visible=is_visible,
+                alert_type=alert_type,
+                alert_comparator=alert_comparator,
+                alert_threshold=alert_threshold,
+                alert_condition=alert_condition,
+                alert_track=alert_track,
+                alert_severity=alert_severity,
+                alert_digest_mode=alert_digest_mode,
+                actions_mode=actions_mode,
+                parsed_actions=parsed_actions,
+            )
+        except Exception as exc:
+            self.logger.error("Failed to update alert '%s': %s", name, exc)
+            return await self.fail(
+                ctx, f"Failed to update alert '{name}': {exc}", name=name, updated=False
+            )
+
+    async def _update(
+        self,
+        ctx: Context,
+        service: Any,
+        mapper: AlertActionSettings,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        name = kwargs["name"]
+        saved_search = find_alert_saved_search(
+            service, name, kwargs["app"], kwargs["owner"]
+        )
+        if not saved_search:
+            return await self.fail(
+                ctx, f"Alert '{name}' not found", name=name, updated=False
+            )
+        update_config = self._scalar_updates(kwargs)
+        if kwargs["parsed_actions"] is not None:
+            content = dict(getattr(saved_search, "content", None) or {})
+            if kwargs["actions_mode"] == "override":
+                update_config.update(mapper.override_fields(content, kwargs["parsed_actions"]))
+            else:
+                update_config.update(mapper.patch_fields(content, kwargs["parsed_actions"]))
+        if not update_config:
+            return await self.fail(
+                ctx, "No updates provided", name=name, updated=False
+            )
+        await ctx.info(f"Updating alert '{name}' ({kwargs['actions_mode']})")
+        await self.notify_progress(ctx, 50, 100, f"Updating alert '{name}'")
+        original_namespace = apply_saved_search_namespace(service, saved_search)
+        try:
+            saved_search = service.saved_searches[saved_search.name]
+            saved_search.update(**update_config).refresh()
+        finally:
+            service.namespace = original_namespace
+        await self.notify_progress(ctx, 100, 100, f"Updated alert '{name}'")
+        acl = get_saved_search_acl(saved_search)
+        return self.format_success_response(
+            {
+                "name": name,
+                "updated": True,
+                "actions_mode": kwargs["actions_mode"] if kwargs["parsed_actions"] is not None else None,
+                "changes": sorted(update_config.keys()),
+                "app": acl.get("app", ""),
+                "owner": acl.get("owner", ""),
+            }
+        )
+
+    def _scalar_updates(self, kwargs: dict[str, Any]) -> dict[str, str]:
+        config: dict[str, str] = {}
+        if kwargs["search"] is not None:
+            config["search"] = sanitize_search_query(kwargs["search"])
+        if kwargs["description"] is not None:
+            config["description"] = kwargs["description"]
+        if kwargs["cron_schedule"] is not None:
+            config["cron_schedule"] = kwargs["cron_schedule"]
+            config["is_scheduled"] = "1"
+        if kwargs["earliest_time"] is not None:
+            config["dispatch.earliest_time"] = kwargs["earliest_time"]
+        if kwargs["latest_time"] is not None:
+            config["dispatch.latest_time"] = kwargs["latest_time"]
+        if kwargs["is_visible"] is not None:
+            config["is_visible"] = "1" if kwargs["is_visible"] else "0"
+        if kwargs["alert_type"] is not None:
+            config["alert_type"] = kwargs["alert_type"]
+        if kwargs["alert_comparator"] is not None:
+            config["alert_comparator"] = kwargs["alert_comparator"]
+        if kwargs["alert_threshold"] is not None:
+            config["alert_threshold"] = str(kwargs["alert_threshold"])
+        if kwargs["alert_condition"] is not None:
+            config["alert_condition"] = kwargs["alert_condition"]
+        if kwargs["alert_track"] is not None:
+            config["alert.track"] = "1" if kwargs["alert_track"] else "0"
+        if kwargs["alert_severity"] is not None:
+            config["alert.severity"] = str(kwargs["alert_severity"])
+        if kwargs["alert_digest_mode"] is not None:
+            config["alert.digest_mode"] = "1" if kwargs["alert_digest_mode"] else "0"
+        return config

--- a/src/tools/alerts/update_alert.py
+++ b/src/tools/alerts/update_alert.py
@@ -99,6 +99,17 @@ class UpdateAlert(AlertContextMixin, BaseTool):
                 )
             mapper = AlertActionSettings()
             parsed_actions = mapper.parse_actions(actions) if actions is not None else None
+            if parsed_actions is not None and not parsed_actions:
+                if actions_mode == "override":
+                    return await self.fail(
+                        ctx,
+                        "actions_mode=override requires a non-empty actions list. "
+                        "Omit actions to leave them unchanged, or use patch with "
+                        "enabled=false to disable one action.",
+                        name=name,
+                        updated=False,
+                    )
+                parsed_actions = None
             unknown = await self.unknown_actions_message(ctx, service, parsed_actions)
             if unknown:
                 return await self.fail(ctx, unknown, name=name, updated=False)

--- a/tests/test_alert_action_settings.py
+++ b/tests/test_alert_action_settings.py
@@ -1,0 +1,121 @@
+"""Unit tests for alert action field mapping."""
+
+from src.tools.alerts.alert_action_settings import AlertActionSettings
+from src.tools.alerts.alert_saved_search import create_alert_config
+
+
+class TestAlertActionSettings:
+    def setup_method(self) -> None:
+        self.mapper = AlertActionSettings()
+
+    def test_email_uses_flat_param_keys(self) -> None:
+        fields = self.mapper.splunk_fields(
+            [
+                {
+                    "name": "email",
+                    "params": {"to": "ops@example.com", "subject": "High errors"},
+                    "enabled": True,
+                }
+            ]
+        )
+        assert fields["actions"] == "email"
+        assert fields["action.email"] == "1"
+        assert fields["action.email.to"] == "ops@example.com"
+        assert fields["action.email.subject"] == "High errors"
+
+    def test_custom_action_prefixes_param(self) -> None:
+        fields = self.mapper.splunk_fields(
+            [{"name": "my_pagerduty", "params": {"routing_key": "R0abc"}}]
+        )
+        assert fields["action.my_pagerduty"] == "1"
+        assert fields["action.my_pagerduty.param.routing_key"] == "R0abc"
+        assert fields["actions"] == "my_pagerduty"
+
+    def test_dotted_param_key_is_used_as_is(self) -> None:
+        fields = self.mapper.splunk_fields(
+            [{"name": "webhook", "params": {"param.url": "https://hooks.example/splunk"}}]
+        )
+        assert fields["action.webhook.param.url"] == "https://hooks.example/splunk"
+
+    def test_multiple_actions_join_csv(self) -> None:
+        fields = self.mapper.splunk_fields(
+            [
+                {"name": "email", "params": {"to": "a@b.com"}},
+                {"name": "rss", "params": {}},
+            ]
+        )
+        assert fields["actions"] == "email,rss"
+        assert fields["action.email"] == "1"
+        assert fields["action.rss"] == "1"
+
+    def test_patch_keeps_other_actions_and_unspecified_params(self) -> None:
+        current = {
+            "actions": "email,webhook",
+            "action.email": "1",
+            "action.email.to": "ops@example.com",
+            "action.email.subject": "Old",
+            "action.webhook": "1",
+            "action.webhook.param.url": "https://old.example",
+        }
+        fields = self.mapper.patch_fields(
+            current,
+            [{"name": "email", "params": {"subject": "New subject"}}],
+        )
+        assert fields["action.email"] == "1"
+        assert fields["action.email.subject"] == "New subject"
+        assert "action.email.to" not in fields
+        assert "action.webhook" not in fields
+        assert fields["actions"] == "email,webhook"
+
+    def test_patch_can_disable_one_action(self) -> None:
+        current = {"actions": "email,rss", "action.email": "1", "action.rss": "1"}
+        fields = self.mapper.patch_fields(
+            current,
+            [{"name": "email", "enabled": False, "params": {}}],
+        )
+        assert fields["action.email"] == "0"
+        assert fields["actions"] == "rss"
+
+    def test_override_disables_missing_actions(self) -> None:
+        current = {"actions": "email,rss", "action.email": "1", "action.rss": "1"}
+        fields = self.mapper.override_fields(
+            current,
+            [{"name": "webhook", "params": {"url": "https://hooks.example"}}],
+        )
+        assert fields["actions"] == "webhook"
+        assert fields["action.webhook"] == "1"
+        assert fields["action.webhook.param.url"] == "https://hooks.example"
+        assert fields["action.email"] == "0"
+        assert fields["action.rss"] == "0"
+
+    def test_parse_actions_accepts_json_string(self) -> None:
+        parsed = self.mapper.parse_actions(
+            '[{"name": "email", "params": {"to": "ops@example.com"}}]'
+        )
+        assert parsed == [
+            {"name": "email", "params": {"to": "ops@example.com"}, "enabled": True}
+        ]
+
+
+class TestCreateAlertConfig:
+    def test_uses_rest_alert_argument_names(self) -> None:
+        config = create_alert_config(
+            search="index=_internal | head 1",
+            description="probe",
+            earliest_time="-15m",
+            latest_time="now",
+            cron_schedule="0 0 1 1 *",
+            is_visible=True,
+            alert_type="number of events",
+            alert_comparator="greater than",
+            alert_threshold="0",
+            alert_condition="",
+            alert_track=True,
+            alert_severity=3,
+            alert_digest_mode=True,
+        )
+        assert "alert.comparator" not in config
+        assert "alert.threshold" not in config
+        assert config["alert_comparator"] == "greater than"
+        assert config["alert_threshold"] == "0"
+        assert config["alert.track"] == "1"

--- a/tests/test_alert_tool_context.py
+++ b/tests/test_alert_tool_context.py
@@ -6,6 +6,7 @@ import pytest
 
 from src.core.base import BaseTool
 from src.tools.alerts.alert_tool_context import AlertContextMixin
+from src.tools.alerts.update_alert import UpdateAlert
 
 
 class _StubAlertTool(AlertContextMixin, BaseTool):
@@ -35,7 +36,7 @@ async def test_notify_progress_uses_fastmcp_report_progress() -> None:
 
 
 @pytest.mark.asyncio
-async def test_unknown_actions_warns_when_catalog_fails() -> None:
+async def test_unknown_actions_fails_closed_when_catalog_errors() -> None:
     tool = _StubAlertTool("stub", "stub")
     ctx = AsyncMock()
     service = Mock()
@@ -43,5 +44,17 @@ async def test_unknown_actions_warns_when_catalog_fails() -> None:
     message = await tool.unknown_actions_message(
         ctx, service, [{"name": "email", "params": {}, "enabled": True}]
     )
-    assert message is None
-    ctx.warning.assert_awaited()
+    assert message is not None
+    assert "Could not validate alert actions" in message
+    ctx.warning.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_alert_rejects_empty_override_actions() -> None:
+    tool = UpdateAlert("update_alert", "update")
+    tool.check_splunk_available = lambda ctx: (True, Mock(), "")  # type: ignore[method-assign]
+    ctx = AsyncMock()
+    result = await tool.execute(ctx, name="x", actions_mode="override", actions=[])
+    assert result["status"] == "error"
+    assert "non-empty actions list" in result["error"]
+    ctx.error.assert_awaited()

--- a/tests/test_alert_tool_context.py
+++ b/tests/test_alert_tool_context.py
@@ -1,0 +1,47 @@
+"""Tests for FastMCP Context helpers on alert tools."""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from src.core.base import BaseTool
+from src.tools.alerts.alert_tool_context import AlertContextMixin
+
+
+class _StubAlertTool(AlertContextMixin, BaseTool):
+    async def execute(self, ctx, **kwargs):  # pragma: no cover - not used
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_fail_sends_ctx_error_and_structured_dict() -> None:
+    tool = _StubAlertTool("stub", "stub")
+    ctx = AsyncMock()
+    result = await tool.fail(ctx, "bad request", name="x", created=False)
+    ctx.error.assert_awaited_once_with("bad request")
+    assert result["status"] == "error"
+    assert result["error"] == "bad request"
+    assert result["created"] is False
+
+
+@pytest.mark.asyncio
+async def test_notify_progress_uses_fastmcp_report_progress() -> None:
+    tool = _StubAlertTool("stub", "stub")
+    ctx = AsyncMock()
+    await tool.notify_progress(ctx, 50, 100, "halfway")
+    ctx.report_progress.assert_awaited_once_with(
+        progress=50, total=100, message="halfway"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unknown_actions_warns_when_catalog_fails() -> None:
+    tool = _StubAlertTool("stub", "stub")
+    ctx = AsyncMock()
+    service = Mock()
+    service.get.side_effect = RuntimeError("catalog down")
+    message = await tool.unknown_actions_message(
+        ctx, service, [{"name": "email", "params": {}, "enabled": True}]
+    )
+    assert message is None
+    ctx.warning.assert_awaited()

--- a/tests/test_alert_tools.py
+++ b/tests/test_alert_tools.py
@@ -1,0 +1,52 @@
+"""Tests for alert create/update/delete and list_alert_actions tools."""
+
+import pytest
+
+
+class TestAlertToolAvailability:
+    """Verify the new alert management tools are registered."""
+
+    async def test_alert_tools_are_registered(self, fastmcp_client):
+        async with fastmcp_client as client:
+            tools = await client.list_tools()
+            names = {tool.name for tool in tools}
+            assert "list_alert_actions" in names
+            assert "create_alert" in names
+            assert "update_alert" in names
+            assert "delete_alert" in names
+
+    async def test_update_alert_describes_patch_and_override(self, fastmcp_client):
+        async with fastmcp_client as client:
+            tools = await client.list_tools()
+            update_alert = next(tool for tool in tools if tool.name == "update_alert")
+            description = (update_alert.description or "").lower()
+            assert "patch" in description
+            assert "override" in description
+            assert update_alert.inputSchema is not None
+
+    async def test_delete_alert_requires_confirm_in_schema(self, fastmcp_client):
+        async with fastmcp_client as client:
+            tools = await client.list_tools()
+            delete_alert = next(tool for tool in tools if tool.name == "delete_alert")
+            properties = (delete_alert.inputSchema or {}).get("properties") or {}
+            assert "confirm" in properties
+
+    async def test_create_alert_without_splunk_returns_error(
+        self, fastmcp_client, extract_tool_result
+    ):
+        async with fastmcp_client as client:
+            result = await client.call_tool(
+                "create_alert",
+                {
+                    "name": "unit_test_alert",
+                    "search": "index=_internal | head 1",
+                    "cron_schedule": "0 0 1 1 *",
+                },
+            )
+            data = extract_tool_result(result)
+            assert isinstance(data, dict)
+            assert "status" in data
+            if data.get("status") == "error":
+                assert "error" in data
+            else:
+                pytest.skip("Live Splunk available in this test environment")


### PR DESCRIPTION
## Summary
- Add `list_alert_actions`, `create_alert`, `update_alert`, and `delete_alert` so models can manage Splunk alerts (scheduled saved searches) without going through `create_saved_search`.
- Support any installed alert action, including custom ones and multiple actions. `update_alert` uses `actions_mode=patch` (default, merge one setting) or `override` (replace the full action set).
- FastMCP 4 context: `ctx.info` / `ctx.error` / `ctx.warning` / `report_progress` on every path. Unit tests plus `scripts/test_alert_tools_mcp_client.py` for a live FastMCP client run.

## Test plan
- [x] `uv run pytest tests/test_alert_action_settings.py tests/test_alert_tool_context.py tests/test_alert_tools.py tests/test_alerts.py -q`
- [x] Live FastMCP client against Splunk: list actions → create (email+rss) → patch scalars / email.subject / custom action → override to rss → delete
- [x] Re-run `uv run python scripts/test_alert_tools_mcp_client.py` with `SPLUNK_HOST` + `SPLUNK_TOKEN` if you want a second live check
- [x] Confirm `list_alert_actions` shows custom actions on your instance before creating with them