### PR TITLE
chore: fold Dependabot pip floors into a lock-correct sweep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dev = [
 "pytest-asyncio>=1.4.0",
 "black>=26.5.1",
 "mypy>=2.3.0",
-"ruff>=0.16.1",
+"ruff>=0.16.2",
 "pre-commit>=4.6.1"
 ]
 # Pull in the ITSI MCP server alongside the core mcp-server-for-splunk
@@ -72,7 +72,7 @@ docs = [
 ]
 # Optional Sentry monitoring
 sentry = [
-"sentry-sdk[mcp,starlette,httpx,asyncio]>=2.63.0",
+"sentry-sdk[mcp,starlette,httpx,asyncio]>=2.67.1",
 ]
 # Optional OpenTelemetry distributed tracing.
 # Enabled at runtime only when OTEL_EXPORTER_OTLP_ENDPOINT is set.
@@ -125,7 +125,7 @@ dev-dependencies = [
 "pytest-asyncio>=1.4.0",
 "pytest-cov>=7.1.0",
 "black>=26.5.1",
-"ruff>=0.16.1",
+"ruff>=0.16.2",
 "mypy>=2.3.0",
 "pre-commit>=4.6.1",
 "watchdog>=6.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1474,7 +1474,7 @@ wheels = [
 
 [[package]]
 name = "mcp-itsi-server"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "packaging/mcp-itsi-server" }
 dependencies = [
     { name = "fastmcp" },
@@ -1491,7 +1491,7 @@ requires-dist = [
 
 [[package]]
 name = "mcp-server-for-splunk"
-version = "0.6.8"
+version = "0.6.9"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -1577,10 +1577,10 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.4.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=7.1.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.16.1" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.16.2" },
     { name = "safety", marker = "extra == 'security'", specifier = ">=3.8.1" },
     { name = "semgrep", marker = "extra == 'security'", specifier = ">=1.0.0,<1.137" },
-    { name = "sentry-sdk", extras = ["mcp", "starlette", "httpx", "asyncio"], marker = "extra == 'sentry'", specifier = ">=2.63.0" },
+    { name = "sentry-sdk", extras = ["mcp", "starlette", "httpx", "asyncio"], marker = "extra == 'sentry'", specifier = ">=2.67.1" },
     { name = "splunk-sdk", specifier = ">=2.1.1" },
     { name = "uvicorn", specifier = ">=0.52.1" },
     { name = "wsproto", specifier = ">=1.3.2" },
@@ -1598,7 +1598,7 @@ dev = [
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "ruff", specifier = ">=0.16.1" },
+    { name = "ruff", specifier = ">=0.16.2" },
     { name = "safety", specifier = ">=3.8.1" },
     { name = "watchdog", specifier = ">=6.0.0" },
 ]
@@ -2897,15 +2897,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.63.0"
+version = "2.68.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/c8/b3c970a5b186722d276cd40a05b3254e03bccc0208560aff20f612e018e8/sentry_sdk-2.63.0.tar.gz", hash = "sha256:2a1502bf864769275dbc8c2c9fc7a0f7f5e18358180b615d262d13a31ffba216", size = 912449, upload-time = "2026-06-16T12:45:57.553Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/94/23b7dd072acb9628907bd3f4fbf61794a7b12a9db8f33c1276f70ae5ac92/sentry_sdk-2.68.0.tar.gz", hash = "sha256:648c58e9887311a03470a41539e24bdbbf64a30ca4f5336f7e3dcc87276400b3", size = 1008854, upload-time = "2026-08-13T09:06:21.268Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/57/cb205f7d93373120f666b9c5736dc0815524d96a9b278e7a728f018dc22a/sentry_sdk-2.63.0-py3-none-any.whl", hash = "sha256:3a9b5ddd403f79eb73bd670f75f04485819db53d28f76ced7bc09041cb0dfd6a", size = 495950, upload-time = "2026-06-16T12:45:55.819Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/9b/e2421d08956d0bc4691d995393d835e563886bff499d8fb10fdefae85a8d/sentry_sdk-2.68.0-py3-none-any.whl", hash = "sha256:538e56c2d03679d42f7c0cb5f1af73a7a510b00abc7e296c13ac49b107b713a4", size = 518670, upload-time = "2026-08-13T09:06:19.735Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Raise `ruff` floor to `>=0.16.2` (lock already had 0.16.2)
- Raise `sentry-sdk` extra floor to `>=2.67.1` and refresh `uv.lock` so frozen installs resolve 2.68.0 instead of 2.63.0
- Sync workspace package versions in the lock to the already-released 0.6.9 / 0.1.3

Supersedes: #259 #260

## Test plan
- [x] `uv lock --check`
- [x] `uv run ruff check src/ tests/`
- [x] Targeted pytest (`test_http_session_mode`, `test_health_routes`, `test_alert_tools`)
- [ ] CI green
- [ ] Close superseded Dependabot PRs after this lands