### PR TITLE
feat: return search job_id before Splunk finishes

### DIFF
--- a/docs/guides/configuration/client_configuration.md
+++ b/docs/guides/configuration/client_configuration.md
@@ -484,9 +484,11 @@ List and search tools return one page plus:
 - `has_more` — more rows exist
 - `next_offset` — pass as `offset` on the next call
 
-Catalog lists default to 50 rows (max 200). Search results default to 50 (max 100). `count=0` is rejected.
+Catalog lists default to 50 rows (max 200). Search results default to 50 (max 100). Catalog `count=0` is rejected. Search `count=0` or `max_results=0` is treated as 50.
 
-When a search returns `has_more`, call `get_search_job_results` with the same `job_id` and `offset=next_offset`. The job is kept so page 2 does not rerun SPL.
+`run_splunk_search` waits up to `MCP_SEARCH_WAIT_SECONDS` (default 15) then returns `job_id` even if Splunk is still running. When `is_done` is false, poll `get_search_job_info`, then `get_search_job_results`.
+
+When a completed search returns `has_more`, call `get_search_job_results` with the same `job_id` and `offset=next_offset`. The job is kept so page 2 does not rerun SPL.
 
 ## 🔒 **Security Considerations**
 

--- a/docs/guides/configuration/client_configuration.md
+++ b/docs/guides/configuration/client_configuration.md
@@ -484,7 +484,7 @@ List and search tools return one page plus:
 - `has_more` — more rows exist
 - `next_offset` — pass as `offset` on the next call
 
-Catalog lists default to 50 rows (max 200). Search results default to 50 (max 100). Catalog `count=0` is rejected. Search `count=0` or `max_results=0` is treated as 50.
+Catalog lists default to 50 rows (max 200). Search results default to 50 (max 100). `count=0` uses the default. Values above the max are capped. A `status: error` tool payload is raised as an MCP `ToolError` so the agent sees the message.
 
 `run_splunk_search` waits up to `MCP_SEARCH_WAIT_SECONDS` (default 15) then returns `job_id` even if Splunk is still running. When `is_done` is false, poll `get_search_job_info`, then `get_search_job_results`.
 

--- a/docs/guides/lookups_and_dashboards.md
+++ b/docs/guides/lookups_and_dashboards.md
@@ -16,7 +16,7 @@ List CSV lookup table files available in Splunk.
 {
     "owner": "nobody",      # Optional: Filter by owner (default: nobody)
     "app": "-",             # Optional: Filter by app (default: - for all)
-    "count": 50,            # Optional: Page size 1-200 (default: 50)
+    "count": 50,            # Optional: default 50, max 200 (larger values are capped)
     "offset": 0,            # Optional: Pagination offset (default: 0)
     "search_filter": ""     # Optional: Filter like 'name=*geo*'
 }

--- a/env.example
+++ b/env.example
@@ -61,6 +61,8 @@ ITSI_REQUEST_TIMEOUT=30
 MCP_STATELESS_HTTP=true
 # Return JSON responses instead of SSE streams (improves compatibility with some clients)
 MCP_JSON_RESPONSE=true
+# How long run_splunk_search waits for Splunk before returning job_id for polling
+MCP_SEARCH_WAIT_SECONDS=15
 
 # Executed Workflows Storage
 # Directory for latest executed workflows per (session_id, workflow_id)

--- a/src/core/list_paging.py
+++ b/src/core/list_paging.py
@@ -1,6 +1,9 @@
 """Shared MCP list/search paging contract."""
 
 from dataclasses import dataclass
+from typing import Annotated
+
+from pydantic import Field
 
 
 class PaginationError(ValueError):
@@ -11,6 +14,39 @@ class PaginationError(ValueError):
 class PaginationParams:
     count: int
     offset: int
+
+
+LIST_PAGE_DEFAULT = 50
+LIST_PAGE_MAX = 200
+METADATA_PAGE_MAX = 100
+
+
+def count_arg_help(*, default: int = LIST_PAGE_DEFAULT, max_count: int = LIST_PAGE_MAX) -> str:
+    return (
+        f"    count (int, optional): Page size. Default {default}. Maximum {max_count}. "
+        f"Values above {max_count} are capped to {max_count}; 0 uses {default}. "
+        f"Do not send a count larger than {max_count}.\n"
+    )
+
+
+ListPageCount = Annotated[
+    int,
+    Field(
+        description=(
+            "Page size. Default 50. Maximum 200; larger values are capped to 200. "
+            "Do not send a count above 200."
+        )
+    ),
+]
+MetadataPageCount = Annotated[
+    int,
+    Field(
+        description=(
+            "Page size. Default 50. Maximum 100; larger values are capped to 100. "
+            "Do not send a count above 100."
+        )
+    ),
+]
 
 
 def clamp_search_page_size(
@@ -34,15 +70,16 @@ def clamp_search_page_size(
 
 
 def validate_pagination(
-    count: int = 50,
+    count: int = LIST_PAGE_DEFAULT,
     offset: int = 0,
-    max_count: int = 200,
+    max_count: int = LIST_PAGE_MAX,
 ) -> PaginationParams:
     if offset < 0:
         raise PaginationError("offset must be >= 0")
-    if count < 1 or count > max_count:
-        raise PaginationError(f"count must be between 1 and {max_count}")
-    return PaginationParams(count=count, offset=offset)
+    return PaginationParams(
+        count=clamp_search_page_size(count, default=LIST_PAGE_DEFAULT, max_count=max_count),
+        offset=offset,
+    )
 
 
 def build_paging(

--- a/src/core/list_paging.py
+++ b/src/core/list_paging.py
@@ -13,6 +13,26 @@ class PaginationParams:
     offset: int
 
 
+def clamp_search_page_size(
+    count: int | None,
+    max_results: int | None = None,
+    *,
+    default: int = 50,
+    max_count: int = 100,
+) -> int:
+    """Coerce agent-supplied page sizes. 0/negative become default; over max is capped."""
+    raw = default
+    if count is not None:
+        raw = count
+    elif max_results is not None:
+        raw = max_results
+    if raw < 1:
+        return default
+    if raw > max_count:
+        return max_count
+    return raw
+
+
 def validate_pagination(
     count: int = 50,
     offset: int = 0,

--- a/src/core/loader.py
+++ b/src/core/loader.py
@@ -12,12 +12,14 @@ import sys
 from typing import Any, get_type_hints
 
 from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
 from fastmcp.prompts import Message
 from fastmcp.server.dependencies import get_context
 
 from .base import BaseTool
 from .discovery import discover_tools
 from .registry import tool_registry
+from .tool_mcp_result import raise_on_tool_error_status, wrap_unexpected_tool_failure
 
 logger = logging.getLogger(__name__)
 
@@ -159,12 +161,14 @@ class ToolLoader:
 
                 # Call the tool's execute method
                 result = await tool_instance.execute(ctx, **bound_args.arguments)
-                return result
+                return raise_on_tool_error_status(result)
 
+            except ToolError:
+                raise
             except Exception as e:
                 self.logger.error(f"Tool {tool_name} execution failed: {e}")
                 self.logger.exception("Full traceback:")
-                return {"status": "error", "error": str(e)}
+                raise wrap_unexpected_tool_failure(e) from e
 
         # Set function metadata
         tool_wrapper.__name__ = tool_name

--- a/src/core/splunk_job_wait.py
+++ b/src/core/splunk_job_wait.py
@@ -1,0 +1,69 @@
+"""Poll a Splunk search job without holding the MCP request indefinitely."""
+
+import asyncio
+import os
+import time
+from dataclasses import dataclass
+from typing import Any
+
+DEFAULT_SEARCH_WAIT_SECONDS = 15.0
+
+
+@dataclass(frozen=True)
+class JobWaitSnapshot:
+    is_done: bool
+    is_failed: bool
+    cancelled: bool
+    content: dict[str, Any]
+
+
+def resolve_search_wait_seconds() -> float:
+    raw = (os.getenv("MCP_SEARCH_WAIT_SECONDS") or "").strip()
+    if not raw:
+        return DEFAULT_SEARCH_WAIT_SECONDS
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return DEFAULT_SEARCH_WAIT_SECONDS
+
+
+def _read_job(job: Any) -> tuple[bool, bool, dict[str, Any]]:
+    done = bool(job.is_done())
+    content = dict(getattr(job, "content", {}) or {})
+    failed = str(content.get("isFailed", "0")) == "1"
+    return done, failed, content
+
+
+def _cancel_job(job: Any) -> None:
+    cancel = getattr(job, "cancel", None)
+    if callable(cancel):
+        cancel()
+
+
+async def wait_for_job(
+    job: Any,
+    *,
+    wait_seconds: float,
+    poll_interval: float = 2.0,
+) -> JobWaitSnapshot:
+    deadline = time.monotonic() + max(float(wait_seconds), 0.0)
+    while True:
+        try:
+            done, failed, content = await asyncio.to_thread(_read_job, job)
+        except asyncio.CancelledError:
+            await asyncio.to_thread(_cancel_job, job)
+            raise
+        if done or failed:
+            return JobWaitSnapshot(
+                is_done=done, is_failed=failed, cancelled=False, content=content
+            )
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return JobWaitSnapshot(
+                is_done=False, is_failed=failed, cancelled=False, content=content
+            )
+        try:
+            await asyncio.sleep(min(poll_interval, remaining))
+        except asyncio.CancelledError:
+            await asyncio.to_thread(_cancel_job, job)
+            raise

--- a/src/core/tool_mcp_result.py
+++ b/src/core/tool_mcp_result.py
@@ -1,0 +1,19 @@
+"""Turn tool status:error payloads into MCP ToolError results."""
+
+from typing import Any
+
+from fastmcp.exceptions import ToolError
+
+
+def raise_on_tool_error_status(result: Any) -> Any:
+    """Raise ToolError when a tool returned a successful-looking error dict."""
+    if isinstance(result, dict) and result.get("status") == "error":
+        raise ToolError(str(result.get("error") or "Tool failed"))
+    return result
+
+
+def wrap_unexpected_tool_failure(exc: BaseException) -> ToolError:
+    """Convert unexpected tool exceptions into an agent-visible ToolError."""
+    if isinstance(exc, ToolError):
+        return exc
+    return ToolError(str(exc))

--- a/src/tools/admin/apps.py
+++ b/src/tools/admin/apps.py
@@ -7,7 +7,7 @@ from typing import Any
 from fastmcp import Context
 
 from src.core.base import BaseTool, ToolMetadata
-from src.core.list_paging import PaginationError
+from src.core.list_paging import LIST_PAGE_DEFAULT, ListPageCount, PaginationError, count_arg_help
 from src.core.splunk_rest_page import fetch_rest_collection_page
 from src.core.utils import log_tool_execution
 
@@ -24,7 +24,7 @@ class ListApps(BaseTool):
             "description, author, and visibility. If has_more is true, call again with "
             "offset=next_offset.\n\n"
             "Args:\n"
-            "    count (int, optional): Page size 1-200 (default 50)\n"
+            f"{count_arg_help()}"
             "    offset (int, optional): Result offset (default 0)\n"
             "    search_filter (str, optional): Splunk REST search filter (e.g. 'name=*TA*')"
         ),
@@ -36,7 +36,7 @@ class ListApps(BaseTool):
     async def execute(
         self,
         ctx: Context,
-        count: int = 50,
+        count: ListPageCount = LIST_PAGE_DEFAULT,
         offset: int = 0,
         search_filter: str = "",
     ) -> dict[str, Any]:

--- a/src/tools/admin/users.py
+++ b/src/tools/admin/users.py
@@ -7,7 +7,7 @@ from typing import Any
 from fastmcp import Context
 
 from src.core.base import BaseTool, ToolMetadata
-from src.core.list_paging import PaginationError
+from src.core.list_paging import LIST_PAGE_DEFAULT, ListPageCount, PaginationError, count_arg_help
 from src.core.splunk_rest_page import fetch_rest_collection_page
 from src.core.utils import log_tool_execution
 
@@ -23,7 +23,7 @@ class ListUsers(BaseTool):
             "Retrieve Splunk users and their properties (username, realname, email, roles, "
             "type, defaultApp). If has_more is true, call again with offset=next_offset.\n\n"
             "Args:\n"
-            "    count (int, optional): Page size 1-200 (default 50)\n"
+            f"{count_arg_help()}"
             "    offset (int, optional): Result offset (default 0)\n"
             "    search_filter (str, optional): Splunk REST search filter (e.g. 'name=*admin*')"
         ),
@@ -35,7 +35,7 @@ class ListUsers(BaseTool):
     async def execute(
         self,
         ctx: Context,
-        count: int = 50,
+        count: ListPageCount = LIST_PAGE_DEFAULT,
         offset: int = 0,
         search_filter: str = "",
     ) -> dict[str, Any]:

--- a/src/tools/dashboards/list_dashboards.py
+++ b/src/tools/dashboards/list_dashboards.py
@@ -8,7 +8,7 @@ from typing import Any
 from fastmcp import Context
 
 from src.core.base import BaseTool, ToolMetadata
-from src.core.list_paging import PaginationError
+from src.core.list_paging import LIST_PAGE_DEFAULT, ListPageCount, PaginationError, count_arg_help
 from src.core.splunk_rest_page import fetch_rest_collection_page
 from src.core.splunk_web_urls import web_links_from_service
 from src.core.utils import log_tool_execution
@@ -32,7 +32,8 @@ class ListDashboards(BaseTool):
             "    owner (str, optional): Filter by owner. Use 'me' for current user's dashboards, "
             "'nobody' for shared dashboards, or a specific username. Default: 'nobody'\n"
             "    app (str, optional): Filter by app context. Default: '-' (all apps)\n"
-            "    count (int, optional): Page size 1-200 (default 50). If has_more, use offset=next_offset\n"
+            f"{count_arg_help()}"
+            "    If has_more is true, call again with offset=next_offset.\n"
             "    offset (int, optional): Result offset for pagination. Default: 0\n"
             "    search_filter (str, optional): Filter results (e.g., 'name=*security*')\n"
             "    type_filter (str, optional): Filter by type: 'classic', 'studio', or 'any'. Default: 'any'\n"
@@ -51,7 +52,7 @@ class ListDashboards(BaseTool):
         ctx: Context,
         owner: str = "nobody",
         app: str = "-",
-        count: int = 50,
+        count: ListPageCount = LIST_PAGE_DEFAULT,
         offset: int = 0,
         search_filter: str = "",
         type_filter: str = "any",

--- a/src/tools/kvstore/collections.py
+++ b/src/tools/kvstore/collections.py
@@ -9,7 +9,7 @@ from splunklib import client as spl_client
 from splunklib.binding import HTTPError
 
 from src.core.base import BaseTool, ToolMetadata
-from src.core.list_paging import PaginationError
+from src.core.list_paging import LIST_PAGE_DEFAULT, ListPageCount, PaginationError, count_arg_help
 from src.core.splunk_rest_page import fetch_rest_collection_page
 from src.core.utils import log_tool_execution
 
@@ -90,7 +90,7 @@ class ListKvstoreCollections(BaseTool):
             "Security: results are constrained by the authenticated user's permissions."
             "Args:\n"
             "    app (str, optional): Optional app name to filter collections\n"
-            "    count (int, optional): Page size 1-200 (default 50)\n"
+            f"{count_arg_help()}"
             "    offset (int, optional): Result offset (default 0)\n\n"
         ),
         category="kvstore",
@@ -102,7 +102,7 @@ class ListKvstoreCollections(BaseTool):
         self,
         ctx: Context,
         app: str | None = None,
-        count: int = 50,
+        count: ListPageCount = LIST_PAGE_DEFAULT,
         offset: int = 0,
     ) -> dict[str, Any]:
         """

--- a/src/tools/lookups/list_lookup_definitions.py
+++ b/src/tools/lookups/list_lookup_definitions.py
@@ -7,7 +7,7 @@ from typing import Any
 from fastmcp import Context
 
 from src.core.base import BaseTool, ToolMetadata
-from src.core.list_paging import PaginationError
+from src.core.list_paging import LIST_PAGE_DEFAULT, ListPageCount, PaginationError, count_arg_help
 from src.core.splunk_rest_page import fetch_rest_collection_page
 from src.core.utils import log_tool_execution
 
@@ -30,7 +30,8 @@ class ListLookupDefinitions(BaseTool):
             "Args:\n"
             "    owner (str, optional): Filter by owner. Default: 'nobody' (all users)\n"
             "    app (str, optional): Filter by app context. Default: '-' (all apps)\n"
-            "    count (int, optional): Page size 1-200 (default 50). If has_more, use offset=next_offset\n"
+            f"{count_arg_help()}"
+            "    If has_more is true, call again with offset=next_offset.\n"
             "    offset (int, optional): Result offset for pagination. Default: 0\n"
             "    search_filter (str, optional): Filter results (e.g., 'filename=*.csv')"
         ),
@@ -44,7 +45,7 @@ class ListLookupDefinitions(BaseTool):
         ctx: Context,
         owner: str = "nobody",
         app: str = "-",
-        count: int = 50,
+        count: ListPageCount = LIST_PAGE_DEFAULT,
         offset: int = 0,
         search_filter: str = "",
     ) -> dict[str, Any]:

--- a/src/tools/lookups/list_lookup_files.py
+++ b/src/tools/lookups/list_lookup_files.py
@@ -7,7 +7,7 @@ from typing import Any
 from fastmcp import Context
 
 from src.core.base import BaseTool, ToolMetadata
-from src.core.list_paging import PaginationError
+from src.core.list_paging import LIST_PAGE_DEFAULT, ListPageCount, PaginationError, count_arg_help
 from src.core.splunk_rest_page import fetch_rest_collection_page
 from src.core.utils import log_tool_execution
 
@@ -31,7 +31,8 @@ class ListLookupFiles(BaseTool):
             "Args:\n"
             "    owner (str, optional): Filter by owner. Default: 'nobody' (all users)\n"
             "    app (str, optional): Filter by app context. Default: '-' (all apps)\n"
-            "    count (int, optional): Page size 1-200 (default 50). If has_more, use offset=next_offset\n"
+            f"{count_arg_help()}"
+            "    If has_more is true, call again with offset=next_offset.\n"
             "    offset (int, optional): Result offset for pagination. Default: 0\n"
             "    search_filter (str, optional): Filter results (e.g., 'name=*geo*')"
         ),
@@ -45,7 +46,7 @@ class ListLookupFiles(BaseTool):
         ctx: Context,
         owner: str = "nobody",
         app: str = "-",
-        count: int = 50,
+        count: ListPageCount = LIST_PAGE_DEFAULT,
         offset: int = 0,
         search_filter: str = "",
     ) -> dict[str, Any]:

--- a/src/tools/metadata/get_metadata.py
+++ b/src/tools/metadata/get_metadata.py
@@ -29,7 +29,8 @@ class GetMetadata(BaseTool):
             "    field (str, optional): 'host', 'sourcetype', or 'source' (default 'host')\n"
             "    earliest_time (str, optional): Start time (default '-24h@h')\n"
             "    latest_time (str, optional): End time (default 'now')\n"
-            "    limit (int, optional): Page size 1-100 (default 100)\n"
+            "    limit (int, optional): Page size. Default 100. Maximum 100. "
+            "Values above 100 are capped; 0 uses 50. Do not send a larger limit.\n"
             "    offset (int, optional): Result offset (default 0)"
         ),
         category="metadata",

--- a/src/tools/metadata/indexes.py
+++ b/src/tools/metadata/indexes.py
@@ -7,7 +7,7 @@ from typing import Any
 from fastmcp import Context
 
 from src.core.base import BaseTool, ToolMetadata
-from src.core.list_paging import PaginationError
+from src.core.list_paging import LIST_PAGE_DEFAULT, ListPageCount, PaginationError, count_arg_help
 from src.core.splunk_rest_page import fetch_rest_collection_page
 from src.core.utils import log_tool_execution
 
@@ -25,7 +25,7 @@ class ListIndexes(BaseTool):
             "Excludes internal indexes (name starts with _) unless include_internal is true. "
             "If has_more is true, call again with offset=next_offset.\n\n"
             "Args:\n"
-            "    count (int, optional): Page size 1-200 (default 50)\n"
+            f"{count_arg_help()}"
             "    offset (int, optional): Result offset (default 0)\n"
             "    search_filter (str, optional): Splunk REST search filter (e.g. 'name=*sec*')\n"
             "    include_internal (bool, optional): Include _internal-style indexes (default false)"
@@ -38,7 +38,7 @@ class ListIndexes(BaseTool):
     async def execute(
         self,
         ctx: Context,
-        count: int = 50,
+        count: ListPageCount = LIST_PAGE_DEFAULT,
         offset: int = 0,
         search_filter: str = "",
         include_internal: bool = False,

--- a/src/tools/metadata/sources.py
+++ b/src/tools/metadata/sources.py
@@ -7,7 +7,13 @@ from typing import Any
 from fastmcp import Context
 
 from src.core.base import BaseTool, ToolMetadata
-from src.core.list_paging import PaginationError
+from src.core.list_paging import (
+    LIST_PAGE_DEFAULT,
+    METADATA_PAGE_MAX,
+    MetadataPageCount,
+    PaginationError,
+    count_arg_help,
+)
 from src.core.splunk_metadata_page import fetch_metadata_page
 from src.core.utils import log_tool_execution
 
@@ -23,7 +29,7 @@ class ListSources(BaseTool):
             "Discover data sources using the metadata command. Sources can be numerous; "
             "results are paged. If has_more is true, call again with offset=next_offset.\n\n"
             "Args:\n"
-            "    count (int, optional): Page size 1-100 (default 50)\n"
+            f"{count_arg_help(max_count=METADATA_PAGE_MAX)}"
             "    offset (int, optional): Result offset (default 0)\n"
             "    index (str, optional): Limit to one index"
         ),
@@ -35,7 +41,7 @@ class ListSources(BaseTool):
     async def execute(
         self,
         ctx: Context,
-        count: int = 50,
+        count: MetadataPageCount = LIST_PAGE_DEFAULT,
         offset: int = 0,
         index: str | None = None,
     ) -> dict[str, Any]:

--- a/src/tools/metadata/sourcetypes.py
+++ b/src/tools/metadata/sourcetypes.py
@@ -7,7 +7,13 @@ from typing import Any
 from fastmcp import Context
 
 from src.core.base import BaseTool, ToolMetadata
-from src.core.list_paging import PaginationError
+from src.core.list_paging import (
+    LIST_PAGE_DEFAULT,
+    METADATA_PAGE_MAX,
+    MetadataPageCount,
+    PaginationError,
+    count_arg_help,
+)
 from src.core.splunk_metadata_page import fetch_metadata_page
 from src.core.utils import log_tool_execution
 
@@ -23,7 +29,7 @@ class ListSourcetypes(BaseTool):
             "Discover sourcetypes using the metadata command. Large environments are paged. "
             "If has_more is true, call again with offset=next_offset.\n\n"
             "Args:\n"
-            "    count (int, optional): Page size 1-100 (default 50)\n"
+            f"{count_arg_help(max_count=METADATA_PAGE_MAX)}"
             "    offset (int, optional): Result offset (default 0)\n"
             "    index (str, optional): Limit to one index"
         ),
@@ -35,7 +41,7 @@ class ListSourcetypes(BaseTool):
     async def execute(
         self,
         ctx: Context,
-        count: int = 50,
+        count: MetadataPageCount = LIST_PAGE_DEFAULT,
         offset: int = 0,
         index: str | None = None,
     ) -> dict[str, Any]:

--- a/src/tools/search/job_results.py
+++ b/src/tools/search/job_results.py
@@ -6,8 +6,12 @@ from typing import Any
 from fastmcp import Context
 
 from src.core.base import BaseTool, ToolMetadata
-from src.core.list_paging import PaginationError
-from src.core.splunk_job_results_page import JobResultsError, fetch_job_results_page
+from src.core.list_paging import PaginationError, clamp_search_page_size
+from src.core.splunk_job_results_page import (
+    SEARCH_PAGE_MAX,
+    JobResultsError,
+    fetch_job_results_page,
+)
 from src.core.splunk_web_urls import web_links_from_service
 from src.core.utils import log_tool_execution
 
@@ -23,7 +27,7 @@ class GetSearchJobResults(BaseTool):
             "when has_more is true. Pass job_id and offset=next_offset.\n\n"
             "Args:\n"
             "    job_id (str): Splunk search job id (sid)\n"
-            "    count (int, optional): Page size 1-100 (default 50)\n"
+            "    count (int, optional): Page size 1-100 (default 50; 0 uses default)\n"
             "    offset (int, optional): Result offset (default 0)\n"
         ),
         category="search",
@@ -38,6 +42,7 @@ class GetSearchJobResults(BaseTool):
         count: int = 50,
         offset: int = 0,
     ) -> dict[str, Any]:
+        count = clamp_search_page_size(count, max_count=SEARCH_PAGE_MAX)
         log_tool_execution("get_search_job_results", job_id=job_id, count=count, offset=offset)
         if not job_id or not job_id.strip():
             return self.format_error_response("job_id is required", job_id=job_id)

--- a/src/tools/search/job_search.py
+++ b/src/tools/search/job_search.py
@@ -9,17 +9,18 @@ from typing import Any
 from fastmcp import Context
 
 from src.core.base import BaseTool, ToolMetadata
-from src.core.list_paging import PaginationError
+from src.core.list_paging import PaginationError, clamp_search_page_size
 from src.core.splunk_job_results_page import (
     JOB_TTL_SECONDS,
+    SEARCH_PAGE_MAX,
     JobResultsError,
     apply_job_ttl,
     fetch_job_results_page,
 )
+from src.core.splunk_job_wait import resolve_search_wait_seconds, wait_for_job
 from src.core.splunk_web_urls import web_links_from_service
 from src.core.utils import log_tool_execution, sanitize_search_query
 from src.tools.search.job_message_parser import JobMessageParser
-from src.tools.search.oneshot_search import _resolve_page_size
 
 
 class JobSearch(BaseTool):
@@ -36,8 +37,11 @@ class JobSearch(BaseTool):
             "long‑running queries (joins, transforms, large scans) where you need job status, scan/"
             "event counts, and reliable result retrieval. Prefer this over oneshot when the query may "
             "exceed ~30s or requires progress visibility.\n\n"
-            "Outputs: job id, first result page, paging fields, and Splunk Web job links. "
-            "If has_more is true, call get_search_job_results with job_id and offset=next_offset.\n"
+            "Waits up to MCP_SEARCH_WAIT_SECONDS (default 15) then returns job_id even if the job "
+            "is still running. If is_done is false, poll get_search_job_info, then "
+            "get_search_job_results. If has_more is true after completion, page with "
+            "offset=next_offset.\n"
+            "count/max_results of 0 is treated as the default page size (50), max 100.\n"
             "Security: results are constrained by the authenticated user's permissions.\n\n"
             "Args:\n"
             "    query (str): The Splunk search query (SPL) to execute. Can be any valid SPL command"
@@ -50,7 +54,7 @@ class JobSearch(BaseTool):
             "    latest_time (str, optional): Search end time in Splunk time format."
             "                Examples: 'now', '-1h', '@d', '2023-01-01T23:59:59'"
             "                Default: 'now'"
-            "    count (int, optional): Page size 1-100 (default 50)\n"
+            "    count (int, optional): Page size 1-100 (default 50; 0 uses default)\n"
             "    max_results (int, optional): Deprecated alias for count\n"
             "    offset (int, optional): Result offset (default 0)"
         ),
@@ -69,24 +73,6 @@ class JobSearch(BaseTool):
         max_results: int | None = None,
         offset: int = 0,
     ) -> dict[str, Any]:
-        """
-        Execute a Splunk search job with comprehensive progress tracking and statistics.
-
-        Args:
-            query (str): The Splunk search query (SPL) to execute. Can be any valid SPL command
-                        or pipeline. Supports complex searches with transforming commands, joins,
-                        and subsearches. Examples: "index=* | stats count by sourcetype",
-                        "search error | eval severity=case(...)"
-            earliest_time (str, optional): Search start time in Splunk time format.
-                                         Examples: "-24h", "-7d@d", "2023-01-01T00:00:00"
-                                         Default: "-24h"
-            latest_time (str, optional): Search end time in Splunk time format.
-                                       Examples: "now", "-1h", "@d", "2023-01-01T23:59:59"
-                                       Default: "now"
-
-        Returns:
-            Dict containing search results, job statistics, progress information, and performance metrics
-        """
         log_tool_execution(
             "run_splunk_search", query=query, earliest_time=earliest_time, latest_time=latest_time
         )
@@ -97,8 +83,8 @@ class JobSearch(BaseTool):
             await ctx.error(f"Search job failed: {error_msg}")
             return self.format_error_response(error_msg)
 
-        # Sanitize and prepare the query
         query = sanitize_search_query(query)
+        page_size = clamp_search_page_size(count, max_results, max_count=SEARCH_PAGE_MAX)
 
         self.logger.info(f"Starting normal search with query: {query}")
         await ctx.info(f"Starting normal search with query: {query}")
@@ -106,58 +92,30 @@ class JobSearch(BaseTool):
 
         try:
             start_time = time.time()
-
-            # Create the search job
-            job = service.jobs.create(query, earliest_time=earliest_time, latest_time=latest_time)
+            job = await asyncio.to_thread(
+                service.jobs.create, query, earliest_time=earliest_time, latest_time=latest_time
+            )
             apply_job_ttl(job, JOB_TTL_SECONDS)
             await ctx.info(f"Search job created: {job.sid}")
 
-            # Poll for completion
-            while not job.is_done():
-                stats = job.content
+            snapshot = await wait_for_job(
+                job, wait_seconds=resolve_search_wait_seconds()
+            )
+            stats = snapshot.content
+            await self._report_progress(ctx, stats)
 
-                # Check if job failed during execution
-                if stats.get("isFailed", "0") == "1":
-                    parsed = JobMessageParser.parse(stats.get("messages"))
-                    error_detail = "; ".join(parsed.error_texts) if parsed.error_texts else (
-                        "Job failed with no specific error message"
-                    )
-                    self.logger.error(f"Search job {job.sid} failed: {error_detail}")
-                    await ctx.error(f"Search job {job.sid} failed: {error_detail}")
-                    return self.format_error_response(f"Search job failed: {error_detail}")
+            if snapshot.is_failed:
+                return await self._failed_job_response(ctx, job.sid, stats)
 
-                progress_dict = {
-                    "done": stats.get("isDone", "0") == "1",
-                    "progress": float(stats.get("doneProgress", 0)) * 100,
-                    "scan_progress": float(stats.get("scanCount", 0)),
-                    "event_progress": float(stats.get("eventCount", 0)),
-                }
-
-                # Report progress with just the numeric value
-                await ctx.report_progress(progress=int(progress_dict["progress"]), total=100)
-
-                self.logger.info(
-                    f"Search job {job.sid} in progress... "
-                    f"Progress: {progress_dict['progress']:.1f}%, "
-                    f"Scanned: {progress_dict['scan_progress']} events, "
-                    f"Matched: {progress_dict['event_progress']} events"
+            client_config = await self.get_client_config_from_context(ctx)
+            links = web_links_from_service(service, client_config)
+            duration = time.time() - start_time
+            if not snapshot.is_done:
+                return self._incomplete_job_response(
+                    job.sid, query, stats, duration, links, offset
                 )
-                await asyncio.sleep(2)
-
-            # Final check for job failure after completion
-            await ctx.report_progress(progress=100, total=100)
-            final_stats = job.content
-            if final_stats.get("isFailed", "0") == "1":
-                parsed = JobMessageParser.parse(final_stats.get("messages"))
-                error_detail = "; ".join(parsed.error_texts) if parsed.error_texts else (
-                    "Job failed with no specific error message"
-                )
-                self.logger.error(f"Search job {job.sid} failed after completion: {error_detail}")
-                await ctx.error(f"Search job {job.sid} failed: {error_detail}")
-                return self.format_error_response(f"Search job failed: {error_detail}")
 
             await ctx.info(f"Getting results for search job: {job.sid}")
-            page_size = _resolve_page_size(count, max_results)
             try:
                 page = await asyncio.to_thread(
                     fetch_job_results_page, job, count=page_size, offset=offset
@@ -166,12 +124,6 @@ class JobSearch(BaseTool):
                 await ctx.error(f"Error reading search results: {results_error}")
                 return self.format_error_response(f"Error reading search results: {results_error}")
 
-            # Get final job stats
-            stats = job.content
-            duration = time.time() - start_time
-
-            client_config = await self.get_client_config_from_context(ctx)
-            links = web_links_from_service(service, client_config)
             return self.format_success_response(
                 {
                     "is_done": True,
@@ -186,7 +138,7 @@ class JobSearch(BaseTool):
                     "job_status": {
                         "progress": 100,
                         "is_finalized": stats.get("isFinalized", "0") == "1",
-                        "is_failed": stats.get("isFailed", "0") == "1",
+                        "is_failed": False,
                     },
                     **page.paging,
                     **links.job_links(job.sid),
@@ -194,11 +146,8 @@ class JobSearch(BaseTool):
             )
 
         except Exception as e:
-            # Enhanced exception logging
             self.logger.error(f"Search failed with exception: {str(e)}", exc_info=True)
             await ctx.error(f"Search failed: {str(e)}")
-
-            # Try to provide more context about the error
             error_detail = str(e)
             if "Connection" in error_detail or "connection" in error_detail:
                 error_detail += " (Check Splunk server connectivity and credentials)"
@@ -206,5 +155,59 @@ class JobSearch(BaseTool):
                 error_detail += " (Check Splunk username and password)"
             elif "Permission" in error_detail or "permission" in error_detail:
                 error_detail += " (Check user permissions for search and index access)"
-
             return self.format_error_response(error_detail)
+
+    async def _failed_job_response(
+        self, ctx: Context, sid: str, stats: dict[str, Any]
+    ) -> dict[str, Any]:
+        parsed = JobMessageParser.parse(stats.get("messages"))
+        error_detail = (
+            "; ".join(parsed.error_texts)
+            if parsed.error_texts
+            else "Job failed with no specific error message"
+        )
+        self.logger.error(f"Search job {sid} failed: {error_detail}")
+        await ctx.error(f"Search job {sid} failed: {error_detail}")
+        return self.format_error_response(f"Search job failed: {error_detail}")
+
+    def _incomplete_job_response(
+        self,
+        sid: str,
+        query: str,
+        stats: dict[str, Any],
+        duration: float,
+        links: Any,
+        offset: int,
+    ) -> dict[str, Any]:
+        progress = int(float(stats.get("doneProgress", 0)) * 100)
+        return self.format_success_response(
+            {
+                "is_done": False,
+                "results": [],
+                "scan_count": int(float(stats.get("scanCount", 0) or 0)),
+                "event_count": int(float(stats.get("eventCount", 0) or 0)),
+                "results_count": 0,
+                "query_executed": query,
+                "duration": round(duration, 3),
+                "job_status": {
+                    "progress": progress,
+                    "is_finalized": stats.get("isFinalized", "0") == "1",
+                    "is_failed": False,
+                },
+                "count": 0,
+                "offset": offset,
+                "total_available": int(float(stats.get("resultCount", 0) or 0)),
+                "has_more": False,
+                "next_offset": None,
+                "poll_with": "get_search_job_info",
+                **links.job_links(sid),
+            }
+        )
+
+    async def _report_progress(self, ctx: Context, stats: dict[str, Any]) -> None:
+        progress = int(float(stats.get("doneProgress", 0)) * 100)
+        self.logger.info(
+            f"Search job progress {progress}%, "
+            f"scanned {stats.get('scanCount', 0)}, matched {stats.get('eventCount', 0)}"
+        )
+        await ctx.report_progress(progress=progress, total=100)

--- a/src/tools/search/list_saved_searches.py
+++ b/src/tools/search/list_saved_searches.py
@@ -5,7 +5,7 @@ from typing import Any, Literal
 from fastmcp import Context
 
 from src.core.base import BaseTool, ToolMetadata
-from src.core.list_paging import PaginationError
+from src.core.list_paging import LIST_PAGE_DEFAULT, ListPageCount, PaginationError, count_arg_help
 from src.core.splunk_rest_page import fetch_rest_collection_page
 from src.core.utils import log_tool_execution
 
@@ -42,7 +42,7 @@ class ListSavedSearches(BaseTool):
             "    app (str, optional): Filter by app (default all)\n"
             "    sharing (str, optional): Filter by sharing level\n"
             "    include_disabled (bool, optional): Include disabled searches (default false)\n"
-            "    count (int, optional): Page size 1-200 (default 50)\n"
+            f"{count_arg_help()}"
             "    offset (int, optional): Result offset (default 0)\n"
             "    search_filter (str, optional): Extra REST search filter (e.g. 'name=*alert*')"
         ),
@@ -58,7 +58,7 @@ class ListSavedSearches(BaseTool):
         app: str | None = None,
         sharing: Literal["user", "app", "global", "system"] | None = None,
         include_disabled: bool = False,
-        count: int = 50,
+        count: ListPageCount = LIST_PAGE_DEFAULT,
         offset: int = 0,
         search_filter: str = "",
     ) -> dict[str, Any]:

--- a/src/tools/search/oneshot_search.py
+++ b/src/tools/search/oneshot_search.py
@@ -9,9 +9,10 @@ from typing import Any
 from fastmcp import Context
 
 from src.core.base import BaseTool, ToolMetadata
-from src.core.list_paging import PaginationError
+from src.core.list_paging import PaginationError, clamp_search_page_size
 from src.core.splunk_job_results_page import (
     JOB_TTL_SECONDS,
+    SEARCH_PAGE_MAX,
     JobResultsError,
     apply_job_ttl,
     fetch_job_results_page,
@@ -21,11 +22,7 @@ from src.core.utils import log_tool_execution, sanitize_search_query
 
 
 def _resolve_page_size(count: int | None, max_results: int | None) -> int:
-    if count is not None:
-        return count
-    if max_results is not None:
-        return max_results
-    return 50
+    return clamp_search_page_size(count, max_results, max_count=SEARCH_PAGE_MAX)
 
 
 def _create_blocking_job(
@@ -58,7 +55,7 @@ class OneshotSearch(BaseTool):
             "    query (str): SPL to execute\n"
             "    earliest_time (str, optional): Start time (default '-15m')\n"
             "    latest_time (str, optional): End time (default 'now')\n"
-            "    count (int, optional): Page size 1-100 (default 50)\n"
+            "    count (int, optional): Page size 1-100 (default 50; 0 uses default)\n"
             "    max_results (int, optional): Deprecated alias for count\n"
             "    offset (int, optional): Result offset (default 0)"
         ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ Test configuration and fixtures for MCP Server for Splunk tests.
 import json
 import os
 import sys
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -21,8 +22,10 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 # Import FastMCP for proper testing
 try:
     from fastmcp import Client
+    from fastmcp.exceptions import ToolError
 except ImportError:
     Client = None
+    ToolError = Exception
 
 
 # Mock classes that match the actual structure
@@ -692,6 +695,33 @@ def extract_tool_result():
             return {"empty_result": True}
 
     return _extract
+
+
+def wrap_client_tool_errors(client):
+    """Map MCP ToolError to a status/error payload so legacy client tests still read .data."""
+    original = client.call_tool
+
+    async def _call_tool(*args, **kwargs):
+        try:
+            return await original(*args, **kwargs)
+        except ToolError as exc:
+            return SimpleNamespace(data={"status": "error", "error": str(exc)})
+
+    client.call_tool = _call_tool
+    return client
+
+
+@pytest.fixture
+def tool_payload(extract_tool_result):
+    """Call a tool and map MCP ToolError to the legacy status/error dict."""
+
+    async def _call(client, name: str, arguments: dict | None = None) -> dict:
+        try:
+            return extract_tool_result(await client.call_tool(name, arguments or {}))
+        except ToolError as exc:
+            return {"status": "error", "error": str(exc)}
+
+    return _call
 
 
 @pytest.fixture

--- a/tests/test_alert_tools.py
+++ b/tests/test_alert_tools.py
@@ -32,10 +32,11 @@ class TestAlertToolAvailability:
             assert "confirm" in properties
 
     async def test_create_alert_without_splunk_returns_error(
-        self, fastmcp_client, extract_tool_result
+        self, fastmcp_client, tool_payload
     ):
         async with fastmcp_client as client:
-            result = await client.call_tool(
+            data = await tool_payload(
+                client,
                 "create_alert",
                 {
                     "name": "unit_test_alert",
@@ -43,7 +44,6 @@ class TestAlertToolAvailability:
                     "cron_schedule": "0 0 1 1 *",
                 },
             )
-            data = extract_tool_result(result)
             assert isinstance(data, dict)
             assert "status" in data
             if data.get("status") == "error":

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -80,7 +80,7 @@ class TestListTriggeredAlerts:
         return service
 
     async def test_list_triggered_alerts_success(
-        self, fastmcp_client, extract_tool_result, mock_service
+        self, fastmcp_client, tool_payload, mock_service
     ):
         """Test successful listing of triggered alerts."""
         # Mock the fired_alerts method to return our test data
@@ -89,8 +89,7 @@ class TestListTriggeredAlerts:
         ):
             async with fastmcp_client as client:
                 # Execute tool through FastMCP
-                result = await client.call_tool("list_triggered_alerts", {})
-                data = extract_tool_result(result)
+                data = await tool_payload(client, "list_triggered_alerts")
 
                 # In test mode, we expect either success or error status
                 if data.get("status") == "success":
@@ -113,15 +112,14 @@ class TestListTriggeredAlerts:
                     # Ensure we get some kind of response
                     assert isinstance(data, dict)
 
-    async def test_list_triggered_alerts_with_parameters(self, fastmcp_client, extract_tool_result):
+    async def test_list_triggered_alerts_with_parameters(self, fastmcp_client, tool_payload):
         """Test listing triggered alerts with custom parameters."""
         async with fastmcp_client as client:
-            # Execute tool with custom parameters
-            result = await client.call_tool(
+            data = await tool_payload(
+                client,
                 "list_triggered_alerts",
                 {"count": 100, "earliest_time": "-1h@h", "latest_time": "-30m@m", "search": "CPU"},
             )
-            data = extract_tool_result(result)
 
             # Verify we get a response
             assert isinstance(data, dict)
@@ -135,13 +133,11 @@ class TestListTriggeredAlerts:
                 assert params["search_filter"] == "CPU"
 
     async def test_list_triggered_alerts_basic_functionality(
-        self, fastmcp_client, extract_tool_result
+        self, fastmcp_client, tool_payload
     ):
         """Test basic alerts tool functionality."""
         async with fastmcp_client as client:
-            # Execute tool with basic parameters
-            result = await client.call_tool("list_triggered_alerts", {})
-            data = extract_tool_result(result)
+            data = await tool_payload(client, "list_triggered_alerts")
 
             # Verify we get a proper response structure
             assert isinstance(data, dict)

--- a/tests/test_dashboard_tools.py
+++ b/tests/test_dashboard_tools.py
@@ -80,12 +80,11 @@ class TestListDashboards:
 
         return service
 
-    async def test_list_dashboards_success(self, fastmcp_client, extract_tool_result):
+    async def test_list_dashboards_success(self, fastmcp_client, tool_payload):
         """Test successful listing of dashboards."""
         async with fastmcp_client as client:
             # Execute tool through FastMCP
-            result = await client.call_tool("list_dashboards", {})
-            data = extract_tool_result(result)
+            data = await tool_payload(client, "list_dashboards")
 
             # Verify response structure
             if data.get("status") == "success":
@@ -212,14 +211,13 @@ class TestGetDashboardDefinition:
 
         return service
 
-    async def test_get_dashboard_classic_success(self, fastmcp_client, extract_tool_result):
+    async def test_get_dashboard_classic_success(self, fastmcp_client, tool_payload):
         """Test successful retrieval of classic dashboard."""
         async with fastmcp_client as client:
             # Execute tool through FastMCP
-            result = await client.call_tool(
-                "get_dashboard_definition", {"name": "security_overview"}
+            data = await tool_payload(
+                client, "get_dashboard_definition", {"name": "security_overview"}
             )
-            data = extract_tool_result(result)
 
             # Verify response structure
             if data.get("status") == "success":
@@ -232,14 +230,15 @@ class TestGetDashboardDefinition:
                 if data.get("type"):
                     assert data["type"] in ["classic", "studio"]
 
-    async def test_get_dashboard_studio_success(self, fastmcp_client, extract_tool_result):
+    async def test_get_dashboard_studio_success(self, fastmcp_client, tool_payload):
         """Test successful retrieval of Dashboard Studio dashboard."""
         async with fastmcp_client as client:
             # Execute tool through FastMCP
-            result = await client.call_tool(
-                "get_dashboard_definition", {"name": "performance_dashboard", "app": "myapp"}
+            data = await tool_payload(
+                client,
+                "get_dashboard_definition",
+                {"name": "performance_dashboard", "app": "myapp"},
             )
-            data = extract_tool_result(result)
 
             # Verify response structure
             if data.get("status") == "success":
@@ -256,7 +255,7 @@ class TestGetDashboardDefinition:
 class TestCreateDashboard:
     """Test suite for CreateDashboard tool."""
 
-    async def test_create_studio_dashboard_success(self, fastmcp_client, extract_tool_result):
+    async def test_create_studio_dashboard_success(self, fastmcp_client, tool_payload):
         studio_def = {
             "version": "1.0.0",
             "title": "Studio Created",
@@ -264,7 +263,8 @@ class TestCreateDashboard:
             "visualizations": {},
         }
         async with fastmcp_client as client:
-            result = await client.call_tool(
+            data = await tool_payload(
+                client,
                 "create_dashboard",
                 {
                     "name": "studio_created",
@@ -274,16 +274,16 @@ class TestCreateDashboard:
                     "overwrite": False,
                 },
             )
-            data = extract_tool_result(result)
             if data.get("status") == "success":
                 assert data["name"] == "studio_created"
                 assert data["type"] in ["studio", "classic"]
                 assert "web_url" in data
 
-    async def test_create_classic_dashboard_success(self, fastmcp_client, extract_tool_result):
+    async def test_create_classic_dashboard_success(self, fastmcp_client, tool_payload):
         classic_xml = """<dashboard><label>Classic Created</label></dashboard>"""
         async with fastmcp_client as client:
-            result = await client.call_tool(
+            data = await tool_payload(
+                client,
                 "create_dashboard",
                 {
                     "name": "classic_created",
@@ -292,7 +292,6 @@ class TestCreateDashboard:
                     "description": "Created by tests",
                 },
             )
-            data = extract_tool_result(result)
             if data.get("status") == "success":
                 assert data["name"] == "classic_created"
                 assert data["type"] in ["studio", "classic"]
@@ -461,12 +460,13 @@ class TestCreateDashboard:
         assert stored == prewrapped
         assert result.get("type") == "studio"
 
-    async def test_overwrite_existing_dashboard(self, fastmcp_client, extract_tool_result):
+    async def test_overwrite_existing_dashboard(self, fastmcp_client, tool_payload):
         # First attempt should simulate conflict -> then overwrite path
         classic_xml = """<dashboard><label>Exists</label></dashboard>"""
         async with fastmcp_client as client:
             # initial create will throw conflict in mock; overwrite=True triggers update path
-            result = await client.call_tool(
+            data = await tool_payload(
+                client,
                 "create_dashboard",
                 {
                     "name": "exists_dashboard",
@@ -474,16 +474,16 @@ class TestCreateDashboard:
                     "overwrite": True,
                 },
             )
-            data = extract_tool_result(result)
             # Should still succeed with update path
             if data.get("status") == "success":
                 assert data["name"] == "exists_dashboard"
                 assert "web_url" in data
 
-    async def test_acl_update(self, fastmcp_client, extract_tool_result):
+    async def test_acl_update(self, fastmcp_client, tool_payload):
         studio_def = {"version": "1.0.0", "title": "ACL Demo"}
         async with fastmcp_client as client:
-            result = await client.call_tool(
+            data = await tool_payload(
+                client,
                 "create_dashboard",
                 {
                     "name": "acl_demo",
@@ -493,7 +493,6 @@ class TestCreateDashboard:
                     "write_perms": ["admin"],
                 },
             )
-            data = extract_tool_result(result)
             if data.get("status") == "success":
                 assert data["name"] == "acl_demo"
                 # The mock service sets ACL; we simply assert success contract

--- a/tests/test_get_search_job_results.py
+++ b/tests/test_get_search_job_results.py
@@ -81,8 +81,10 @@ class TestGetSearchJobResults:
         assert result["status"] == "error"
         assert "job_id" in result["error"]
 
-    async def test_rejects_invalid_count(self, tool, mock_context, mock_service, mock_job):
+    async def test_clamps_zero_count_to_default(self, tool, mock_context, mock_service, mock_job):
         tool.check_splunk_available = Mock(return_value=(True, mock_service, None))
+        tool.get_client_config_from_context = AsyncMock(return_value={})
         result = await tool.execute(mock_context, job_id=mock_job.sid, count=0)
-        assert result["status"] == "error"
-        assert "count" in result["error"]
+        assert result["status"] == "success"
+        mock_job.results.assert_called()
+        assert mock_job.results.call_args.kwargs["count"] == 50

--- a/tests/test_job_search_wait.py
+++ b/tests/test_job_search_wait.py
@@ -1,0 +1,89 @@
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from src.tools.search.job_search import JobSearch
+
+
+@pytest.fixture
+def job_search_tool() -> JobSearch:
+    return JobSearch("run_splunk_search", "search")
+
+
+@pytest.fixture
+def mock_context() -> Mock:
+    ctx = Mock()
+    ctx.info = AsyncMock()
+    ctx.error = AsyncMock()
+    ctx.report_progress = AsyncMock()
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_run_splunk_search_returns_job_id_when_wait_expires(
+    job_search_tool: JobSearch, mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MCP_SEARCH_WAIT_SECONDS", "0")
+    service = Mock()
+    service.host = "splunk.example"
+    service.scheme = "https"
+    job = Mock()
+    job.sid = "1788882620.1334"
+    job.is_done.return_value = False
+    job.content = {
+        "isDone": "0",
+        "isFailed": "0",
+        "doneProgress": "0.4",
+        "scanCount": "12",
+        "eventCount": "3",
+        "resultCount": "0",
+    }
+    service.jobs.create.return_value = job
+    job_search_tool.check_splunk_available = Mock(return_value=(True, service, None))
+    job_search_tool.get_client_config_from_context = AsyncMock(return_value={})
+
+    result = await job_search_tool.execute(mock_context, query="index=_internal | head 1")
+
+    assert result["status"] == "success"
+    assert result["is_done"] is False
+    assert result["job_id"] == "1788882620.1334"
+    assert result["poll_with"] == "get_search_job_info"
+    assert result["results"] == []
+    job.results.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_splunk_search_clamps_zero_count_instead_of_erroring(
+    job_search_tool: JobSearch, mock_context: Mock
+) -> None:
+    service = Mock()
+    service.host = "splunk.example"
+    service.scheme = "https"
+    job = Mock()
+    job.sid = "job.done"
+    job.is_done.return_value = True
+    job.content = {
+        "isDone": "1",
+        "isFailed": "0",
+        "doneProgress": "1",
+        "scanCount": "2",
+        "eventCount": "2",
+        "resultCount": "2",
+        "earliestTime": "",
+        "latestTime": "",
+        "isFinalized": "1",
+    }
+    job.results.return_value = [{"host": "a"}]
+    service.jobs.create.return_value = job
+    job_search_tool.check_splunk_available = Mock(return_value=(True, service, None))
+    job_search_tool.get_client_config_from_context = AsyncMock(return_value={})
+
+    result = await job_search_tool.execute(
+        mock_context, query="index=_internal | head 1", count=0
+    )
+
+    assert result["status"] == "success"
+    assert result["is_done"] is True
+    assert "count must be between" not in str(result)
+    job.results.assert_called()
+    assert job.results.call_args.kwargs["count"] == 50

--- a/tests/test_list_paging.py
+++ b/tests/test_list_paging.py
@@ -14,11 +14,9 @@ def test_validate_defaults() -> None:
     assert params.offset == 0
 
 
-def test_validate_rejects_zero_and_over_cap() -> None:
-    with pytest.raises(PaginationError):
-        validate_pagination(count=0)
-    with pytest.raises(PaginationError):
-        validate_pagination(count=201, max_count=200)
+def test_validate_clamps_zero_and_over_cap() -> None:
+    assert validate_pagination(count=0).count == 50
+    assert validate_pagination(count=500, max_count=200).count == 200
     with pytest.raises(PaginationError):
         validate_pagination(offset=-1)
 

--- a/tests/test_list_paging.py
+++ b/tests/test_list_paging.py
@@ -3,6 +3,7 @@ import pytest
 from src.core.list_paging import (
     PaginationError,
     build_paging,
+    clamp_search_page_size,
     validate_pagination,
 )
 
@@ -31,6 +32,17 @@ def test_has_more_and_next_offset() -> None:
         "has_more": True,
         "next_offset": 50,
     }
+
+
+def test_clamp_search_page_size_treats_zero_as_default() -> None:
+    assert clamp_search_page_size(0) == 50
+    assert clamp_search_page_size(None, 0) == 50
+    assert clamp_search_page_size(-5) == 50
+
+
+def test_clamp_search_page_size_caps_over_max() -> None:
+    assert clamp_search_page_size(500, max_count=100) == 100
+    assert clamp_search_page_size(25) == 25
 
 
 def test_last_page_has_no_next() -> None:

--- a/tests/test_list_saved_searches_pagination.py
+++ b/tests/test_list_saved_searches_pagination.py
@@ -44,10 +44,13 @@ async def test_list_saved_searches_uses_rest_paging() -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_lookup_files_rejects_count_zero() -> None:
+async def test_list_lookup_files_clamps_count_zero() -> None:
+    payload = {"entry": [], "paging": {"total": 0, "offset": 0}}
+    service = Mock()
+    service.get.return_value = SimpleNamespace(body=_Body(payload))
     tool = ListLookupFiles("list_lookup_files", "list")
-    tool.check_splunk_available = Mock(return_value=(True, Mock(), ""))
+    tool.check_splunk_available = Mock(return_value=(True, service, ""))
     ctx = SimpleNamespace(info=AsyncMock(), error=AsyncMock())
     result = await tool.execute(ctx, count=0)
-    assert result["status"] == "error"
-    assert "count" in result["error"]
+    assert result["status"] == "success"
+    assert service.get.call_args.kwargs["count"] == 50

--- a/tests/test_list_tools_pagination.py
+++ b/tests/test_list_tools_pagination.py
@@ -57,13 +57,17 @@ async def test_list_indexes_pages_and_excludes_internal() -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_indexes_rejects_count_zero() -> None:
+async def test_list_indexes_clamps_oversize_count() -> None:
+    service = _collection_service(
+        [{"name": "main", "content": {}, "acl": {}}],
+        total=1,
+    )
     tool = ListIndexes("list_indexes", "list")
-    tool.get_splunk_service = AsyncMock(return_value=Mock())
+    tool.get_splunk_service = AsyncMock(return_value=service)
     ctx = SimpleNamespace(info=AsyncMock(), error=AsyncMock())
-    result = await tool.execute(ctx, count=0)
-    assert result["status"] == "error"
-    assert "count" in result["error"]
+    result = await tool.execute(ctx, count=500, offset=0)
+    assert result["status"] == "success"
+    assert service._captured["params"]["count"] == 200
 
 
 @pytest.mark.asyncio
@@ -97,4 +101,10 @@ async def test_list_users_pages() -> None:
 
 def test_pagination_error_type() -> None:
     with pytest.raises(PaginationError):
-        raise PaginationError("count must be between 1 and 200")
+        raise PaginationError("offset must be >= 0")
+
+
+def test_list_indexes_description_states_count_cap() -> None:
+    description = ListIndexes.METADATA.description
+    assert "Maximum 200" in description
+    assert "Do not send a count larger than 200" in description

--- a/tests/test_lookup_tools.py
+++ b/tests/test_lookup_tools.py
@@ -74,14 +74,10 @@ class TestListLookupFiles:
 
         return service
 
-    async def test_list_lookup_files_success(
-        self, fastmcp_client, extract_tool_result, mock_service
-    ):
+    async def test_list_lookup_files_success(self, fastmcp_client, tool_payload, mock_service):
         """Test successful listing of lookup files."""
         async with fastmcp_client as client:
-            # Execute tool through FastMCP
-            result = await client.call_tool("list_lookup_files", {})
-            data = extract_tool_result(result)
+            data = await tool_payload(client, "list_lookup_files")
 
             # Verify response structure
             if data.get("status") == "success":
@@ -147,13 +143,11 @@ class TestListLookupDefinitions:
         return service
 
     async def test_list_lookup_definitions_success(
-        self, fastmcp_client, extract_tool_result, mock_service
+        self, fastmcp_client, tool_payload, mock_service
     ):
         """Test successful listing of lookup definitions."""
         async with fastmcp_client as client:
-            # Execute tool through FastMCP
-            result = await client.call_tool("list_lookup_definitions", {})
-            data = extract_tool_result(result)
+            data = await tool_payload(client, "list_lookup_definitions")
 
             # Verify response structure
             if data.get("status") == "success":

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -16,12 +16,10 @@ from fastmcp.exceptions import ToolError
 class TestMCPClientIntegration:
     """Integration tests using FastMCP in-memory client following FastMCP best practices"""
 
-    async def test_fastmcp_client_health_check(self, fastmcp_client, extract_tool_result):
+    async def test_fastmcp_client_health_check(self, fastmcp_client, tool_payload):
         """Test health check via FastMCP client"""
         async with fastmcp_client as client:
-            # Call the health check tool
-            result = await client.call_tool("get_splunk_health")
-            health_data = extract_tool_result(result)
+            health_data = await tool_payload(client, "get_splunk_health")
 
             # The test should handle all possible states
             assert "status" in health_data
@@ -80,11 +78,10 @@ class TestMCPClientIntegration:
 class TestSplunkToolsIntegration:
     """Integration tests for Splunk tools using FastMCP in-memory testing"""
 
-    async def test_splunk_health_check(self, fastmcp_client, extract_tool_result):
+    async def test_splunk_health_check(self, fastmcp_client, tool_payload):
         """Test Splunk health check tool via FastMCP client"""
         async with fastmcp_client as client:
-            result = await client.call_tool("get_splunk_health")
-            health_data = extract_tool_result(result)
+            health_data = await tool_payload(client, "get_splunk_health")
 
             assert "status" in health_data
             # In test environment without Splunk connection, we expect error or disconnected
@@ -94,11 +91,10 @@ class TestSplunkToolsIntegration:
                 assert "version" in health_data
                 assert "server_name" in health_data
 
-    async def test_list_indexes(self, fastmcp_client, extract_tool_result):
+    async def test_list_indexes(self, fastmcp_client, tool_payload):
         """Test listing Splunk indexes via FastMCP client"""
         async with fastmcp_client as client:
-            result = await client.call_tool("list_indexes")
-            indexes_data = extract_tool_result(result)
+            indexes_data = await tool_payload(client, "list_indexes")
 
             # Should have either success response or error response
             if "status" in indexes_data and indexes_data["status"] == "success":
@@ -108,7 +104,7 @@ class TestSplunkToolsIntegration:
             elif "status" in indexes_data and indexes_data["status"] == "error":
                 assert "error" in indexes_data
 
-    async def test_oneshot_search(self, fastmcp_client, extract_tool_result):
+    async def test_oneshot_search(self, fastmcp_client, tool_payload):
         """Test oneshot search via FastMCP client"""
         async with fastmcp_client as client:
             search_params = {
@@ -118,8 +114,7 @@ class TestSplunkToolsIntegration:
                 "max_results": 5,
             }
 
-            result = await client.call_tool("run_oneshot_search", search_params)
-            search_data = extract_tool_result(result)
+            search_data = await tool_payload(client, "run_oneshot_search", search_params)
 
             # Should have either results or error
             if "status" in search_data and search_data["status"] == "success":
@@ -129,7 +124,7 @@ class TestSplunkToolsIntegration:
             elif "status" in search_data and search_data["status"] == "error":
                 assert "error" in search_data
 
-    async def test_job_search(self, fastmcp_client, extract_tool_result):
+    async def test_job_search(self, fastmcp_client, tool_payload):
         """Test job-based search via FastMCP client"""
         async with fastmcp_client as client:
             search_params = {
@@ -138,8 +133,7 @@ class TestSplunkToolsIntegration:
                 "latest_time": "now",
             }
 
-            result = await client.call_tool("run_splunk_search", search_params)
-            search_data = extract_tool_result(result)
+            search_data = await tool_payload(client, "run_splunk_search", search_params)
 
             # Should have either results or error
             if "job_id" in search_data:
@@ -148,11 +142,10 @@ class TestSplunkToolsIntegration:
             elif "status" in search_data and search_data["status"] == "error":
                 assert "error" in search_data
 
-    async def test_list_apps(self, fastmcp_client, extract_tool_result):
+    async def test_list_apps(self, fastmcp_client, tool_payload):
         """Test listing Splunk apps via FastMCP client"""
         async with fastmcp_client as client:
-            result = await client.call_tool("list_apps")
-            apps_data = extract_tool_result(result)
+            apps_data = await tool_payload(client, "list_apps")
 
             # Should have either apps or error
             if "apps" in apps_data:
@@ -161,11 +154,10 @@ class TestSplunkToolsIntegration:
             elif "status" in apps_data and apps_data["status"] == "error":
                 assert "error" in apps_data
 
-    async def test_list_users(self, fastmcp_client, extract_tool_result):
+    async def test_list_users(self, fastmcp_client, tool_payload):
         """Test listing Splunk users via FastMCP client"""
         async with fastmcp_client as client:
-            result = await client.call_tool("list_users")
-            users_data = extract_tool_result(result)
+            users_data = await tool_payload(client, "list_users")
 
             # Should have either users or error
             if "users" in users_data:
@@ -229,7 +221,7 @@ class TestErrorHandling:
             with pytest.raises(ToolError):
                 await client.call_tool("get_configurations", {})
 
-    async def test_search_with_invalid_query(self, fastmcp_client, extract_tool_result):
+    async def test_search_with_invalid_query(self, fastmcp_client, tool_payload):
         """Test search tool with invalid query"""
         async with fastmcp_client as client:
             search_params = {
@@ -238,8 +230,7 @@ class TestErrorHandling:
                 "max_results": 5,
             }
 
-            result = await client.call_tool("run_oneshot_search", search_params)
-            search_data = extract_tool_result(result)
+            search_data = await tool_payload(client, "run_oneshot_search", search_params)
 
             # Should return an error status or handle gracefully
             if "status" in search_data:
@@ -252,15 +243,14 @@ class TestErrorHandling:
 class TestPerformance:
     """Performance and load tests using FastMCP patterns"""
 
-    async def test_multiple_rapid_health_checks(self, fastmcp_client, extract_tool_result):
+    async def test_multiple_rapid_health_checks(self, fastmcp_client, tool_payload):
         """Test multiple rapid health check calls"""
         async with fastmcp_client as client:
             start_time = time.time()
 
             # Call health check multiple times
             for _ in range(10):  # Reduced from 100 to be more reasonable
-                result = await client.call_tool("get_splunk_health")
-                health_data = extract_tool_result(result)
+                health_data = await tool_payload(client, "get_splunk_health")
                 assert "status" in health_data
 
             end_time = time.time()
@@ -275,38 +265,30 @@ class TestPerformance:
 class TestWorkflowIntegration:
     """Test realistic workflows using FastMCP patterns"""
 
-    async def test_discovery_workflow(self, fastmcp_client, extract_tool_result):
+    async def test_discovery_workflow(self, fastmcp_client, tool_payload):
         """Test a realistic discovery workflow"""
         async with fastmcp_client as client:
-            # 1. Check health first
-            health_result = await client.call_tool("get_splunk_health")
-            health_data = extract_tool_result(health_result)
+            health_data = await tool_payload(client, "get_splunk_health")
             assert "status" in health_data
 
-            # 2. List available indexes
-            indexes_result = await client.call_tool("list_indexes")
-            indexes_data = extract_tool_result(indexes_result)
+            indexes_data = await tool_payload(client, "list_indexes")
 
-            # 3. List apps
-            apps_result = await client.call_tool("list_apps")
-            apps_data = extract_tool_result(apps_result)
+            apps_data = await tool_payload(client, "list_apps")
 
             # All should return structured data
             for data in [health_data, indexes_data, apps_data]:
                 assert isinstance(data, dict)
 
-    async def test_search_workflow(self, fastmcp_client, extract_tool_result):
+    async def test_search_workflow(self, fastmcp_client, tool_payload):
         """Test a realistic search workflow"""
         async with fastmcp_client as client:
-            # 1. Start with a simple search
-            simple_search = await client.call_tool(
-                "run_oneshot_search", {"query": "| metadata type=hosts", "max_results": 5}
+            simple_data = await tool_payload(
+                client, "run_oneshot_search", {"query": "| metadata type=hosts", "max_results": 5}
             )
-            simple_data = extract_tool_result(simple_search)
             assert isinstance(simple_data, dict)
 
-            # 2. Try a more complex search
-            complex_search = await client.call_tool(
+            complex_data = await tool_payload(
+                client,
                 "run_splunk_search",
                 {
                     "query": "| rest /services/server/info",
@@ -314,7 +296,6 @@ class TestWorkflowIntegration:
                     "latest_time": "now",
                 },
             )
-            complex_data = extract_tool_result(complex_search)
             assert isinstance(complex_data, dict)
 
 

--- a/tests/test_mcp_server_comprehensive.py
+++ b/tests/test_mcp_server_comprehensive.py
@@ -23,6 +23,7 @@ from fastmcp import Client
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from src.server import mcp
+from tests.conftest import wrap_client_tool_errors
 
 
 class TestMCPServerCore:
@@ -32,7 +33,7 @@ class TestMCPServerCore:
     async def client(self):
         """Create FastMCP client for in-memory testing."""
         async with Client(mcp) as client:
-            yield client
+            yield wrap_client_tool_errors(client)
 
     async def test_server_initialization(self, client):
         """Test that the server initializes correctly."""
@@ -102,7 +103,7 @@ class TestHealthTools:
     async def client(self):
         """Create FastMCP client for in-memory testing."""
         async with Client(mcp) as client:
-            yield client
+            yield wrap_client_tool_errors(client)
 
     @pytest.fixture
     def mock_splunk_service(self):
@@ -185,7 +186,7 @@ class TestSearchTools:
     async def client(self):
         """Create FastMCP client for in-memory testing."""
         async with Client(mcp) as client:
-            yield client
+            yield wrap_client_tool_errors(client)
 
     @pytest.fixture
     def mock_search_results(self):
@@ -295,7 +296,7 @@ class TestAdminTools:
     async def client(self):
         """Create FastMCP client for in-memory testing."""
         async with Client(mcp) as client:
-            yield client
+            yield wrap_client_tool_errors(client)
 
     async def test_list_apps(self, client):
         """Test listing Splunk apps."""
@@ -366,7 +367,7 @@ class TestMetadataTools:
     async def client(self):
         """Create FastMCP client for in-memory testing."""
         async with Client(mcp) as client:
-            yield client
+            yield wrap_client_tool_errors(client)
 
     async def test_list_indexes(self, client):
         """Test listing Splunk indexes."""
@@ -436,7 +437,7 @@ class TestKVStoreTools:
     async def client(self):
         """Create FastMCP client for in-memory testing."""
         async with Client(mcp) as client:
-            yield client
+            yield wrap_client_tool_errors(client)
 
     async def test_list_kvstore_collections(self, client):
         """Test listing KV Store collections."""
@@ -482,7 +483,7 @@ class TestResources:
     async def client(self):
         """Create FastMCP client for in-memory testing."""
         async with Client(mcp) as client:
-            yield client
+            yield wrap_client_tool_errors(client)
 
     async def test_splunk_health_resource(self, client):
         """Test Splunk health resource."""
@@ -781,7 +782,7 @@ class TestServerMiddleware:
     async def client(self):
         """Create FastMCP client for in-memory testing."""
         async with Client(mcp) as client:
-            yield client
+            yield wrap_client_tool_errors(client)
 
     async def test_client_config_middleware(self, client):
         """Test client configuration middleware."""
@@ -807,7 +808,7 @@ class TestErrorHandling:
     async def client(self):
         """Create FastMCP client for in-memory testing."""
         async with Client(mcp) as client:
-            yield client
+            yield wrap_client_tool_errors(client)
 
     async def test_tool_with_invalid_parameters(self, client):
         """Test tool behavior with invalid parameters."""
@@ -893,7 +894,7 @@ class TestServerConfiguration:
     async def client(self):
         """Create FastMCP client for in-memory testing."""
         async with Client(mcp) as client:
-            yield client
+            yield wrap_client_tool_errors(client)
 
     async def test_server_metadata(self, client):
         """Test server metadata and capabilities."""
@@ -945,7 +946,7 @@ class TestIntegrationWorkflows:
     async def client(self):
         """Create FastMCP client for in-memory testing."""
         async with Client(mcp) as client:
-            yield client
+            yield wrap_client_tool_errors(client)
 
     @pytest.fixture
     def comprehensive_mock_splunk_service(self):

--- a/tests/test_splunk_job_wait.py
+++ b/tests/test_splunk_job_wait.py
@@ -1,0 +1,66 @@
+import asyncio
+
+import pytest
+
+from src.core.splunk_job_wait import resolve_search_wait_seconds, wait_for_job
+
+
+class _Job:
+    def __init__(self, snapshots: list[dict]) -> None:
+        self._snapshots = list(snapshots)
+        self.sid = "job.1"
+        self.cancelled = False
+        self.content = self._snapshots[0]
+
+    def is_done(self) -> bool:
+        self.content = self._snapshots.pop(0) if self._snapshots else self.content
+        return self.content.get("isDone") == "1"
+
+    def cancel(self) -> None:
+        self.cancelled = True
+
+
+@pytest.mark.asyncio
+async def test_wait_for_job_returns_incomplete_after_budget() -> None:
+    job = _Job(
+        [
+            {"isDone": "0", "isFailed": "0", "doneProgress": "0.2"},
+            {"isDone": "0", "isFailed": "0", "doneProgress": "0.4"},
+        ]
+    )
+    snapshot = await wait_for_job(job, wait_seconds=0.05, poll_interval=0.01)
+    assert snapshot.is_done is False
+    assert snapshot.is_failed is False
+    assert snapshot.cancelled is False
+
+
+@pytest.mark.asyncio
+async def test_wait_for_job_returns_when_done() -> None:
+    job = _Job([{"isDone": "1", "isFailed": "0", "doneProgress": "1"}])
+    snapshot = await wait_for_job(job, wait_seconds=1, poll_interval=0.01)
+    assert snapshot.is_done is True
+
+
+@pytest.mark.asyncio
+async def test_wait_for_job_cancels_splunk_job_on_disconnect() -> None:
+    job = _Job(
+        [{"isDone": "0", "isFailed": "0", "doneProgress": "0.1"}]
+        * 20
+    )
+
+    async def _run() -> None:
+        await wait_for_job(job, wait_seconds=5, poll_interval=0.05)
+
+    task = asyncio.create_task(_run())
+    await asyncio.sleep(0.02)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert job.cancelled is True
+
+
+def test_resolve_search_wait_seconds_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MCP_SEARCH_WAIT_SECONDS", "8")
+    assert resolve_search_wait_seconds() == 8.0
+    monkeypatch.setenv("MCP_SEARCH_WAIT_SECONDS", "nope")
+    assert resolve_search_wait_seconds() == 15.0

--- a/tests/test_splunk_job_wait.py
+++ b/tests/test_splunk_job_wait.py
@@ -55,7 +55,7 @@ async def test_wait_for_job_cancels_splunk_job_on_disconnect() -> None:
     await asyncio.sleep(0.02)
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
-        await task
+        _ = await task
     assert job.cancelled is True
 
 

--- a/tests/test_splunk_tools.py
+++ b/tests/test_splunk_tools.py
@@ -12,12 +12,10 @@ from fastmcp.exceptions import ToolError
 class TestSplunkHealthTool:
     """Test the health check functionality using FastMCP in-memory testing"""
 
-    async def test_health_check_success(self, fastmcp_client, extract_tool_result):
+    async def test_health_check_success(self, fastmcp_client, tool_payload):
         """Test successful health check using FastMCP client"""
         async with fastmcp_client as client:
-            # Call the health check tool
-            result = await client.call_tool("get_splunk_health")
-            data = extract_tool_result(result)
+            data = await tool_payload(client, "get_splunk_health")
 
             # Verify the health check response structure
             assert "status" in data
@@ -28,11 +26,11 @@ class TestSplunkHealthTool:
                 assert "version" in data
                 assert "server_name" in data
 
-    async def test_health_check_with_custom_params(self, fastmcp_client, extract_tool_result):
+    async def test_health_check_with_custom_params(self, fastmcp_client, tool_payload):
         """Test health check with custom connection parameters"""
         async with fastmcp_client as client:
-            # Test with custom Splunk connection parameters
-            result = await client.call_tool(
+            data = await tool_payload(
+                client,
                 "get_splunk_health",
                 {
                     "splunk_host": "test.example.com",
@@ -43,7 +41,6 @@ class TestSplunkHealthTool:
                     "splunk_verify_ssl": False,
                 },
             )
-            data = extract_tool_result(result)
 
             # Should return status information
             assert "status" in data
@@ -52,12 +49,10 @@ class TestSplunkHealthTool:
 class TestIndexTools:
     """Test index-related tools using FastMCP"""
 
-    async def test_list_indexes_success(self, fastmcp_client, extract_tool_result):
+    async def test_list_indexes_success(self, fastmcp_client, tool_payload):
         """Test successful index listing"""
         async with fastmcp_client as client:
-            # ListIndexes doesn't take any parameters according to the tool definition
-            result = await client.call_tool("list_indexes")
-            data = extract_tool_result(result)
+            data = await tool_payload(client, "list_indexes")
 
             # Check expected response structure
             assert "indexes" in data or "status" in data
@@ -71,12 +66,10 @@ class TestIndexTools:
 class TestMetadataTools:
     """Test metadata tools (sourcetypes and sources) using FastMCP"""
 
-    async def test_list_sourcetypes_success(self, fastmcp_client, extract_tool_result):
+    async def test_list_sourcetypes_success(self, fastmcp_client, tool_payload):
         """Test successful sourcetype listing"""
         async with fastmcp_client as client:
-            # ListSourcetypes doesn't take any parameters
-            result = await client.call_tool("list_sourcetypes")
-            data = extract_tool_result(result)
+            data = await tool_payload(client, "list_sourcetypes")
 
             # Check expected response structure
             assert "sourcetypes" in data or "status" in data
@@ -85,12 +78,10 @@ class TestMetadataTools:
                 assert "count" in data
                 assert isinstance(data["sourcetypes"], list)
 
-    async def test_list_sources_success(self, fastmcp_client, extract_tool_result):
+    async def test_list_sources_success(self, fastmcp_client, tool_payload):
         """Test successful source listing"""
         async with fastmcp_client as client:
-            # ListSources doesn't take any parameters
-            result = await client.call_tool("list_sources")
-            data = extract_tool_result(result)
+            data = await tool_payload(client, "list_sources")
 
             # Check expected response structure
             assert "sources" in data or "status" in data
@@ -103,10 +94,11 @@ class TestMetadataTools:
 class TestSearchTools:
     """Test search functionality using FastMCP"""
 
-    async def test_run_oneshot_search_basic(self, fastmcp_client, extract_tool_result):
+    async def test_run_oneshot_search_basic(self, fastmcp_client, tool_payload):
         """Test basic oneshot search"""
         async with fastmcp_client as client:
-            result = await client.call_tool(
+            data = await tool_payload(
+                client,
                 "run_oneshot_search",
                 {
                     "query": "index=main",
@@ -115,7 +107,6 @@ class TestSearchTools:
                     "max_results": 10,
                 },
             )
-            data = extract_tool_result(result)
 
             # Verify response structure
             assert "status" in data or "results" in data
@@ -125,49 +116,48 @@ class TestSearchTools:
                 assert "query_executed" in data
                 assert isinstance(data["results"], list)
 
-    async def test_run_oneshot_search_with_pipe(self, fastmcp_client, extract_tool_result):
+    async def test_run_oneshot_search_with_pipe(self, fastmcp_client, tool_payload):
         """Test oneshot search with pipe command"""
         async with fastmcp_client as client:
-            result = await client.call_tool(
-                "run_oneshot_search", {"query": "| stats count by log_level"}
+            data = await tool_payload(
+                client, "run_oneshot_search", {"query": "| stats count by log_level"}
             )
-            data = extract_tool_result(result)
 
             # Should have some response structure
             assert isinstance(data, dict)
             # In test environment, might return error or results
             assert "status" in data or "results" in data
 
-    async def test_run_oneshot_search_with_search_prefix(self, fastmcp_client, extract_tool_result):
+    async def test_run_oneshot_search_with_search_prefix(self, fastmcp_client, tool_payload):
         """Test oneshot search that already has search prefix"""
         async with fastmcp_client as client:
-            result = await client.call_tool("run_oneshot_search", {"query": "search index=main"})
-            data = extract_tool_result(result)
+            data = await tool_payload(
+                client, "run_oneshot_search", {"query": "search index=main"}
+            )
 
             assert isinstance(data, dict)
             assert "status" in data or "results" in data
 
-    async def test_run_oneshot_search_max_results_limit(self, fastmcp_client, extract_tool_result):
+    async def test_run_oneshot_search_max_results_limit(self, fastmcp_client, tool_payload):
         """Test oneshot search with max results limiting"""
         async with fastmcp_client as client:
-            result = await client.call_tool(
-                "run_oneshot_search", {"query": "index=main", "max_results": 5}
+            data = await tool_payload(
+                client, "run_oneshot_search", {"query": "index=main", "max_results": 5}
             )
-            data = extract_tool_result(result)
 
             assert isinstance(data, dict)
             if "results" in data:
                 # If we get results, they should respect the limit
                 assert len(data["results"]) <= 5
 
-    async def test_run_splunk_search_job(self, fastmcp_client, extract_tool_result):
+    async def test_run_splunk_search_job(self, fastmcp_client, tool_payload):
         """Test job-based search functionality"""
         async with fastmcp_client as client:
-            result = await client.call_tool(
+            data = await tool_payload(
+                client,
                 "run_splunk_search",
                 {"query": "index=main | head 5", "earliest_time": "-1h", "latest_time": "now"},
             )
-            data = extract_tool_result(result)
 
             assert isinstance(data, dict)
             assert "status" in data or "results" in data
@@ -176,12 +166,10 @@ class TestSearchTools:
 class TestAppAndUserTools:
     """Test app and user management tools using FastMCP"""
 
-    async def test_list_apps_success(self, fastmcp_client, extract_tool_result):
+    async def test_list_apps_success(self, fastmcp_client, tool_payload):
         """Test successful app listing"""
         async with fastmcp_client as client:
-            # ListApps doesn't take any parameters
-            result = await client.call_tool("list_apps")
-            data = extract_tool_result(result)
+            data = await tool_payload(client, "list_apps")
 
             assert "apps" in data or "status" in data
 
@@ -189,12 +177,10 @@ class TestAppAndUserTools:
                 assert "count" in data
                 assert isinstance(data["apps"], list)
 
-    async def test_list_users_success(self, fastmcp_client, extract_tool_result):
+    async def test_list_users_success(self, fastmcp_client, tool_payload):
         """Test successful user listing"""
         async with fastmcp_client as client:
-            # ListUsers doesn't take any parameters
-            result = await client.call_tool("list_users")
-            data = extract_tool_result(result)
+            data = await tool_payload(client, "list_users")
 
             assert "users" in data or "status" in data
 
@@ -206,32 +192,29 @@ class TestAppAndUserTools:
 class TestKVStoreTools:
     """Test KV Store tools using FastMCP"""
 
-    async def test_list_kvstore_collections(self, fastmcp_client, extract_tool_result):
+    async def test_list_kvstore_collections(self, fastmcp_client, tool_payload):
         """Test listing KV Store collections"""
         async with fastmcp_client as client:
-            result = await client.call_tool("list_kvstore_collections")
-            data = extract_tool_result(result)
+            data = await tool_payload(client, "list_kvstore_collections")
 
             assert "collections" in data or "status" in data
 
             if "collections" in data:
                 assert "count" in data
 
-    async def test_list_kvstore_collections_specific_app(self, fastmcp_client, extract_tool_result):
+    async def test_list_kvstore_collections_specific_app(self, fastmcp_client, tool_payload):
         """Test listing KV Store collections for specific app"""
         async with fastmcp_client as client:
-            result = await client.call_tool("list_kvstore_collections", {"app": "search"})
-            data = extract_tool_result(result)
+            data = await tool_payload(client, "list_kvstore_collections", {"app": "search"})
 
             assert "collections" in data or "status" in data
 
-    async def test_get_kvstore_data_success(self, fastmcp_client, extract_tool_result):
+    async def test_get_kvstore_data_success(self, fastmcp_client, tool_payload):
         """Test KV Store data retrieval"""
         async with fastmcp_client as client:
-            result = await client.call_tool(
-                "get_kvstore_data", {"collection": "users", "app": "search"}
+            data = await tool_payload(
+                client, "get_kvstore_data", {"collection": "users", "app": "search"}
             )
-            data = extract_tool_result(result)
 
             assert "documents" in data or "status" in data
 
@@ -239,24 +222,22 @@ class TestKVStoreTools:
 class TestConfigurationTools:
     """Test configuration management tools using FastMCP"""
 
-    async def test_get_configurations_all_stanzas(self, fastmcp_client, extract_tool_result):
+    async def test_get_configurations_all_stanzas(self, fastmcp_client, tool_payload):
         """Test getting all configuration stanzas"""
         async with fastmcp_client as client:
-            result = await client.call_tool("get_configurations", {"conf_file": "props"})
-            data = extract_tool_result(result)
+            data = await tool_payload(client, "get_configurations", {"conf_file": "props"})
 
             assert "file" in data or "status" in data
 
             if "file" in data:
                 assert "stanzas" in data
 
-    async def test_get_configurations_specific_stanza(self, fastmcp_client, extract_tool_result):
+    async def test_get_configurations_specific_stanza(self, fastmcp_client, tool_payload):
         """Test getting specific configuration stanza"""
         async with fastmcp_client as client:
-            result = await client.call_tool(
-                "get_configurations", {"conf_file": "props", "stanza": "default"}
+            data = await tool_payload(
+                client, "get_configurations", {"conf_file": "props", "stanza": "default"}
             )
-            data = extract_tool_result(result)
 
             assert "stanza" in data or "status" in data
 
@@ -264,18 +245,18 @@ class TestConfigurationTools:
 class TestSavedSearchTools:
     """Test saved search functionality using FastMCP"""
 
-    async def test_list_saved_searches(self, fastmcp_client, extract_tool_result):
+    async def test_list_saved_searches(self, fastmcp_client, tool_payload):
         """Test listing saved searches"""
         async with fastmcp_client as client:
-            result = await client.call_tool("list_saved_searches")
-            data = extract_tool_result(result)
+            data = await tool_payload(client, "list_saved_searches")
 
             assert "saved_searches" in data or "status" in data
 
-    async def test_create_saved_search(self, fastmcp_client, extract_tool_result):
+    async def test_create_saved_search(self, fastmcp_client, tool_payload):
         """Test creating a saved search"""
         async with fastmcp_client as client:
-            result = await client.call_tool(
+            data = await tool_payload(
+                client,
                 "create_saved_search",
                 {
                     "name": "Test Search",
@@ -284,17 +265,15 @@ class TestSavedSearchTools:
                     "is_visible": True,
                 },
             )
-            data = extract_tool_result(result)
 
             assert "name" in data or "status" in data
 
-    async def test_execute_saved_search(self, fastmcp_client, extract_tool_result):
+    async def test_execute_saved_search(self, fastmcp_client, tool_payload):
         """Test executing a saved search"""
         async with fastmcp_client as client:
-            result = await client.call_tool(
-                "execute_saved_search", {"name": "Messages by minute last 3 hours"}
+            data = await tool_payload(
+                client, "execute_saved_search", {"name": "Messages by minute last 3 hours"}
             )
-            data = extract_tool_result(result)
 
             # Should return some kind of response
             assert isinstance(data, dict)
@@ -303,32 +282,24 @@ class TestSavedSearchTools:
 class TestToolIntegration:
     """Test integration between multiple tools using FastMCP"""
 
-    async def test_health_check_before_operations(self, fastmcp_client, extract_tool_result):
+    async def test_health_check_before_operations(self, fastmcp_client, tool_payload):
         """Test health check workflow before operations"""
         async with fastmcp_client as client:
-            # First check health
-            health_result = await client.call_tool("get_splunk_health")
-            health_data = extract_tool_result(health_result)
+            health_data = await tool_payload(client, "get_splunk_health")
             assert "status" in health_data
 
-            # Then perform operation - no parameters needed
-            indexes_result = await client.call_tool("list_indexes")
-            indexes_data = extract_tool_result(indexes_result)
+            indexes_data = await tool_payload(client, "list_indexes")
             assert isinstance(indexes_data, dict)
 
-    async def test_search_workflow(self, fastmcp_client, extract_tool_result):
+    async def test_search_workflow(self, fastmcp_client, tool_payload):
         """Test complete search workflow"""
         async with fastmcp_client as client:
-            # First list indexes - no parameters needed
-            indexes_result = await client.call_tool("list_indexes")
-            indexes_data = extract_tool_result(indexes_result)
+            indexes_data = await tool_payload(client, "list_indexes")
             assert isinstance(indexes_data, dict)
 
-            # Then perform search
-            search_result = await client.call_tool(
-                "run_oneshot_search", {"query": "index=main | head 5"}
+            search_data = await tool_payload(
+                client, "run_oneshot_search", {"query": "index=main | head 5"}
             )
-            search_data = extract_tool_result(search_result)
             assert isinstance(search_data, dict)
 
     async def test_mcp_connectivity(self, fastmcp_client, mcp_helpers):

--- a/tests/test_tool_enhancer.py
+++ b/tests/test_tool_enhancer.py
@@ -45,17 +45,15 @@ class TestToolDescriptionEnhancer:
                 assert "examples" in analysis
 
     async def test_enhance_nonexistent_tool(
-        self, enhancer_tool, fastmcp_client, extract_tool_result
+        self, enhancer_tool, fastmcp_client, tool_payload
     ):
         """Test error handling for non-existent tool"""
         async with fastmcp_client as client:
-            result = await client.call_tool(
-                "enhance_tool_description", {"tool_name": "nonexistent_tool"}
+            data = await tool_payload(
+                client, "enhance_tool_description", {"tool_name": "nonexistent_tool"}
             )
-
-            data = extract_tool_result(result)
             # Should return error for non-existent tool
-            assert "error" in data or "not found" in str(result)
+            assert "error" in data or "not found" in str(data)
 
     async def test_parameter_analysis(self, enhancer_tool):
         """Test parameter analysis functionality"""

--- a/tests/test_tool_mcp_result.py
+++ b/tests/test_tool_mcp_result.py
@@ -36,7 +36,7 @@ async def test_tool_wrapper_raises_status_error(monkeypatch: pytest.MonkeyPatch)
                 "indexes": [],
             }
 
-    monkeypatch.setattr("src.core.loader.get_context", lambda: SimpleNamespace())
+    monkeypatch.setattr("src.core.loader.get_context", SimpleNamespace)
     wrapper = ToolLoader(Mock())._create_tool_wrapper(_ErrorTool, "list_indexes")
     with pytest.raises(ToolError, match="count must be between 1 and 200"):
         await wrapper()

--- a/tests/test_tool_mcp_result.py
+++ b/tests/test_tool_mcp_result.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from src.core.base import BaseTool
+from src.core.loader import ToolLoader
+from src.core.tool_mcp_result import raise_on_tool_error_status, wrap_unexpected_tool_failure
+
+
+def test_raise_on_tool_error_status_surfaces_message() -> None:
+    with pytest.raises(ToolError, match="count must be between 1 and 200"):
+        raise_on_tool_error_status(
+            {"status": "error", "error": "count must be between 1 and 200", "indexes": []}
+        )
+
+
+def test_raise_on_tool_error_status_passes_success_through() -> None:
+    payload = {"status": "success", "indexes": ["main"]}
+    assert raise_on_tool_error_status(payload) is payload
+
+
+def test_wrap_unexpected_tool_failure_is_tool_error() -> None:
+    with pytest.raises(ToolError, match="boom"):
+        raise wrap_unexpected_tool_failure(RuntimeError("boom"))
+
+
+@pytest.mark.asyncio
+async def test_tool_wrapper_raises_status_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _ErrorTool(BaseTool):
+        async def execute(self, ctx, **kwargs):
+            return {
+                "status": "error",
+                "error": "count must be between 1 and 200",
+                "indexes": [],
+            }
+
+    monkeypatch.setattr("src.core.loader.get_context", lambda: SimpleNamespace())
+    wrapper = ToolLoader(Mock())._create_tool_wrapper(_ErrorTool, "list_indexes")
+    with pytest.raises(ToolError, match="count must be between 1 and 200"):
+        await wrapper()


### PR DESCRIPTION
## Summary

- `run_splunk_search` waits up to `MCP_SEARCH_WAIT_SECONDS` (default 15s), then returns `job_id` with `is_done=false` so sessionless clients can poll instead of looking like a timeout.
- Invalid search `count` / `max_results` (`0` or over 100) are clamped instead of failing; catalog list tools still reject `count=0`.
- Cancelling the MCP request now cancels the Splunk job.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor/Chore

## Checklist

- [x] Tests added/updated (if applicable)
- [x] Docs updated (README or docs/)
- [x] Lint and type checks pass (`uv run ruff check`, `uv run mypy`)

## Test plan

- [ ] `run_splunk_search` on a query that takes >15s returns `job_id` and `is_done=false`
- [ ] Poll `get_search_job_info` then `get_search_job_results` for that job
- [ ] `count=0` on search tools returns a 50-row page instead of an error
- [ ] Aborting the MCP request cancels the Splunk job
- [ ] Catalog list tools still reject `count=0`

## Related issues

Local Docker/sessionless clients (Deslicer AI) were aborting long `run_splunk_search` calls. Jobs finished in a few seconds on Splunk; the MCP HTTP POST stayed open until `job.is_done()`, which looked like a timeout.